### PR TITLE
fix: Add a Retry mode for the Chat button

### DIFF
--- a/app/(main)/forms/create/ui/chat-box.tsx
+++ b/app/(main)/forms/create/ui/chat-box.tsx
@@ -7,6 +7,7 @@ import {
   Paperclip,
   StopCircle,
   Globe,
+  Repeat2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -46,10 +47,22 @@ const ChatErrorAlert = ({
 const SubmitButton = ({
   pending,
   disabled,
+  retryMode = false,
 }: {
   pending: boolean;
   disabled: boolean;
+  retryMode?: boolean;
 }) => {
+
+  const chatIcon = retryMode ? (
+    <Repeat2 className="size-3" />
+  ) : pending ? (
+    <StopCircle className="size-6" />
+  ) : (
+    <CornerDownLeft className="size-3" />
+  );
+
+
   return (
     <Button
       type="submit"
@@ -58,12 +71,8 @@ const SubmitButton = ({
       aria-disabled={pending}
       disabled={disabled || pending}
     >
-      Chat
-      {pending ? (
-        <StopCircle className="size-6" />
-      ) : (
-        <CornerDownLeft className="size-3" />
-      )}
+      {retryMode ? "Retry" : "Chat"}
+      {chatIcon}
     </Button>
   );
 };
@@ -94,9 +103,11 @@ const ChatBox = ({
   ...props
 }: ChatBoxProps) => {
   const [input, setInput] = useState("");
+  const [retryMode, setRetryMode] = useState(false);
   const [state, action, pending] = useActionState(
     async (prevState: PromptResult, formData: FormData) => {
       const contextStore = new AssistantStore();
+      setRetryMode(false);
 
       if (requiresNewContext) {
         contextStore.clear();
@@ -117,6 +128,7 @@ const ChatBox = ({
       const promptResult = await defineFormAction(prevState, formData);
 
       if (ApiResult.isError(promptResult)) {
+        setRetryMode(true);
         return promptResult;
       }
 
@@ -179,6 +191,8 @@ const ChatBox = ({
 
   // Handle translation submission
   const handleTranslateSubmit = () => {
+    setRetryMode(false);
+
     if (!targetLanguage.trim()) {
       return;
     }
@@ -291,7 +305,7 @@ const ChatBox = ({
               <TooltipContent side="top">Use Microphone</TooltipContent>
             </Tooltip>
           </TooltipProvider>
-          <SubmitButton pending={pending} disabled={input.length === 0} />
+          <SubmitButton pending={pending} disabled={input.length === 0} retryMode={retryMode} />
         </div>
       </form>
       <p className="text-center text-xs text-gray-500">


### PR DESCRIPTION
# Add a Retry mode for the Chat button

## Description
- When a request fails, now the "Chat" button shows a "Retry" mode to indicate to the user they can retry sending their message and self-recover

## Related Issues
- related to https://github.com/endatix/endatix-private/issues/234

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)e

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="790" height="266" alt="image" src="https://github.com/user-attachments/assets/ba596a2b-55c8-4501-97c1-5676accb41c7" />