### PR TITLE
fix: Remove onAfterRenderContentElement from createCustomQuestionClass

### DIFF
--- a/lib/questions/infrastructure/specialized-survey-question.ts
+++ b/lib/questions/infrastructure/specialized-survey-question.ts
@@ -39,7 +39,6 @@ export interface CustomQuestionConfig {
   inheritBaseProps?: boolean;
   questionJSON?: Question;
   elementsJSON?: Question[];
-  onAfterRenderContentElement?: string;
 }
 
 /**
@@ -58,18 +57,6 @@ export function createCustomQuestionClass(config: CustomQuestionConfig) {
         ...(config.elementsJSON
           ? { elementsJSON: config.elementsJSON }
           : { questionJSON: config.questionJSON }),
-        onAfterRenderContentElement: config.onAfterRenderContentElement
-          ? (new Function(
-              "question",
-              "element",
-              "htmlElement",
-              config.onAfterRenderContentElement,
-            ) as (
-              question: Question,
-              element: Question,
-              htmlElement: HTMLElement,
-            ) => void)
-          : undefined,
       };
     }
 
@@ -135,9 +122,6 @@ export function initializeCustomQuestions(
           ...(parsedJson.elementsJSON
             ? { elementsJSON: parsedJson.elementsJSON }
             : { questionJSON: parsedJson.questionJSON }),
-          onAfterRenderContentElement: parsedJson.onAfterRenderContentElement
-            ? parsedJson.onAfterRenderContentElement
-            : undefined,
         };
 
         const QuestionClass = createCustomQuestionClass(config);


### PR DESCRIPTION
# Remove onAfterRenderContentElement from createCustomQuestionClass

## Description
Removeing the setting of onAfterRenderContentElement for custom questions from the DB at this logic will not be supported anymore and could lead to Remote Code Execution (RCE) in Custom Questions.

## Related Issues
closes #277

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.