### PR TITLE
fix: Better format agent settings; Add gpt-5-mini model; Prevent overriding with empty form definition

### DIFF
--- a/app/(main)/admin/agents/[agentId]/page.tsx
+++ b/app/(main)/admin/agents/[agentId]/page.tsx
@@ -49,21 +49,36 @@ export default async function AgentDetailsPage({ params }: Params) {
         </div>
       </div>
       <div className="bg-card border rounded-lg p-6 mb-8">
-        <div className="mb-2 text-lg font-semibold">
-          Model: <span className="font-normal">{agent.data.model}</span>
+        <div className="mb-4">
+          <div className="font-semibold mb-2">Model:</div>
+          <div className="bg-muted/50 border rounded p-3 font-mono text-sm">
+            {agent.data.model}
+          </div>
         </div>
-        <div className="mb-2">
-          Temperature:{" "}
-          <span className="font-mono">{agent.data.temperature}</span>
+        <div className="mb-4">
+          <div className="font-semibold mb-2">Temperature:</div>
+          <div className="bg-muted/50 border rounded p-3 font-mono text-sm">
+            {agent.data.temperature}
+          </div>
         </div>
-        <div className="mb-2">
-          System Prompt:{" "}
-          <span className="font-mono">{agent.data.systemPrompt}</span>
+        <div className="mb-4">
+          <div className="font-semibold mb-2">System Prompt:</div>
+          <div className="bg-muted/50 border rounded p-3 font-mono text-sm whitespace-pre-wrap break-words">
+            {agent.data.systemPrompt}
+          </div>
         </div>
-        <div className="mb-2">
-          Created: {getFormattedDate(new Date(agent.data.createdAt))}
+        <div className="mb-4">
+          <div className="font-semibold mb-2">Created:</div>
+          <div className="bg-muted/50 border rounded p-3 text-sm">
+            {getFormattedDate(new Date(agent.data.createdAt))}
+          </div>
         </div>
-        <div className="mb-2">Conversations: {conversations.data.length}</div>
+        <div className="mb-4">
+          <div className="font-semibold mb-2">Conversations:</div>
+          <div className="bg-muted/50 border rounded p-3 text-sm">
+            {conversations.data.length}
+          </div>
+        </div>
       </div>
       <div>
         <h2 className="text-xl font-semibold mb-4">Conversations</h2>

--- a/app/(main)/forms/create/ui/preview-form.tsx
+++ b/app/(main)/forms/create/ui/preview-form.tsx
@@ -27,7 +27,9 @@ const PreviewForm = ({ model, slkVal }: PreviewFormProps) => {
 
   useEffect(() => {
     if (creator) {
-      creator.JSON = model;
+      if (model && Object.keys(model).length > 0) {
+        creator.JSON = model;
+      }
       return;
     }
 

--- a/features/agents/ui/agent-form.tsx
+++ b/features/agents/ui/agent-form.tsx
@@ -28,7 +28,7 @@ interface AgentFormProps {
   isPending?: boolean;
 }
 
-const ENABLED_MODELS = ["o4-mini"];
+const ENABLED_MODELS = ["gpt-5-mini", "o4-mini"];
 const AGENTS_NAMES = ["DefineForm"];
 
 export function AgentFormContainer({


### PR DESCRIPTION
## Description
- Better format agent settings
Old:
<img width="1474" height="1612" alt="image" src="https://github.com/user-attachments/assets/798cff52-1680-4f08-bf6d-e9f3419212a1" />

New:
<img width="1456" height="1614" alt="image" src="https://github.com/user-attachments/assets/365f02a9-9822-4eac-a7bf-de6f2dc37d3b" />

- Add "gpt-5-mini" model as an option

- Prevent overriding with empty form definition in the AI Assistant form preview.

## Related Issues
https://github.com/endatix/endatix-private/issues/277

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
