### PR TITLE
feat: Open prefilled form by token

### DIFF
--- a/__tests__/pages/share-form.test.tsx
+++ b/__tests__/pages/share-form.test.tsx
@@ -51,6 +51,7 @@ describe("ShareForm Page", async () => {
 
     const props = {
       params: Promise.resolve({ formId: "invalid-id" }),
+      searchParams: Promise.resolve({}),
     };
 
     // The component should call notFound() and not return JSX
@@ -77,6 +78,7 @@ describe("ShareForm Page", async () => {
 
     const props = {
       params: Promise.resolve({ formId: "valid-id" }),
+      searchParams: Promise.resolve({}),
     };
 
     const component = await ShareFormPage(props);

--- a/app/(public)/share/[formId]/page.tsx
+++ b/app/(public)/share/[formId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { FormTokenCookieStore } from "@/features/public-form/infrastructure/cookie-store";
 import SurveyJsWrapper from "@/features/public-form/ui/survey-js-wrapper";
+import { TokenHandler } from "@/features/public-form/ui/token-handler";
 import { getActiveDefinitionUseCase } from "@/features/public-form/use-cases/get-active-definition.use-case";
 import { getPartialSubmissionUseCase } from "@/features/public-form/use-cases/get-partial-submission.use-case";
 import { recaptchaConfig } from "@/features/recaptcha/recaptcha-config";
@@ -14,15 +15,17 @@ import Script from "next/script";
 
 type ShareSurveyPage = {
   params: Promise<{ formId: string }>;
+  searchParams: Promise<{ token?: string }>;
 };
 
-async function ShareSurveyPage({ params }: ShareSurveyPage) {
+async function ShareSurveyPage({ params, searchParams }: ShareSurveyPage) {
   const { formId } = await params;
+  const { token: urlToken } = await searchParams;
   const cookieStore = await cookies();
   const tokenStore = new FormTokenCookieStore(cookieStore);
 
   const [submissionResult, activeDefinitionResult] = await Promise.all([
-    getPartialSubmissionUseCase({ formId, tokenStore }),
+    getPartialSubmissionUseCase({ formId, tokenStore, urlToken }),
     getActiveDefinitionUseCase({ formId }),
   ]);
 
@@ -51,6 +54,7 @@ async function ShareSurveyPage({ params }: ShareSurveyPage) {
         height: "100%",
       }}
     >
+      {urlToken && <TokenHandler formId={formId} />}
       {shouldLoadReCaptcha && (
         <>
           <Script src={recaptchaConfig.JS_URL} strategy="beforeInteractive" />

--- a/features/public-form/application/actions/set-token-from-url.action.ts
+++ b/features/public-form/application/actions/set-token-from-url.action.ts
@@ -1,0 +1,19 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { FormTokenCookieStore } from "@/features/public-form/infrastructure/cookie-store";
+import { Result } from "@/lib/result";
+
+/**
+ * Server action to set a submission token from URL parameter into cookies.
+ * This enables prefilled form functionality where an external system
+ * creates a submission with prefilled data and passes the token via URL.
+ */
+export async function setTokenFromUrlAction(
+  formId: string,
+  token: string,
+): Promise<Result<void>> {
+  const cookieStore = await cookies();
+  const tokenStore = new FormTokenCookieStore(cookieStore);
+  return tokenStore.setToken({ formId, token });
+}

--- a/features/public-form/application/use-search-params-variables.hook.ts
+++ b/features/public-form/application/use-search-params-variables.hook.ts
@@ -47,7 +47,10 @@ export const useSearchParamsVariables = (
     const searchParamsVars: Record<string, DynamicVariable> = {};
 
     searchParams.forEach((value, key) => {
-      searchParamsVars[key] = value;
+      // Skip 'token' parameter as it's used for submission prefill, not as a variable
+      if (key !== "token") {
+        searchParamsVars[key] = value;
+      }
     });
 
     if (Object.keys(searchParamsVars).length === 0) {

--- a/features/public-form/ui/token-handler.tsx
+++ b/features/public-form/ui/token-handler.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { setTokenFromUrlAction } from "../application/actions/set-token-from-url.action";
+
+interface TokenHandlerProps {
+  formId: string;
+}
+
+/**
+ * Client component that handles token from URL:
+ * 1. Extracts token from URL search params
+ * 2. Saves it to cookie via server action
+ * 3. Removes token from URL to prevent reload issues
+ */
+export function TokenHandler({ formId }: TokenHandlerProps) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const hasProcessedRef = useRef(false);
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+
+    // Only process once and only if token exists
+    if (!token || hasProcessedRef.current) {
+      return;
+    }
+
+    hasProcessedRef.current = true;
+
+    // Save token to cookie via server action
+    setTokenFromUrlAction(formId, token).then(() => {
+      // Remove token from URL to prevent issues on refresh
+      const newSearchParams = new URLSearchParams(searchParams);
+      newSearchParams.delete("token");
+
+      const newUrl = newSearchParams.toString()
+        ? `${window.location.pathname}?${newSearchParams.toString()}`
+        : window.location.pathname;
+
+      window.history.replaceState(null, "", newUrl);
+    });
+  }, [searchParams, router, formId]);
+
+  return null; // This component doesn't render anything
+}


### PR DESCRIPTION
# Open prefilled form by token

## Description
Changes in Endatix Hub to support the token query string in the share form link - it is read from the query string, set in the cookie like the token is set for the partial submissions, then the logic works like with the partial submissions.

## Related Issues
https://github.com/endatix/endatix-private/issues/310

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project