### PR TITLE
feat: Change Docker image Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:20-alpine AS base
 RUN npm install -g pnpm
 WORKDIR /app
 


### PR DESCRIPTION
# Change Docker image Node version

## Description
Specific Node version is needed for Endatix Hub to work. The Node image for Docker must also use the correct version.

## Related Issues
https://github.com/endatix/endatix-private/issues/185

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
