### PR TITLE
chore: bump qs to v6.14.1 to fix GHSA-6rw7-vpxm-498p

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -55,10 +55,11 @@
       "node-forge": "^1.3.3",
       "mdast-util-to-hast": "^13.2.1",
       "mermaid": "^11.10.0",
-      "js-yaml": "^4.1.1"
+      "js-yaml": "^4.1.1",
+      "qs": "^6.14.1"
     },
     "comments": {
-      "overrides": "[node-forge] to version 1.3.3 until issue is addressed by Docusaurus | [mdast-util-to-hast] on 13.2.1 to fix CVE-2025-66400. Remove on next Docusaurus bump | [mermaid] on 11.10.0 to fix CVE-2025-54881. Remove on next Docusaurus bump | [js-yaml] to 4.1.1 to fix CVE-2025-64718. Remove on next Docusaurus bump"
+      "overrides": "[node-forge] to version 1.3.3 until issue is addressed by Docusaurus | [mdast-util-to-hast] on 13.2.1 to fix CVE-2025-66400. Remove on next Docusaurus bump | [mermaid] on 11.10.0 to fix CVE-2025-54881. Remove on next Docusaurus bump | [js-yaml] to 4.1.1 to fix CVE-2025-64718. Remove on next Docusaurus bump | [qs] to 6.14.1 to fix CVE-2025-66400. Remove on next Docusaurus bump"
     },
     "onlyBuiltDependencies": [
       "core-js",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   mdast-util-to-hast: ^13.2.1
   mermaid: ^11.10.0
   js-yaml: ^4.1.1
+  qs: ^6.14.1
 
 importers:
 
@@ -4461,8 +4462,8 @@ packages:
     resolution: {integrity: sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==}
     engines: {node: '>=12.20'}
 
-  qs@6.13.0:
-    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -8257,7 +8258,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.13.0
+      qs: 6.14.1
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -9232,7 +9233,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.13.0
+      qs: 6.14.1
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
@@ -11250,7 +11251,7 @@ snapshots:
     dependencies:
       escape-goat: 4.0.0
 
-  qs@6.13.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
# chore: bump qs to v6.14.1 to fix GHSA-6rw7-vpxm-498p

## Description
Addresses https://github.com/ljharb/qs/security/advisories/GHSA-6rw7-vpxm-498p

## Related Issues
- closes https://github.com/endatix/endatix/issues/560

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.