### PR TITLE
fix: Templates search restarts after template preview

### DIFF
--- a/features/forms/ui/template-selector.tsx
+++ b/features/forms/ui/template-selector.tsx
@@ -118,6 +118,7 @@ export default function TemplateSelector({
               onSelectTemplate={handleSelectTemplate}
               onPreviewTemplate={onPreviewTemplate}
               onSearch={handleSearch}
+              searchQuery={searchQuery}
             />
           </PopoverContent>
         </Popover>
@@ -160,6 +161,7 @@ export default function TemplateSelector({
               onSelectTemplate={handleSelectTemplate}
               onPreviewTemplate={onPreviewTemplate}
               onSearch={handleSearch}
+              searchQuery={searchQuery}
             />
           </div>
         </DrawerContent>
@@ -181,6 +183,7 @@ interface TemplateListProps {
   onSelectTemplate: (template: FormTemplate) => void;
   onPreviewTemplate: (templateId: string) => void;
   onSearch: (value: string) => void;
+  searchQuery: string;
 }
 
 function TemplateList({
@@ -191,6 +194,7 @@ function TemplateList({
   onSelectTemplate,
   onPreviewTemplate,
   onSearch,
+  searchQuery,
 }: TemplateListProps) {
   const [hoveredTemplateId, setHoveredTemplateId] = useState<string | null>(null);
 
@@ -198,6 +202,7 @@ function TemplateList({
     <Command shouldFilter={false}>
       <CommandInput 
         placeholder="Search templates..." 
+        value={searchQuery}
         onValueChange={onSearch}
       />
       <CommandList>


### PR DESCRIPTION
# fix: Templates search restarts after template preview

## Description
Selecting template upon preview to help with UX. This is done as the search is a popup which is auto-closing on clicking outside and this will be best way to keep UX streamlined

## Related Issues
fixes https://github.com/endatix/endatix-private/issues/158

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above