### PR TITLE
fix: Set caching headers for api/auth/me route

### DIFF
--- a/lib/utils/route-handlers.ts
+++ b/lib/utils/route-handlers.ts
@@ -15,7 +15,6 @@ interface ErrorResponse {
   fields?: Record<string, string[]>;
 }
 
-
 /**
  * Converts an ApiError to an ErrorResponse to easily create a problem details response.
  * @param title - The title of the error.
@@ -191,3 +190,52 @@ export const apiResponses = {
   notFound: notFoundResponse,
   serverError: serverError,
 };
+
+/**
+ * Options for caching the response - CDN, proxy, etc.
+ */
+export interface CachingOptions {
+  /**
+   * The mode to prevent proxy caching in.
+   * @param browserOnly - Prevents proxy caching in the browser only.
+   * @param noStore - Prevents proxy caching in the browser and server.
+   */
+  storeMode?: "browserOnly" | "noStore";
+
+  /**
+   * The ETag for the response.
+   * @param etag - The ETag for the response.
+   */
+  etag?: string;
+}
+
+/**
+ * Sets the caching headers for the response - CDN, proxy, etc.
+ * This is useful for authentication/authorization data that should not be cached.
+ * @param response - The NextResponse to set the caching headers for.
+ * @param options - The options for the caching headers.
+ */
+export function setResponseCachingHeaders(
+  response: NextResponse,
+  options: CachingOptions,
+): void {
+  const { storeMode = "browserOnly" } = options;
+  if (storeMode === "browserOnly") {
+    response.headers.set(
+      "Cache-Control",
+      "private, max-age=0, must-revalidate",
+    );
+  } else if (storeMode === "noStore") {
+    response.headers.set(
+      "Cache-Control",
+      "no-store, no-cache, must-revalidate",
+    );
+  }
+
+  response.headers.set("Pragma", "no-cache");
+  response.headers.set("Vary", "Cookie");
+
+  if (options.etag) {
+    response.headers.set("ETag", `"${options.etag}"`);
+  }
+}


### PR DESCRIPTION
# fix: Set caching headers for api/auth/me route

## Description
- Set caching headers for auth/me route
- Adds setResponseCachingHeaders for reusability 

## Related Issues
- fixes https://github.com/endatix/endatix-hub/issues/239

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.