### PR TITLE
fix: Changes to make Form and Form Template designers responsive

### DIFF
--- a/app/(main)/forms/[formId]/page.tsx
+++ b/app/(main)/forms/[formId]/page.tsx
@@ -39,7 +39,7 @@ export default async function FormEditPage({ params }: Params) {
 
   return (
     <Suspense fallback={<FormEditorLoader />}>
-      <div className="h-dvh overflow-hidden gap-4">
+      <div className="h-dvh overflow-hidden max-w-[100vw] -m-6">
         <FormEditorContainer {...props} />
       </div>
     </Suspense>

--- a/app/(main)/forms/templates/[templateId]/page.tsx
+++ b/app/(main)/forms/templates/[templateId]/page.tsx
@@ -32,7 +32,11 @@ export default async function FormTemplateEditPage({ params }: Params) {
       isEnabled: template.isEnabled,
     };
 
-    return <FormTemplateEditorContainer {...props} />;
+    return (
+      <div className="h-dvh overflow-hidden max-w-[100vw] -m-6">
+        <FormTemplateEditorContainer {...props} />
+      </div>
+    );
   } catch (error) {
     console.error("Error fetching template:", error);
     notFound();

--- a/features/form-templates/ui/creator-styles.scss
+++ b/features/form-templates/ui/creator-styles.scss
@@ -1,6 +1,6 @@
 #surveyCreatorContainer {
-  height: calc(100vh - 112px);
   width: 100%;
+  height: calc(100dvh - 64px);
   overflow: auto;
   display: flex;
   flex-direction: column;

--- a/features/form-templates/ui/form-template-editor.tsx
+++ b/features/form-templates/ui/form-template-editor.tsx
@@ -244,7 +244,7 @@ function FormTemplateEditor({
 
   return (
     <>
-      <div className="flex justify-between items-center mt-0 pt-4 pb-4 sticky top-0 z-50 w-full border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="flex justify-between items-center mt-0 pt-4 pb-4 px-6 sticky top-0 z-50 w-full border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="flex w-full items-center gap-8">
           <button
             onClick={handleSaveAndGoBack}

--- a/features/forms/ui/editor/form-editor-styles.scss
+++ b/features/forms/ui/editor/form-editor-styles.scss
@@ -9,7 +9,7 @@ global {
 
 #creator {
   width: 100%;
-  height: calc(100vh - 112px);
+  height: calc(100dvh - 64px);
   position: relative;
   overflow: auto;
   display: flex;

--- a/features/forms/ui/editor/form-editor.tsx
+++ b/features/forms/ui/editor/form-editor.tsx
@@ -948,7 +948,7 @@ function FormEditor({
 
   return (
     <>
-      <div className="flex justify-between items-center mt-0 pt-4 pb-4 sticky top-0 z-50 w-full border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="flex justify-between items-center mt-0 pt-4 pb-4 px-6 sticky top-0 z-50 w-full border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="flex w-full items-center gap-8">
           <button
             onClick={handleSaveAndGoBack}


### PR DESCRIPTION
# Changes to make Form and Form Template designers responsive

## Description
Form and Form Template designers became not responsive after the removal of nav bar from them. These changes fix this and also address other layout issues connected with undesired padding on the designer screens.

## Related Issues
closes #93

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
