### PR TITLE
fix: Adding check to ensure delete callback returns success when StoreDataAsText is True

### DIFF
--- a/features/storage/__tests__/hooks/use-blob-storage.test.ts
+++ b/features/storage/__tests__/hooks/use-blob-storage.test.ts
@@ -234,7 +234,9 @@ describe("useBlobStorage", () => {
     });
 
     it("should handle upload errors gracefully", async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("Network error"),
+      );
 
       const { result } = renderHook(() =>
         useBlobStorage({
@@ -311,6 +313,7 @@ describe("useBlobStorage", () => {
         },
       ],
       callback: vi.fn(),
+      question: { storeDataAsText: false },
     } as unknown as ClearFilesEvent;
 
     beforeEach(() => {
@@ -384,6 +387,28 @@ describe("useBlobStorage", () => {
       });
 
       expect(global.fetch).not.toHaveBeenCalled();
+      expect(emptyOptions.callback).toHaveBeenCalledWith("success");
+    });
+
+    it("should return success if storeDataAsText is true", async () => {
+      const emptyOptions: ClearFilesEvent = {
+        value: [],
+        callback: vi.fn(),
+        question: { storeDataAsText: true },
+      } as unknown as ClearFilesEvent;
+
+      const { result } = renderHook(() =>
+        useBlobStorage({
+          formId: mockFormId,
+          submissionId: mockSubmissionId,
+          surveyModel: mockSurveyModel,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.deleteFiles(mockSurveyModel, emptyOptions);
+      });
+
       expect(emptyOptions.callback).toHaveBeenCalledWith("success");
     });
 
@@ -485,7 +510,9 @@ describe("useBlobStorage", () => {
     });
 
     it("should handle network errors", async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("Network error"),
+      );
 
       const { result } = renderHook(() =>
         useBlobStorage({

--- a/features/storage/hooks/use-blob-storage.ts
+++ b/features/storage/hooks/use-blob-storage.ts
@@ -284,6 +284,10 @@ export function useBlobStorage({
   const deleteFiles = useCallback(
     async (sender: SurveyModel, options: ClearFilesEvent) => {
       try {
+        if (options.question?.storeDataAsText) {
+          return options.callback("success");
+        }
+
         if (!options.value || options.value.length === 0) {
           return options.callback("success");
         }


### PR DESCRIPTION
# fix: Adding check to ensure delete callback returns success when StoreDataAsText is True

## Description
- Adding check to ensure delete callback returns success when StoreDataAsText is True
- Updating `use-blob-storage.tests.ts`

## Related Issues
- fixes https://github.com/endatix/endatix-hub/issues/191

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.