### PR TITLE
feat: Form embedding works with submission access token

### DIFF
--- a/app/(public)/embed/[formId]/page.tsx
+++ b/app/(public)/embed/[formId]/page.tsx
@@ -1,22 +1,22 @@
 "use server";
 
+import { NotFoundComponent } from "@/components/error-handling/not-found/not-found-component";
+import { AssetStorageProvider } from "@/features/asset-storage/server";
 import { FormTokenCookieStore } from "@/features/public-form/infrastructure/cookie-store";
-import SurveyJsWrapper from "@/features/public-form/ui/survey-js-wrapper";
 import { EmbedHeightReporter } from "@/features/public-form/ui/embed-height-reporter";
+import SurveyJsWrapper from "@/features/public-form/ui/survey-js-wrapper";
 import { getActiveDefinitionUseCase } from "@/features/public-form/use-cases/get-active-definition.use-case";
 import { getPartialSubmissionUseCase } from "@/features/public-form/use-cases/get-partial-submission.use-case";
+import { getSubmissionByAccessTokenUseCase } from "@/features/public-submissions/edit/get-submission-by-access-token.use-case";
 import { recaptchaConfig } from "@/features/recaptcha/recaptcha-config";
 import { ReCaptchaStyleFix } from "@/features/recaptcha/ui/recaptcha-style-fix";
-import {
-  ApiResult,
-  isNotFoundError,
-  isValidationError,
-} from "@/lib/endatix-api";
+import { ApiResult, Submission } from "@/lib/endatix-api";
 import { Result } from "@/lib/result";
+import { hasTokenPermission, TokenPermission } from "@/lib/utils";
 import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import Script from "next/script";
-import { AssetStorageProvider } from "@/features/asset-storage/server";
+import { Suspense } from "react";
 
 type EmbedSurveyPage = {
   params: Promise<{ formId: string }>;
@@ -29,22 +29,83 @@ async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
   const cookieStore = await cookies();
   const tokenStore = new FormTokenCookieStore(cookieStore);
 
+  if (urlToken) {
+    if (!hasTokenPermission(urlToken, TokenPermission.Read)) {
+      return (
+        <NotFoundComponent
+          notFoundTitle="Access Denied"
+          notFoundSubtitle="You don't have permission to view this submission"
+          notFoundMessage="The access token does not include view permissions."
+          titleSize="medium"
+        />
+      );
+    }
+
+    if (!hasTokenPermission(urlToken, TokenPermission.Write)) {
+      return (
+        <NotFoundComponent
+          notFoundTitle="Access Denied"
+          notFoundSubtitle="You don't have permission to edit this submission"
+          notFoundMessage="The access token does not include edit permissions."
+          titleSize="medium"
+        />
+      );
+    }
+  }
+
+  // Fetch submission: URL token uses access token API, otherwise cookie-based partial submission
+  const submissionResultPromise = urlToken
+    ? getSubmissionByAccessTokenUseCase({ formId, token: urlToken })
+    : getPartialSubmissionUseCase({ formId, tokenStore, urlToken: undefined });
+
   const [submissionResult, activeDefinitionResult] = await Promise.all([
-    getPartialSubmissionUseCase({ formId, tokenStore, urlToken }),
+    submissionResultPromise,
     getActiveDefinitionUseCase({ formId }),
   ]);
 
-  if (
-    (isNotFoundError(submissionResult) ||
-      isValidationError(submissionResult)) &&
-    urlToken
-  ) {
-    notFound();
-  }
+  let submission;
 
-  const submission = ApiResult.isSuccess(submissionResult)
-    ? submissionResult.data
-    : undefined;
+  if (urlToken) {
+    const accessTokenResult = submissionResult as Result<Submission>;
+    if (Result.isError(accessTokenResult)) {
+      const errorMessage = accessTokenResult.message.toLowerCase();
+
+      if (errorMessage.includes("expired")) {
+        return (
+          <NotFoundComponent
+            notFoundTitle="Token Expired"
+            notFoundSubtitle="This link has expired"
+            notFoundMessage="Please request a new access link to continue."
+            titleSize="medium"
+          />
+        );
+      }
+
+      if (errorMessage.includes("permission") || errorMessage.includes("forbidden")) {
+        return (
+          <NotFoundComponent
+            notFoundTitle="Access Denied"
+            notFoundSubtitle="You don't have permission to access this submission"
+            notFoundMessage="The access token does not have the required permissions."
+            titleSize="medium"
+          />
+        );
+      }
+
+      return (
+        <NotFoundComponent
+          notFoundTitle="Submission Not Found"
+          notFoundSubtitle="Unable to load submission"
+          notFoundMessage="The submission may have been deleted or the token is invalid."
+          titleSize="medium"
+        />
+      );
+    }
+    submission = accessTokenResult.value;
+  } else {
+    const partialResult = submissionResult as ApiResult<Submission>;
+    submission = ApiResult.isSuccess(partialResult) ? partialResult.data : undefined;
+  }
 
   if (Result.isError(activeDefinitionResult)) {
     notFound();
@@ -70,18 +131,20 @@ async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
 
       <EmbedHeightReporter />
 
-      <AssetStorageProvider>
-        <SurveyJsWrapper
-          formId={formId}
-          definition={activeDefinition.jsonData}
-          submission={submission}
-          theme={activeDefinition.themeModel}
-          customQuestions={activeDefinition.customQuestions}
-          requiresReCaptcha={activeDefinition.requiresReCaptcha}
-          isEmbed={true}
-          urlToken={urlToken}
-        />
-      </AssetStorageProvider>
+      <Suspense fallback={<div>Loading...</div>}>
+        <AssetStorageProvider>
+          <SurveyJsWrapper
+            formId={formId}
+            definition={activeDefinition.jsonData}
+            submission={submission}
+            theme={activeDefinition.themeModel}
+            customQuestions={activeDefinition.customQuestions}
+            requiresReCaptcha={activeDefinition.requiresReCaptcha}
+            isEmbed={true}
+            urlToken={urlToken}
+          />
+        </AssetStorageProvider>
+      </Suspense>
     </div>
   );
 }

