### PR TITLE
feat: Adding dynamic robots.txt with allowed domains configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,8 @@ RESIZE_IMAGES_WIDTH=800
 ############################
 # [OPTIONAL] SLK.
 NEXT_PUBLIC_SLK=
+
+# SEO
+############################
+# [OPTIONAL] List of allowed domains with app.endatix.com robots.txt behavior (User-agent: *, Allow: /login, Disallow: /). Comma-separated list.
+ROBOTS_ALLOWED_DOMAINS=app.endatix.com

--- a/__tests__/app/robots.test.ts
+++ b/__tests__/app/robots.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import robots, { MAIN_ENDATIX_RULES, RESTRICTED_RULES } from '@/app/robots';
+import { headers } from 'next/headers';
+import { type ReadonlyHeaders } from 'next/dist/server/web/spec-extension/adapters/headers';
+
+// Mock environment variables
+const originalEnv = process.env;
+
+// Create a mock factory function for ReadonlyHeaders
+function createMockHeaders(hostValue: string): ReadonlyHeaders {
+  // Create a basic implementation that satisfies the interface
+  return {
+    entries: () => [][Symbol.iterator](),
+    forEach: () => {},
+    get: (key: string) => key === 'host' ? hostValue : null,
+    getAll: () => [],
+    has: () => false,
+    keys: () => [][Symbol.iterator](),
+    values: () => [][Symbol.iterator](),
+    [Symbol.iterator]: () => [][Symbol.iterator]()
+  } as unknown as ReadonlyHeaders;
+}
+
+// Direct manual mock for headers
+vi.mock('next/headers', () => ({
+  headers: vi.fn()
+}));
+
+describe('Robots.ts rule sets', () => {
+  it('should define proper rule sets', () => {
+    // Main Endatix rule should allow /login
+    expect(MAIN_ENDATIX_RULES[0].userAgent).toBe('*');
+    expect(MAIN_ENDATIX_RULES[0].allow).toBe('/login');
+    expect(MAIN_ENDATIX_RULES[0].disallow).toBe('/');
+    
+    // Restricted rule should fully disallow
+    expect(RESTRICTED_RULES[0].userAgent).toBe('*');
+    expect(RESTRICTED_RULES[0].disallow).toBe('/');
+    // Check that 'allow' property doesn't exist on restricted rules
+    expect('allow' in RESTRICTED_RULES[0]).toBe(false);
+  });
+});
+
+describe('Robots.ts metadata route', () => {
+  beforeEach(() => {
+    // Reset modules and mocks
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('should allow /login for app.endatix.com host when explicitly listed', async () => {
+    // Arrange
+    vi.mocked(headers).mockReturnValue(
+      Promise.resolve(createMockHeaders('app.endatix.com'))
+    );
+    process.env.ROBOTS_ALLOWED_DOMAINS = 'app.endatix.com,portal.endatix.com';
+    
+    // Act
+    const result = await robots();
+    
+    // Assert
+    expect(result.rules).toEqual(MAIN_ENDATIX_RULES);
+  });
+
+  it('should NOT allow /login for a subdomain that is not explicitly listed', async () => {
+    // Arrange
+    vi.mocked(headers).mockReturnValue(
+      Promise.resolve(createMockHeaders('ci.hub.endatix.com'))
+    );
+    process.env.ROBOTS_ALLOWED_DOMAINS = 'app.endatix.com';
+    
+    // Act
+    const result = await robots();
+    
+    // Assert
+    expect(result.rules).toEqual(RESTRICTED_RULES);
+  });
+
+  it('should allow /login for a subdomain when explicitly listed', async () => {
+    // Arrange
+    vi.mocked(headers).mockReturnValue(
+      Promise.resolve(createMockHeaders('test.endatix.com'))
+    );
+    process.env.ROBOTS_ALLOWED_DOMAINS = 'test.endatix.com,endatix.com';
+    
+    // Act
+    const result = await robots();
+    
+    // Assert
+    expect(result.rules).toEqual(MAIN_ENDATIX_RULES);
+  });
+
+  it('should fully disallow for non-endatix domains', async () => {
+    // Arrange
+    vi.mocked(headers).mockReturnValue(
+      Promise.resolve(createMockHeaders('forms.homegrownstorage.com'))
+    );
+    process.env.ROBOTS_ALLOWED_DOMAINS = 'app.endatix.com';
+    
+    // Act
+    const result = await robots();
+    
+    // Assert
+    expect(result.rules).toEqual(RESTRICTED_RULES);
+  });
+  
+  it('should use default of app.endatix.com if no env variable is set', async () => {
+    // Arrange
+    vi.mocked(headers).mockReturnValue(
+      Promise.resolve(createMockHeaders('app.endatix.com'))
+    );
+    delete process.env.ROBOTS_ALLOWED_DOMAINS;
+    
+    // Act
+    const result = await robots();
+    
+    // Assert
+    expect(result.rules).toEqual(MAIN_ENDATIX_RULES);
+  });
+
+  it('should handle errors by returning restricted rules', async () => {
+    // Arrange
+    vi.mocked(headers).mockImplementationOnce(() => {
+      throw new Error('Test error');
+    });
+    
+    // Act
+    const result = await robots();
+    
+    // Assert
+    expect(result.rules).toEqual(RESTRICTED_RULES);
+  });
+}); 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,73 @@
+import type { MetadataRoute } from 'next';
+import { headers } from 'next/headers';
+
+/**
+ * Rule set for main Endatix domains that allow login access
+ */
+export const MAIN_ENDATIX_RULES = [
+  {
+    userAgent: '*',
+    allow: '/login',
+    disallow: '/'
+  }
+];
+
+/**
+ * Rule set for all other domains - fully restrictive
+ */
+export const RESTRICTED_RULES = [
+  {
+    userAgent: '*',
+    disallow: '/'
+  }
+];
+
+/**
+ * Dynamic robots.txt generation based on the current hostname
+ * 
+ * The robots.txt content will vary based on the domain:
+ * - For domains explicitly listed in ROBOTS_ALLOWED_DOMAINS: Allow /login, Disallow /
+ * - For all other domains: Disallow all
+ * 
+ * Usage: Set ROBOTS_ALLOWED_DOMAINS=app.endatix.com,portal.endatix.com
+ * Note: Only exact domain matches are allowed; subdomains must be explicitly listed
+ */
+export default async function robots(): Promise<MetadataRoute.Robots> {
+  // Default fallback domain that should always allow /login
+  const DEFAULT_DOMAIN = 'app.endatix.com';
+  
+  try {
+    // Get the current domain from request headers
+    const headersList = await headers();
+    const host = headersList.get('host') || '';
+    
+    // Clean up the host value to remove port if present
+    const currentDomain = host.split(':')[0];
+    
+    // Default to main rules for the default domain
+    if (currentDomain === DEFAULT_DOMAIN) {
+      return { rules: MAIN_ENDATIX_RULES };
+    }
+    
+    // Check allowed domains from environment
+    const allowedDomainsString = process.env.ROBOTS_ALLOWED_DOMAINS || '';
+    if (!allowedDomainsString) {
+      return { rules: RESTRICTED_RULES };
+    }
+    
+    const allowedDomains = allowedDomainsString
+      .split(',')
+      .map(domain => domain.trim())
+      .filter(domain => domain.length > 0);
+    
+    // Check for exact match with the current domain
+    if (allowedDomains.includes(currentDomain)) {
+      return { rules: MAIN_ENDATIX_RULES };
+    }
+  } catch (error) {
+    console.error('Error accessing request headers for robots.txt:', error);
+  }
+  
+  // Default to restricted rules
+  return { rules: RESTRICTED_RULES };
+} 

--- a/env.d.ts
+++ b/env.d.ts
@@ -3,6 +3,7 @@ declare namespace NodeJS {
     // Environment
     NODE_ENV: "development" | "production" | "test";
     REMOTE_IMAGE_HOSTNAMES?: string;
+    ROBOTS_ALLOWED_DOMAINS?: string;
 
     // Session
     SESSION_SECRET: string;


### PR DESCRIPTION

### Description

- Based of the https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots extensibility, we can not control which hostnames will return what robots.tsx response
- Added new Env variable

```bash
# [OPTIONAL] List of allowed domains with app.endatix.com robots.txt behavior (User-agent: *, Allow: /login, Disallow: /). Comma-separated list.
ROBOTS_ALLOWED_DOMAINS=app.endatix.com
```

### Related Tasks
closes https://github.com/endatix/endatix-hub/issues/10