### PR TITLE
fix: Get form definition using private endpoint in Form Designer

### DIFF
--- a/app/(main)/forms/[formId]/design/page.tsx
+++ b/app/(main)/forms/[formId]/design/page.tsx
@@ -11,7 +11,7 @@ import FormEditorLoader from "@/features/forms/ui/editor/form-editor-loader";
 import { FormAssistantProvider } from "@/features/forms/use-cases/design-form/form-assistant.context";
 import { getCurrentConversationUseCase } from "@/features/forms/use-cases/design-form/get-current-conversation.use-case";
 import { aiFeaturesFlag } from "@/lib/feature-flags/flags";
-import { getActiveFormDefinition, getForm } from "@/services/api";
+import { getForm, getFormDefinition } from "@/services/api";
 import { Form, FormDefinition } from "@/types";
 import Link from "next/link";
 import { Suspense } from "react";
@@ -35,7 +35,7 @@ export default async function FormDesignerPage({ params }: Params) {
   try {
     form = await getForm(formId);
 
-    const response: FormDefinition = await getActiveFormDefinition(formId);
+    const response: FormDefinition = await getFormDefinition(formId, form.activeDefinitionId!);
     formJson = response?.jsonData ? JSON.parse(response.jsonData) : null;
   } catch (error) {
     console.error("Failed to load form:", error);

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,6 +9,7 @@ export type Form = {
   submissionsCount?: number;
   themeId?: string;
   webHookSettingsJson?: string;
+  activeDefinitionId?: string;
 };
 
 export type FormDefinition = {


### PR DESCRIPTION
# Get form definition using private endpoint in Form Designer

## Description
Get form definition using GET `forms/{formId}/defenitions/{defenitionId}` in Form Designer

## Related Issues
#426 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above
hots to help explain your changes.