### PR TITLE
fix: Add fallback logic to resolve contentType from file extension 

### DIFF
--- a/features/asset-storage/infrastructure/__tests__/blob-metadata-parser.test.ts
+++ b/features/asset-storage/infrastructure/__tests__/blob-metadata-parser.test.ts
@@ -131,6 +131,42 @@ describe("blobMetadataParser.parseFromProperties", () => {
     );
     expect(lowercased.uploadedBy).toBe("usr-456");
   });
+
+  it("infers contentType from file extension when stored as application/octet-stream", () => {
+    const result = blobMetadataParser.parseFromProperties(
+      {
+        contentType: "application/octet-stream",
+        sizeInBytes: 1024,
+        metadata: {},
+      },
+      "s/f1/s1/photo.png",
+    );
+    expect(result.contentType).toBe("image/png");
+  });
+
+  it("keeps application/octet-stream when extension is unknown", () => {
+    const result = blobMetadataParser.parseFromProperties(
+      {
+        contentType: "application/octet-stream",
+        sizeInBytes: 100,
+        metadata: {},
+      },
+      "s/f1/s1/file.bin",
+    );
+    expect(result.contentType).toBe("application/octet-stream");
+  });
+
+  it("does not override explicit contentType with extension guess", () => {
+    const result = blobMetadataParser.parseFromProperties(
+      {
+        contentType: "image/jpeg",
+        sizeInBytes: 500,
+        metadata: {},
+      },
+      "s/f1/s1/photo.png",
+    );
+    expect(result.contentType).toBe("image/jpeg");
+  });
 });
 
 describe("blobMetadataParser.parseFromBlob", () => {
@@ -264,6 +300,33 @@ describe("blobMetadataParser.parseFromBlob", () => {
     expect(result.kind).toBe("user");
     expect(result.originalFileName).toBe("from-lowercase");
     expect(result.questionName).toBe("q-lower");
+  });
+
+  it("infers contentType from displayName when blob has application/octet-stream", () => {
+    const blob = {
+      name: "s/f1/s1/screenshot.png",
+      metadata: {},
+      properties: {
+        contentType: "application/octet-stream",
+        contentLength: 2048,
+      },
+    } as unknown as BlobItem;
+
+    const result = blobMetadataParser.parseFromBlob(blob);
+
+    expect(result.contentType).toBe("image/png");
+  });
+
+  it("infers contentType from displayName when placeholder (missing contentType)", () => {
+    const blob = {
+      name: "s/f1/s1/document.pdf",
+      metadata: {},
+      properties: { contentLength: 100 },
+    } as unknown as BlobItem;
+
+    const result = blobMetadataParser.parseFromBlob(blob);
+
+    expect(result.contentType).toBe("application/pdf");
   });
 });
 

--- a/features/asset-storage/infrastructure/blob-metadata-parser.ts
+++ b/features/asset-storage/infrastructure/blob-metadata-parser.ts
@@ -19,6 +19,46 @@ const DEFAULT_CONTENT_TYPE = "application/octet-stream";
 /** Placeholder when content type is missing in list views (e.g. table "—"). */
 const LIST_CONTENT_TYPE_PLACEHOLDER = "—";
 
+/** Extension (lowercase) → MIME type for inferring type when blob has application/octet-stream. */
+const EXTENSION_TO_MIME: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  bmp: "image/bmp",
+  ico: "image/x-icon",
+  pdf: "application/pdf",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+};
+
+/**
+ * When stored contentType is generic (octet-stream or placeholder), guess from file extension
+ * so legacy uploads can be previewed (e.g. image in modal).
+ */
+function resolveContentType(contentType: string, fileName: string): string {
+  const shouldResolveFromExtension =
+    !contentType ||
+    contentType === DEFAULT_CONTENT_TYPE ||
+    contentType === LIST_CONTENT_TYPE_PLACEHOLDER;
+
+  if (!shouldResolveFromExtension) {
+    return contentType;
+  }
+
+  const extension = fileName.split(".").pop()?.toLowerCase();
+  if (!extension) {
+    return contentType;
+  }
+
+  return EXTENSION_TO_MIME[extension] ?? contentType;
+}
+
 function parseFileState(value: string | undefined): ProcessedState | undefined {
   if (value === "original" || value === "optimized") return value;
   return undefined;
@@ -53,11 +93,12 @@ export const blobMetadataParser = {
    */
   parseFromBlob(blob: BlobItem): UserFileMetadata {
     const metadata = blob.metadata ?? {};
-    const contentType =
+    const rawContentType =
       metadata["content-type"] ??
       (blob.properties?.contentType as string | undefined) ??
       LIST_CONTENT_TYPE_PLACEHOLDER;
     const displayName = getLastSegmentFromUrlPath(blob.name);
+    const contentType = resolveContentType(rawContentType, displayName);
     const fields = parseMetadataFields(metadata);
 
     return {
@@ -79,7 +120,9 @@ export const blobMetadataParser = {
   ): UserFileMetadata {
     const metadata = properties.metadata ?? {};
     const displayName = getLastSegmentFromUrlPath(blobName);
-    const contentType = properties.contentType?.trim() || DEFAULT_CONTENT_TYPE;
+    const rawContentType =
+      properties.contentType?.trim() || DEFAULT_CONTENT_TYPE;
+    const contentType = resolveContentType(rawContentType, displayName);
     const fields = parseMetadataFields(metadata);
 
     return {


### PR DESCRIPTION
# fix: Add fallback logic to resolve contentType from file extension 

## Description
Add fallback logic to resolve contentType from file extension 

- Logic is active when contentType is missing or default placeholder
- Update tests

## Related Issues
- fixes https://github.com/endatix/endatix-hub/issues/390

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="1136" height="270" alt="image" src="https://github.com/user-attachments/assets/8d2605ef-0ad4-409b-bb2f-24a2c53c5303" />
<img width="1019" height="1040" alt="image" src="https://github.com/user-attachments/assets/61a4365d-36d8-4685-91f4-503ec6c87292" />
