### PR TITLE
feat: Sticky Actions column in submissions grid

### DIFF
--- a/features/submissions/ui/table/data-table.tsx
+++ b/features/submissions/ui/table/data-table.tsx
@@ -15,6 +15,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Submission } from "@/lib/endatix-api";
+import { cn } from "@/lib/utils";
 import {
   closestCenter,
   DndContext,
@@ -127,6 +128,7 @@ export function DataTable<TData extends Submission>({
     manualFiltering: true,
     enableRowSelection: true,
     enableMultiRowSelection: false,
+    enableColumnPinning: true,
     onSortingChange: setSorting,
     onRowSelectionChange: setRowSelection,
     state: {
@@ -134,6 +136,9 @@ export function DataTable<TData extends Submission>({
       rowSelection,
       columnOrder,
       columnVisibility,
+      columnPinning: {
+        left: ['actions'],
+      },
     },
   });
 
@@ -148,17 +153,25 @@ export function DataTable<TData extends Submission>({
         onDragEnd={handleDragEnd}
       >
         <div className="w-full overflow-x-auto">
-          <Table>
+          <Table className="border-separate border-spacing-0">
             <TableHeader>
               <SortableContext
-                items={columnOrder}
+                items={columnOrder.filter(id => id !== 'actions')}
                 strategy={horizontalListSortingStrategy}
               >
                 {table.getHeaderGroups().map((headerGroup) => (
                   <TableRow key={headerGroup.id}>
                     {headerGroup.headers.map((header) => {
+                      const isPinned = header.column.getIsPinned();
                       return (
-                        <TableHead key={header.id} colSpan={header.colSpan}>
+                        <TableHead
+                          key={header.id}
+                          colSpan={header.colSpan}
+                          className={cn(
+                            isPinned && "sticky bg-background z-10",
+                            isPinned === 'left' && "left-0"
+                          )}
+                        >
                           {header.isPlaceholder ? null : (
                             <DraggableColumnHeader
                               header={header}
@@ -177,15 +190,25 @@ export function DataTable<TData extends Submission>({
                 rows.map((row) => (
                   <TableRow
                     key={row.id}
-                    className={getRowClassName(row)}
+                    className={cn("group", getRowClassName(row))}
                     onClick={() => handleRowSelectionChange(row)}
                     data-state={row.getIsSelected() && "selected"}
                   >
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id}>
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </TableCell>
-                    ))}
+                    {row.getVisibleCells().map((cell) => {
+                      const isPinned = cell.column.getIsPinned();
+                      return (
+                        <TableCell
+                          key={cell.id}
+                          className={cn(
+                            isPinned && "sticky bg-background group-hover:bg-slate-50 z-10 transition-colors duration-150",
+                            isPinned === 'left' && "left-0",
+                            isPinned && row.getIsSelected() && "bg-accent"
+                          )}
+                        >
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      );
+                    })}
                   </TableRow>
                 ))
               ) : (


### PR DESCRIPTION
# Sticky Actions column in submissions grid

## Description
The Actions column in the submissions grid is sticky (pinned).

## Related Issues
closes https://github.com/endatix/endatix/issues/615

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="838" height="383" alt="image" src="https://github.com/user-attachments/assets/6168d41f-0654-49f9-9004-8b3551676d63" />
