### PR TITLE
fix: Fix tagbox other choice and added error handling for missing choice

### DIFF
--- a/features/submissions/ui/answers/tagbox-answer.tsx
+++ b/features/submissions/ui/answers/tagbox-answer.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import { Minus } from "lucide-react";
 import React from "react";
 import { Question } from "survey-core";
-import { ValueTooltip } from './value-tooltip';
+import { ValueTooltip } from "./value-tooltip";
 
 interface TagBoxAnswerProps extends React.HtmlHTMLAttributes<HTMLDivElement> {
   question: Question;
@@ -11,6 +11,11 @@ interface TagBoxAnswerProps extends React.HtmlHTMLAttributes<HTMLDivElement> {
 const TagBoxAnswer = ({ question, className }: TagBoxAnswerProps) => {
   if (!question?.value) {
     return <Minus className="h-4 w-4" />;
+  }
+
+  const choices = question.choices;
+  if (question.isOtherSelected) {
+    choices.push(question.otherItemValue);
   }
 
   return (
@@ -26,13 +31,18 @@ const TagBoxAnswer = ({ question, className }: TagBoxAnswerProps) => {
 };
 
 const TagItem = ({ choice }: { choice: Question }) => {
+  if (!choice) {
+    console.error("Choice not found", choice);
+    return null;
+  }
+
   return (
     <Badge
       variant="outline"
       className="flex flex-row items-center gap-2 text-sm font-medium"
-      key={choice.value}
+      key={choice?.value}
     >
-      {choice.title}
+      {choice?.title}
       <ValueTooltip value={choice} />
     </Badge>
   );


### PR DESCRIPTION
# fix: Fix tagbox other choice and added error handling for missing choice

## Description
The submissions page was failing due to "other" option of the tag box causing null choice passed to the child components for rendering. This PR adds support for "other" option



## Related Issues
- relates to https://github.com/endatix/endatix-private/issues/238

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="594" height="63" alt="image" src="https://github.com/user-attachments/assets/eb2e193e-daa0-4d9f-909c-b20bb3a8ab78" />