### PR TITLE
fix: Add max height to form card and adding flex col orientation to the card

### DIFF
--- a/features/forms/ui/form-card.tsx
+++ b/features/forms/ui/form-card.tsx
@@ -80,7 +80,7 @@ const FormCard = ({ form, isSelected, onSaveAsTemplate, className, ...props }: F
       )}
       {...props}
     >
-      <div className="cursor-pointer">
+      <div className="flex flex-col justify-between h-full cursor-pointer">
         <CardHeader className="flex flex-row justify-between p-4 pt-6">
           <CardTitle className="text-2xl font-normal font-sans tracking-tigher">
             {form.name}


### PR DESCRIPTION
# Add max height to form card and adding flex col orientation to the card

## Description
- Add max height to form card and adding flex col orientation to the card

## Related Issues
- fixes https://github.com/endatix/endatix-hub/issues/151

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="1053" height="297" alt="image" src="https://github.com/user-attachments/assets/9ec24594-5559-4631-899e-9bebe7ef38a8" />