### PR TITLE
fix: Add overflow handling for language selector when rendered

### DIFF
--- a/features/public-form/ui/language-selector.tsx
+++ b/features/public-form/ui/language-selector.tsx
@@ -17,22 +17,34 @@ export function LanguageSelector({
 }: LanguageSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  
-  const { currentLocale, currentOption, languageOptions, changeLocale } = useLanguageSelection({
+
+  const {
+    currentLocale,
+    currentOption,
+    languageOptions,
+    changeLocale,
+    hasMultipleLocales,
+  } = useLanguageSelection({
     availableLocales,
     surveyModel,
     preselectedLocale: initialLocale,
   });
 
-  const handleLocaleChange = useCallback((newLocale: string) => {
-    changeLocale(newLocale);
-    setIsOpen(false);
-  }, [changeLocale]);
+  const handleLocaleChange = useCallback(
+    (newLocale: string) => {
+      changeLocale(newLocale);
+      setIsOpen(false);
+    },
+    [changeLocale],
+  );
 
   // Close dropdown on click outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
         setIsOpen(false);
       }
     };
@@ -55,8 +67,17 @@ export function LanguageSelector({
     };
   }, [isOpen]);
 
-  // Don't show selector if only one locale available
-  if (!languageOptions.length || languageOptions.length <= 1) {
+  useEffect(() => {
+    if (hasMultipleLocales) {
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, [hasMultipleLocales]);
+
+  if (!hasMultipleLocales) {
     return null;
   }
 


### PR DESCRIPTION
# fix: Add overflow handling for language selector when rendered

## Description
Adds a selector detection rule, which triggers hidden overflow when the lang selector is rendered

## Related Issues
- fixes https://github.com/endatix/endatix-hub/issues/105

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
N/A