### PR TITLE
fix: reCAPTCHA logo z-index when reCAPTCHA is loaded

### DIFF
--- a/app/(public)/share/[formId]/page.tsx
+++ b/app/(public)/share/[formId]/page.tsx
@@ -5,6 +5,7 @@ import SurveyJsWrapper from "@/features/public-form/ui/survey-js-wrapper";
 import { getActiveDefinitionUseCase } from "@/features/public-form/use-cases/get-active-definition.use-case";
 import { getPartialSubmissionUseCase } from "@/features/public-form/use-cases/get-partial-submission.use-case";
 import { recaptchaConfig } from "@/features/recaptcha/recaptcha-config";
+import { ReCaptchaStyleFix } from "@/features/recaptcha/ui/recaptcha-style-fix";
 import { ApiResult } from "@/lib/endatix-api";
 import { Result } from "@/lib/result";
 import { cookies } from "next/headers";
@@ -39,7 +40,12 @@ async function ShareSurveyPage({ params }: ShareSurveyPage) {
 
   return (
     <>
-      {shouldLoadReCaptcha && <Script src={recaptchaConfig.JS_URL} />}
+      {shouldLoadReCaptcha && (
+        <>
+          <Script src={recaptchaConfig.JS_URL} strategy="beforeInteractive" />
+          <ReCaptchaStyleFix />
+        </>
+      )}
       <SurveyJsWrapper
         formId={formId}
         definition={activeDefinition.jsonData}

--- a/features/recaptcha/ui/recaptcha-style-fix.tsx
+++ b/features/recaptcha/ui/recaptcha-style-fix.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Component that fixes reCAPTCHA logo z-index when reCAPTCHA is loaded
+ */
+export function ReCaptchaStyleFix() {
+  useEffect(() => {
+    const style = document.createElement("style");
+    style.textContent = `
+      .grecaptcha-badge {
+        z-index: 9999 !important;
+      }
+    `;
+    document.head.appendChild(style);
+
+    return () => {
+      if (style.parentNode) {
+        style.parentNode.removeChild(style);
+      }
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
# fix: reCAPTCHA logo z-index when reCAPTCHA is loaded

## Description
Adds conditional CSS to increase the z-index of the reCAPTCHA badge if reCAPTCHA is loaded on the page

## Related Issues
- fixes https://github.com/endatix/endatix-hub/issues/91

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="589" height="537" alt="image" src="https://github.com/user-attachments/assets/5c2117fd-e71f-4181-bc8d-6ae91aff0c70" />