### PR TITLE
feat: Add "Beta" badge next to "AI Assistant"

### DIFF
--- a/features/forms/ui/editor/form-editor-with-chat.tsx
+++ b/features/forms/ui/editor/form-editor-with-chat.tsx
@@ -244,17 +244,27 @@ export default function FormEditorWithChat({
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
-                <span className="text-lg font-semibold text-foreground/70 tracking-wide" style={{ writingMode: 'vertical-rl', textOrientation: 'mixed' }}>
-                  AI Assistant
-                </span>
+                <div className="flex flex-col items-center gap-2">
+                  <span className="text-lg font-semibold text-foreground/70 tracking-wide" style={{ writingMode: 'vertical-rl', textOrientation: 'mixed' }}>
+                    AI Assistant
+                  </span>
+                  <span className="px-1 py-2 text-xs font-medium bg-primary text-primary-foreground rounded-full tracking-wide" style={{ writingMode: 'vertical-rl' }}>
+                    Beta
+                  </span>
+                </div>
               </div>
             ) : null}
             {!isCollapsed && (
               <div className="flex flex-col gap-4 p-2 w-full -mt-2">
                 <div className="flex items-center justify-between w-full px-2">
-                  <span className="text-lg font-semibold text-foreground/70">
-                    AI Assistant
-                  </span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-lg font-semibold text-foreground/70">
+                      AI Assistant
+                    </span>
+                    <span className="px-2 py-0.5 text-xs font-medium bg-primary text-primary-foreground rounded-full">
+                      Beta
+                    </span>
+                  </div>
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>


### PR DESCRIPTION
# Add "Beta" badge next to "AI Assistant"

## Description
Add "Beta" badge next to "AI Assistant"
<img width="681" height="328" alt="image" src="https://github.com/user-attachments/assets/e8508cd6-7f90-4d0c-9291-4a9980f486e4" />
<img width="202" height="576" alt="image" src="https://github.com/user-attachments/assets/fedd4ed3-5730-4b06-bd29-e4e179a364b0" />

## Related Issues
[List any related issues (e.g., fixes #123, closes #456).](https://github.com/endatix/endatix-private/issues/287)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
