### PR TITLE
chore: Bump immutable to 5.1.5 to address CVE-2026-29063

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
       "lodash-es": "^4.17.23",
       "axios": "^1.13.5",
       "minimatch": "^10.2.1",
-      "rollup": "^4.59.0"
+      "rollup": "^4.59.0",
+      "immutable": "^5.1.5"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",
@@ -144,7 +145,7 @@
       "unrs-resolver"
     ],
     "comments": {
-      "overrides": "[@types/react] & [@types/react-dom] are managed by Next.js. |  [glob] 10.5.0 bump is to address CVE-2025-64756. Remove with vitest 4x | [vite] 7.1.11 bump is to address CVE-2025-62522. Remove with vitest 4x | [preact] 10.27.3 bump is to address CVE-2026-22028. Remove with better auth and next posthog-js bump | [fast-xml-parser] 5.3.4 bump is to address CVE-2026-25128. Remove once we upgrade @azure/storage-blob | [lodash] 4.17.23 bump is to address CVE-2025-13465. Multiple peer dependenices hold outdated versions | [lodash-es] 4.17.23 bump is to address CVE-2025-13465. Fix with quill & react-quill-new bump | [axios] 1.13.5 bump is to address CVE-2026-25639. Remove when @flags-sdk/posthog is updated | [minimatch] 10.2.1 bump is to address CVE-2026-26996. Multiple peer dependenices hold outdated versions | [rollup] 4.59.0 bump is to address CVE-2026-27606. Remove with vitest 4x"
+      "overrides": "[@types/react] & [@types/react-dom] are managed by Next.js. |  [glob] 10.5.0 bump is to address CVE-2025-64756. Remove with vitest 4x | [vite] 7.1.11 bump is to address CVE-2025-62522. Remove with vitest 4x | [preact] 10.27.3 bump is to address CVE-2026-22028. Remove with better auth and next posthog-js bump | [fast-xml-parser] 5.3.4 bump is to address CVE-2026-25128. Remove once we upgrade @azure/storage-blob | [lodash] 4.17.23 bump is to address CVE-2025-13465. Multiple peer dependenices hold outdated versions | [lodash-es] 4.17.23 bump is to address CVE-2025-13465. Fix with quill & react-quill-new bump | [axios] 1.13.5 bump is to address CVE-2026-25639. Remove when @flags-sdk/posthog is updated | [minimatch] 10.2.1 bump is to address CVE-2026-26996. Multiple peer dependenices hold outdated versions | [rollup] 4.59.0 bump is to address CVE-2026-27606. Remove with vitest 4x | [immutable] 5.1.5 bump is to address CVE-2026-29063. Multiple peer dependenices hold outdated versions."
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   axios: ^1.13.5
   minimatch: ^10.2.1
   rollup: ^4.59.0
+  immutable: ^5.1.5
 
 importers:
 
@@ -4607,8 +4608,8 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  immutable@5.1.3:
-    resolution: {integrity: sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==}
+  immutable@5.1.5:
+    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -11449,7 +11450,7 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  immutable@5.1.3: {}
+  immutable@5.1.5: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -12766,7 +12767,7 @@ snapshots:
   sass@1.91.0:
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.3
+      immutable: 5.1.5
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.1


### PR DESCRIPTION
# chore: Bump immutable to 5.1.5 to address CVE-2026-29063

## Description
chore: Bump immutable to 5.1.5 to address CVE-2026-29063

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/453
- addresses https://github.com/endatix/endatix-hub/security/dependabot/49

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security Fix



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.