### PR TITLE
feat: Add gating logic to prevent panel updates for non loop questions

### DIFF
--- a/lib/survey-features/question-loops/__tests__/handle-loop-navigation.test.ts
+++ b/lib/survey-features/question-loops/__tests__/handle-loop-navigation.test.ts
@@ -55,6 +55,50 @@ function fireDynamicPanelValueChanged(
   survey.onDynamicPanelValueChanged.fire(survey, options);
 }
 
+describe("handleLoopExits - gating (early return)", () => {
+  it("returns early when loopSource is missing or empty", () => {
+    const { survey, loopPanel } = createLoopingSurvey();
+    const dispose = handleLoopExits(survey);
+    const runConditionSpy = vi.spyOn(survey, "runCondition");
+    const navSpy = vi.spyOn(survey, "updateNavigationElements");
+
+    loopPanel.loopSource = [];
+    loopPanel.exitAllLoopsCondition = "{panel.exitFlag} = true";
+    survey.setValue("loopPanel[0].exitFlag", true);
+    fireDynamicPanelValueChanged(survey, loopPanel, 0, "exitFlag");
+
+    expect(runConditionSpy).not.toHaveBeenCalled();
+    expect(navSpy).not.toHaveBeenCalled();
+    expect(loopPanel.panels[1].visible).toBe(true);
+    expect(loopPanel.panels[2].visible).toBe(true);
+
+    runConditionSpy.mockRestore();
+    navSpy.mockRestore();
+    dispose?.();
+  });
+
+  it("returns early when loopSource is set but neither exit condition is set", () => {
+    const { survey, loopPanel } = createLoopingSurvey();
+    const dispose = handleLoopExits(survey);
+    const runConditionSpy = vi.spyOn(survey, "runCondition");
+    const navSpy = vi.spyOn(survey, "updateNavigationElements");
+
+    loopPanel.exitAllLoopsCondition = undefined;
+    loopPanel.exitLoopCondition = undefined;
+    survey.setValue("loopPanel[0].exitFlag", true);
+    fireDynamicPanelValueChanged(survey, loopPanel, 0, "exitFlag");
+
+    expect(runConditionSpy).not.toHaveBeenCalled();
+    expect(navSpy).not.toHaveBeenCalled();
+    expect(loopPanel.panels[1].visible).toBe(true);
+    expect(loopPanel.panels[2].visible).toBe(true);
+
+    runConditionSpy.mockRestore();
+    navSpy.mockRestore();
+    dispose?.();
+  });
+});
+
 describe("handleLoopExits - exitAllLoopsCondition", () => {
   it("calls runCondition with resolved panel expression and hides subsequent panels when the condition evaluates to true", () => {
     const { survey, loopPanel } = createLoopingSurvey();
@@ -76,6 +120,10 @@ describe("handleLoopExits - exitAllLoopsCondition", () => {
     expect(loopPanel.panels[0].visible).toBe(true);
     expect(loopPanel.panels[1].visible).toBe(false);
     expect(loopPanel.panels[2].visible).toBe(false);
+    const currentPanelQuestions = loopPanel.panels[0].questions;
+    expect(currentPanelQuestions.find((q) => q.name === "exitFlag")?.visible).toBe(true);
+    expect(currentPanelQuestions.find((q) => q.name === "q1")?.visible).toBe(false);
+    expect(currentPanelQuestions.find((q) => q.name === "q2")?.visible).toBe(false);
     expect(navSpy).toHaveBeenCalled();
 
     runConditionSpy.mockRestore();
@@ -103,6 +151,9 @@ describe("handleLoopExits - exitAllLoopsCondition", () => {
 
     expect(loopPanel.panels[1].visible).toBe(true);
     expect(loopPanel.panels[2].visible).toBe(true);
+    const currentPanelQuestions = loopPanel.panels[0].questions;
+    expect(currentPanelQuestions.find((q) => q.name === "q1")?.visible).toBe(true);
+    expect(currentPanelQuestions.find((q) => q.name === "q2")?.visible).toBe(true);
 
     expect(runConditionSpy).toHaveBeenCalledTimes(2);
     runConditionSpy.mockRestore();

--- a/lib/survey-features/question-loops/handle-loop-navigation.ts
+++ b/lib/survey-features/question-loops/handle-loop-navigation.ts
@@ -18,22 +18,26 @@ function resolveCondition(condition: string, panelName: string, currentIndex: nu
 export function handleLoopExits(survey: SurveyModel) {
     const handler = (sender: SurveyModel, options: DynamicPanelItemValueChangedEvent) => {
         const loopPanel = options.question as LoopingPanelModel;
+        const { 
+            loopSource,
+            exitLoopCondition : singleCondition, 
+            exitAllLoopsCondition : allCondition
+             } = loopPanel;
 
-        if (!loopPanel || !loopPanel.loopSource) return;
+        if (!loopSource || loopSource.length === 0)  return;
+        if (!allCondition && !singleCondition) return;
 
         // Evaluate "Exit All Loops"
         let shouldExitAllLoops = false;
-        const exitAllCond = loopPanel.exitAllLoopsCondition;
-        if (typeof exitAllCond === "string" && exitAllCond.trim() !== "") {
-            const expr = resolveCondition(exitAllCond, loopPanel.name, options.panelIndex);
+        if (typeof allCondition === "string" && allCondition.trim() !== "") {
+            const expr = resolveCondition(allCondition, loopPanel.name, options.panelIndex);
             shouldExitAllLoops = sender.runCondition(expr);
         }
 
         // Evaluate "Exit Current Loop"
         let shouldExitCurrentLoop = false;
-        const exitLoopCond = loopPanel.exitLoopCondition;
-        if (typeof exitLoopCond === "string" && exitLoopCond.trim() !== "") {
-            const expr = resolveCondition(exitLoopCond, loopPanel.name, options.panelIndex);
+        if (typeof singleCondition === "string" && singleCondition.trim() !== "") {
+            const expr = resolveCondition(singleCondition, loopPanel.name, options.panelIndex);
             shouldExitCurrentLoop = sender.runCondition(expr);
         }
 


### PR DESCRIPTION
# feat: Add gating logic to prevent panel updates for non loop questions

## Description
- Add gating logic to handleLoopExits only when dynamic panel has at least one loopSource & at least one exist condition
- Update tests

## Related Issues
- fixes https://github.com/endatix/endatix-hub/issues/425

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.