### PR TITLE
fix: Fix "Create custom question" is missing from Panel

### DIFF
--- a/features/forms/ui/editor/form-editor.tsx
+++ b/features/forms/ui/editor/form-editor.tsx
@@ -776,7 +776,7 @@ function FormEditor({
 
     creator.onElementGetActions.add((_, options) => {
       const element = options.element as Question;
-      if (element?.isQuestion) {
+      if (element?.isQuestion || element?.isPanel) {
         options.actions.unshift({
           id: "create-custom-question",
           title: "Create Custom Question",
@@ -789,7 +789,7 @@ function FormEditor({
     return () => {
       creator.onElementGetActions.remove((_, options) => {
         const element = options.element as Question;
-        if (element?.isQuestion) {
+        if (element?.isQuestion || element?.isPanel) {
           options.actions = options.actions.filter(
             (action) => action.id !== "create-custom-question",
           );


### PR DESCRIPTION
# Fix "Create custom question" is missing from Panel

## Description
"Create custom question" button was displayed only on elements satisfying `element?.isQuestion` but `element?.isPanel` is also needed.

## Related Issues
closes https://github.com/endatix/endatix-private/issues/210

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
