### PR TITLE
fix: Open private form when user is authenticated

### DIFF
--- a/features/forms/use-cases/create-form/create-form.action.ts
+++ b/features/forms/use-cases/create-form/create-form.action.ts
@@ -36,7 +36,7 @@ export async function createFormAction(
     const initialFormRequest = {
       name: rawData.name,
       description: rawData.description || undefined,
-      isEnabled: false,
+      isEnabled: true,
       formDefinitionJsonData: JSON.stringify(EMPTY_FORM_DEFINITION),
     };
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -162,13 +162,13 @@ export const getActiveFormDefinition = async (
   const requestOptions: RequestInit = {};
   const headerBuilder = new HeaderBuilder();
 
-  if (!allowAnonymous) {
-    const session = await getSession();
+  const session = await getSession();
 
-    if (!session.isLoggedIn) {
-      redirect("/login");
-    }
+  if (!allowAnonymous && !session.isLoggedIn) {
+    redirect("/login");
+  }
 
+  if (session.isLoggedIn) {
     headerBuilder.withAuth(session);
   }
 


### PR DESCRIPTION
# Open private form when user is authenticated

## Description
- Always add the auth header when getting form definition with authenticated user
- Create a new form as enabled (this is not a part of the bug fix but logic added for better UX)

## Related Issues
closes #436

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above