--- a/examples/embedding/test-simple-token.html
+++ b/examples/embedding/test-simple-token.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Test: Access Token</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      max-width: 800px;
+      margin: 50px auto;
+      padding: 0 20px;
+    }
+    h1 { color: #333; }
+    .section {
+      margin: 30px 0;
+      padding: 20px;
+      border: 2px solid #e0e0e0;
+      border-radius: 8px;
+      background: #f9f9f9;
+    }
+  </style>
+</head>
+<body>
+  <h1>🔐 Access Token Test</h1>
+
+  <div class="section">
+    <h2>Embed Snippet:</h2>
+    <pre><code>&lt;script src="http://localhost:3000/embed/v1/embed.js"
+        data-form-id="{formId}"
+        data-token="{accessToken}"&gt;&lt;/script&gt;</code></pre>
+
+    <h2>Result:</h2>
+    <p>Form with existing submission should appear below:</p>
+
+    <script src="http://localhost:3000/embed/v1/embed.js"
+            data-form-id="{formId}"
+            data-token="{accessToken}"></script>
+  </div>
+
+  <div class="section" style="background: #fffbef;">
+    <h3>Expected Results:</h3>
+    <ul>
+      <li>✅ Form loads with existing submission data</li>
+      <li>✅ Changes save to same submission</li>
+      <li>✅ Console should be clean (no errors)</li>
+    </ul>
+
+    <h3>Token Format:</h3>
+    <p><code>{submissionId}.{expiryUnix}.rw.{signature}</code></p>
+    <p>Example: <code>1448309533460922368.1738368000.rw.a3f8b2c1</code></p>
+  </div>
+</body>
+</html>

--- a/public/embed/v1/embed.js
+++ b/public/embed/v1/embed.js
@@ -129,7 +129,9 @@
         var src =
           embedProtocol + "//" + parsedUrl.host + "/embed/" + validatedFormId;
 
-        if (options.prefill) {
+        if (options.token) {
+          src += "?token=" + encodeURIComponent(options.token);
+        } else if (options.prefill) {
           src += "?" + options.prefill;
         }
 
@@ -205,6 +207,7 @@
         currentScript.getAttribute("data-base-url") ||
         window.EndatixEmbed.getDefaultBaseUrl(),
       prefill: currentScript.getAttribute("data-prefill") || "",
+      token: currentScript.getAttribute("data-token") || "",
     };
 
     if (document.readyState === "loading") {


### PR DESCRIPTION
# Form embedding works with submission access token

## Description
- The embed script supports attribute `data-token` where an access token can be set
- Embedded prefilled submissions are loaded using the access token
- Partial submitting works for embedded forms loaded using the access token
- Different errors are show accordingly
- A test page `test-simple-token.html` is added

## Related Issues
closes #339

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above
