### PR TITLE
feat: Show custom submitter ID and name

### DIFF
--- a/features/submissions/ui/details/submission-properties.tsx
+++ b/features/submissions/ui/details/submission-properties.tsx
@@ -31,11 +31,33 @@ const getFormattedDate = (date?: Date): string => {
 export function SubmissionProperties({
   submission,
 }: SubmissionPropertiesProps) {
+  let submissionMetadata: Record<string, unknown> | null = null;
+  try {
+    submissionMetadata = submission?.metadata
+      ? (JSON.parse(submission.metadata) as Record<string, unknown>)
+      : null;
+  } catch {
+    submissionMetadata = null;
+  }
+
+  const submittedByName =
+    (submissionMetadata?.["submittedByName"] as string | undefined) ||
+    undefined;
   return (
     <div className="px-4">
       <PropertyDisplay label="Created at">
         {getFormattedDate(submission.createdAt)}
       </PropertyDisplay>
+      {submission.submittedBy && (
+        <PropertyDisplay label="Submitted by (ID)">
+          {submission.submittedBy}
+        </PropertyDisplay>
+      )}
+      {submittedByName && (
+        <PropertyDisplay label="Submitted by (name)">
+          {submittedByName}
+        </PropertyDisplay>
+      )}
       <PropertyDisplay label="Is Complete?" valueClassName="uppercase">
         <CellCompleteStatus isComplete={submission.isComplete} />
       </PropertyDisplay>

--- a/lib/endatix-api/submissions/types.ts
+++ b/lib/endatix-api/submissions/types.ts
@@ -36,6 +36,7 @@ export interface Submission extends ApiEntity {
   jsonData: JsonData;
   currentPage: number;
   metadata: JsonData;
+  submittedBy?: string;
   token: string;
   completedAt?: Date;
   status: SubmissionStatus;


### PR DESCRIPTION
# Show custom submitter ID and name

## Description
When the submitter data is present in the submission, displays it like
<img width="1544" height="836" alt="image" src="https://github.com/user-attachments/assets/0445c45e-dc77-496e-8688-e14aa69dcc58" />

## Related Issues
https://github.com/endatix/endatix-private/issues/242

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project