### PR TITLE
chore(deps): bump mermaid to fix CVE-2025-54881

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -53,10 +53,11 @@
   "pnpm": {
     "overrides": {
       "node-forge": "^1.3.3",
-      "mdast-util-to-hast": "^13.2.1"
+      "mdast-util-to-hast": "^13.2.1",
+      "medmaid": "^11.10.0"
     },
     "comments": {
-      "overrides": "Override node-forge to version 1.3.3 until issue is addressed by Docusaurus | mdast-util-to-hast on 13.2.1 to fix CVE-2025-66400. Remove on next Docusaurus bump"
+      "overrides": "[node-forge] to version 1.3.3 until issue is addressed by Docusaurus | [mdast-util-to-hast] on 13.2.1 to fix CVE-2025-66400. Remove on next Docusaurus bump | [mermaid] on 11.10.0 to fix CVE-2025-54881. Remove on next Docusaurus bump"
     },
     "onlyBuiltDependencies": [
       "core-js",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   node-forge: ^1.3.3
   mdast-util-to-hast: ^13.2.1
+  medmaid: ^11.10.0
 
 importers:
 


### PR DESCRIPTION
# chore(deps): bump mermaid to fix CVE-2025-54881

## Description
Use overrides as latest docusaurus/theme-mermaid was requiring vulnerable version (see below)
```bash
@docusaurus/theme-mermaid 3.9.2
└── mermaid 11.9.0
```

## Related Issues
List any related issues (e.g., fixes #123, closes #456).

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.