### PR TITLE
chore: Bump fast-xml-parser to 5.3.8 to address CVE-2026-27942

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
       "glob": "10.5.0",
       "vite": "^7.1.11",
       "preact": "10.27.3",
-      "fast-xml-parser": "^5.3.4",
+      "fast-xml-parser": "^5.3.8",
       "lodash": "^4.17.23",
       "lodash-es": "^4.17.23",
       "axios": "^1.13.5",
@@ -145,7 +145,7 @@
       "unrs-resolver"
     ],
     "comments": {
-      "overrides": "[@types/react] & [@types/react-dom] are managed by Next.js. |  [glob] 10.5.0 bump is to address CVE-2025-64756. Remove with vitest 4x | [vite] 7.1.11 bump is to address CVE-2025-62522. Remove with vitest 4x | [preact] 10.27.3 bump is to address CVE-2026-22028. Remove with better auth and next posthog-js bump | [fast-xml-parser] 5.3.4 bump is to address CVE-2026-25128. Remove once we upgrade @azure/storage-blob | [lodash] 4.17.23 bump is to address CVE-2025-13465. Multiple peer dependenices hold outdated versions | [lodash-es] 4.17.23 bump is to address CVE-2025-13465. Fix with quill & react-quill-new bump | [axios] 1.13.5 bump is to address CVE-2026-25639. Remove when @flags-sdk/posthog is updated | [minimatch] 10.2.4 bump is to address CVE-2026-27904. Remove with vitest 4x & eslint-config-next | [rollup] 4.59.0 bump is to address CVE-2026-27606. Remove with vitest 4x | [immutable] 5.1.5 bump is to address CVE-2026-29063. Multiple peer dependenices hold outdated versions."
+      "overrides": "[@types/react] & [@types/react-dom] are managed by Next.js. |  [glob] 10.5.0 bump is to address CVE-2025-64756. Remove with vitest 4x | [vite] 7.1.11 bump is to address CVE-2025-62522. Remove with vitest 4x | [preact] 10.27.3 bump is to address CVE-2026-22028. Remove with better auth and next posthog-js bump | [fast-xml-parser] 5.3.4 bump is to address CVE-2026-25128 & CVE-2026-27942. Remove once we upgrade @azure/storage-blob | [lodash] 4.17.23 bump is to address CVE-2025-13465. Multiple peer dependenices hold outdated versions | [lodash-es] 4.17.23 bump is to address CVE-2025-13465. Fix with quill & react-quill-new bump | [axios] 1.13.5 bump is to address CVE-2026-25639. Remove when @flags-sdk/posthog is updated | [minimatch] 10.2.4 bump is to address CVE-2026-27904. Remove with vitest 4x & eslint-config-next | [rollup] 4.59.0 bump is to address CVE-2026-27606. Remove with vitest 4x | [immutable] 5.1.5 bump is to address CVE-2026-29063. Multiple peer dependenices hold outdated versions."
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   glob: 10.5.0
   vite: ^7.1.11
   preact: 10.27.3
-  fast-xml-parser: ^5.3.4
+  fast-xml-parser: ^5.3.8
   lodash: ^4.17.23
   lodash-es: ^4.17.23
   axios: ^1.13.5
@@ -4307,8 +4307,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-parser@5.3.6:
-    resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
+  fast-xml-builder@1.0.0:
+    resolution: {integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==}
+
+  fast-xml-parser@5.4.2:
+    resolution: {integrity: sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==}
     hasBin: true
 
   fastq@1.19.1:
@@ -6881,7 +6884,7 @@ snapshots:
 
   '@azure/core-xml@1.5.0':
     dependencies:
-      fast-xml-parser: 5.3.6
+      fast-xml-parser: 5.4.2
       tslib: 2.8.1
 
   '@azure/logger@1.3.0':
@@ -11203,8 +11206,11 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-parser@5.3.6:
+  fast-xml-builder@1.0.0: {}
+
+  fast-xml-parser@5.4.2:
     dependencies:
+      fast-xml-builder: 1.0.0
       strnum: 2.1.2
 
   fastq@1.19.1:


### PR DESCRIPTION
# chore: Bump fast-xml-parser to 5.3.8 to address CVE-2026-27942

## Description
- bump fast-xml-parser to 5.3.8 to address CVE-2026-27942

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/465
- closes https://github.com/endatix/endatix-hub/security/dependabot/43

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security Fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.