### PR TITLE
fix: Invalidate form cache on form update actions

### DIFF
--- a/features/forms/application/actions/update-form-definition-json.action.ts
+++ b/features/forms/application/actions/update-form-definition-json.action.ts
@@ -2,6 +2,7 @@
 
 import { ensureAuthenticated } from "@/features/auth";
 import { updateFormDefinition } from "@/services/api";
+import { revalidatePath } from "next/cache";
 
 export async function updateFormDefinitionJsonAction(
   formId: string,
@@ -12,6 +13,8 @@ export async function updateFormDefinitionJsonAction(
 
   try {
     await updateFormDefinition(formId, isDraft, JSON.stringify(formJson));
+    revalidatePath(`/forms/${formId}`);
+
     return { success: true };
   } catch (error) {
     console.error("Failed to update form definition", error);

--- a/features/forms/application/actions/update-form-name.action.ts
+++ b/features/forms/application/actions/update-form-name.action.ts
@@ -2,12 +2,15 @@
 
 import { ensureAuthenticated } from "@/features/auth";
 import { updateForm } from "@/services/api";
+import { revalidatePath } from 'next/cache';
 
 export async function updateFormNameAction(formId: string, formName: string) {
   await ensureAuthenticated();
 
   try {
     await updateForm(formId, { name: formName });
+    revalidatePath(`/forms/${formId}`);
+    
     return { success: true };
   } catch (error) {
     console.error("Failed to update form name", error);

--- a/features/forms/application/actions/update-form-theme.action.ts
+++ b/features/forms/application/actions/update-form-theme.action.ts
@@ -2,12 +2,15 @@
 
 import { ensureAuthenticated } from "@/features/auth";
 import { updateForm } from "@/services/api";
+import { revalidatePath } from "next/cache";
 
 export async function updateFormThemeAction(formId: string, themeId: string) {
   await ensureAuthenticated();
 
   try {
     await updateForm(formId, { themeId: themeId });
+    revalidatePath(`/forms/${formId}`);
+
     return { success: true };
   } catch (error) {
     console.error("Failed to update form theme", error);


### PR DESCRIPTION
# fix: Invalidate form cache on form update actions

## Description
Update the form edit route on success operations for the following actions:
- Form name update
- Form definition update
- Form theme change

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/89

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above