### PR TITLE
fix: Made the "build-embed" script cross-platform

### DIFF
--- a/scripts/build-embed.mjs
+++ b/scripts/build-embed.mjs
@@ -1,10 +1,11 @@
 import * as esbuild from "esbuild";
-import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const configPath = join(__dirname, "..", "esbuild.embed.config.js");
-const config = await import(configPath).then(m => m.default || m);
+
+const config = await import(pathToFileURL(configPath).href).then(m => m.default || m);
 
 const isWatch = process.argv.includes("--watch");
 


### PR DESCRIPTION
## Description
Fixed the "Unsupported URL scheme" error when starting Endatix Hub on Windows

## Related Issues
#542 

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.