### PR TITLE
chore(deps): override node-forge to >=1.3.3 due to CVE-2025-66031

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "pnpm:comments": "node ./scripts/echo-pnpm-comments.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.8.1",
@@ -48,6 +49,18 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "node-forge": "^1.3.3"
+    },
+    "comments": {
+      "overrides": "Override node-forge to version 1.3.3 until issue is addressed by Docusaurus"
+    },
+    "onlyBuiltDependencies": [
+      "core-js",
+      "core-js-pure"
+    ]
   },
   "packageManager": "pnpm@10.8.0+sha256.29bf2c5ceaea7991ee82eec15fe7162e0fad816d0c4a6b35a16c01d39274bf69"
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  node-forge: ^1.3.3
+
 importers:
 
   .:
@@ -3740,8 +3743,8 @@ packages:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
 
-  node-forge@1.3.1:
-    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
+  node-forge@1.3.3:
+    resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
     engines: {node: '>= 6.13.0'}
 
   node-releases@2.0.19:
@@ -10362,7 +10365,7 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
-  node-forge@1.3.1: {}
+  node-forge@1.3.3: {}
 
   node-releases@2.0.19: {}
 
@@ -11383,7 +11386,7 @@ snapshots:
   selfsigned@2.4.1:
     dependencies:
       '@types/node-forge': 1.3.13
-      node-forge: 1.3.1
+      node-forge: 1.3.3
 
   semver-diff@4.0.0:
     dependencies:

--- a/docs/scripts/echo-pnpm-comments.mjs
+++ b/docs/scripts/echo-pnpm-comments.mjs
@@ -1,0 +1,23 @@
+import fs from "fs";
+
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+
+const comments = pkg.pnpm?.comments;
+
+if (!comments) process.exit(0);
+
+console.log("\nℹ️ pnpm comments:\n");
+
+for (const [key, value] of Object.entries(comments)) {
+  if (typeof value === "string" && value.includes("|")) {
+    const items = value.split("|").map((item) => item.trim()).filter((item) => item.length > 0);
+    console.log(`❯ ${key}:`);
+    for (const item of items) {
+      console.log(`  - ${item}`);
+    }
+  } else {
+    console.log(`❯ ${key}: ${typeof value === "string" ? value : JSON.stringify(value, null, 2)}`);
+  }
+}
+
+console.log("");


### PR DESCRIPTION
# chore(deps): override node-forge to >=1.3.3 due to CVE-2025-66031

## Description
- chore(deps): override node-forge to >=1.3.3 due to CVE-2025-66031
- add pnpm:comment script to emit comments

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/265

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Other (CI script)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.