### PR TITLE
feat: Add `anyAnswered` and `anyAnsweredByPrefix` logic expression functions

### DIFF
--- a/features/form-templates/ui/survey-preview-component.tsx
+++ b/features/form-templates/ui/survey-preview-component.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuestionLoops } from "@/lib/survey-features/question-loops";
+import { useAnyAnswered } from "@/lib/survey-features/any-answered";
 import { useRichText } from "@/lib/survey-features/rich-text";
 import { useLoopAwareSummaryTable } from "@/lib/survey-features/summary-table";
 import { FormTemplate } from "@/types";
@@ -24,6 +25,7 @@ export default function SurveyPreviewComponent({
   const { isReady: isExtensionsReady, onModelCreated } = useSurveyExtensions();
   useRichText(model);
   useLoopAwareSummaryTable(model);
+  const { initGlobals: initAnyAnsweredGlobals } = useAnyAnswered();
   const { initGlobals: initQuestionLoopsGlobals, bindToSurvey: bindQuestionLoops } = useQuestionLoops();
 
   const { setModelMetadata, registerViewHandlers } = useStorageView();
@@ -32,6 +34,7 @@ export default function SurveyPreviewComponent({
     if (!template || !isExtensionsReady) return;
 
     try {
+      initAnyAnsweredGlobals();
       initQuestionLoopsGlobals();
       const survey = new Model(template.jsonData);
       const unbindQuestionLoops = bindQuestionLoops(survey);
@@ -71,6 +74,7 @@ export default function SurveyPreviewComponent({
     onModelCreated,
     isExtensionsReady,
     setModelMetadata,
+    initAnyAnsweredGlobals,
     initQuestionLoopsGlobals,
     bindQuestionLoops,
   ]);

--- a/features/forms/ui/editor/form-editor.tsx
+++ b/features/forms/ui/editor/form-editor.tsx
@@ -13,6 +13,7 @@ import {
 import { questionLoaderModule } from "@/lib/questions/question-loader-module";
 import { Result } from "@/lib/result";
 import { useSurveyExtensions } from "@/lib/survey-extensions/ui/use-survey-extensions";
+import { useAnyAnswered } from "@/lib/survey-features/any-answered";
 import { useSurveyDesigner } from "@/lib/survey-features/designer/design-survey.context";
 import { JSON_CHANGED_TYPE } from "@/lib/survey-features/json-editor/json-editor-state";
 import {
@@ -191,6 +192,7 @@ function FormEditor({
     initGlobals: initQuestionLoopsGlobals,
     bindToCreator: bindQuestionLoops,
   } = useQuestionLoops();
+  const { initGlobals: initAnyAnsweredGlobals } = useAnyAnswered();
 
   const creatorTheme = useEndatixCreatorTheme();
   const creatorThemeRef = useRef(creatorTheme);
@@ -493,6 +495,7 @@ function FormEditor({
           ...(options || defaultCreatorOptions),
           showSidebar: initialPropertyGridVisible,
         };
+        initAnyAnsweredGlobals();
         initQuestionLoopsGlobals();
         const newCreator = new SurveyCreator(creatorOptions);
         newCreator.applyCreatorTheme(creatorThemeRef.current);
@@ -557,6 +560,7 @@ function FormEditor({
     isExtensionsReady,
     onCreatorCreated,
     bindQuestionLoops,
+    initAnyAnsweredGlobals,
     initQuestionLoopsGlobals,
   ]);
 

--- a/features/forms/ui/preview/preview-form.tsx
+++ b/features/forms/ui/preview/preview-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuestionLoops } from "@/lib/survey-features/question-loops";
+import { useAnyAnswered } from "@/lib/survey-features/any-answered";
 import { useRichTextEditing } from "@/lib/survey-features/rich-text";
 import { useLoopAwareSummaryTableEditing } from "@/lib/survey-features/summary-table";
 import { useEffect, useState } from "react";
@@ -29,6 +30,7 @@ const PreviewForm = ({ model, slkVal }: PreviewFormProps) => {
   const [creator, setCreator] = useState<SurveyCreator | null>(null);
   useRichTextEditing(creator);
   useLoopAwareSummaryTableEditing(creator);
+  const { initGlobals: initAnyAnsweredGlobals } = useAnyAnswered();
   const { initGlobals: initQuestionLoopsGlobals, bindToCreator: bindQuestionLoops } = useQuestionLoops();
 
   useEffect(() => {
@@ -43,6 +45,7 @@ const PreviewForm = ({ model, slkVal }: PreviewFormProps) => {
       slk(slkVal);
     }
 
+    initAnyAnsweredGlobals();
     initQuestionLoopsGlobals();
     const newCreator = new SurveyCreator(creatorOptions);
     const cleanupQuestionLoops = bindQuestionLoops(newCreator);
@@ -56,7 +59,7 @@ const PreviewForm = ({ model, slkVal }: PreviewFormProps) => {
     return () => {
       cleanupQuestionLoops?.();
     }
-  }, [creator, model, slkVal, initQuestionLoopsGlobals, bindQuestionLoops]);
+  }, [creator, model, slkVal, initAnyAnsweredGlobals, initQuestionLoopsGlobals, bindQuestionLoops]);
 
   return creator && <SurveyCreatorComponent creator={creator} />;
 };

--- a/features/public-form/ui/use-survey-model.hook.ts
+++ b/features/public-form/ui/use-survey-model.hook.ts
@@ -12,6 +12,7 @@ import { useSearchParamsVariables } from "../application/use-search-params-varia
 import { setSubmissionData } from "@/lib/survey-features";
 import { useInitOnly } from "@/lib/utils/hooks";
 import { useQuestionLoops } from "@/lib/survey-features/question-loops";
+import { useAnyAnswered } from "@/lib/survey-features/any-answered";
 
 interface UseSurveyModelProps {
   formId: string;
@@ -41,6 +42,7 @@ export function useSurveyModel({
   const [isLoadingQuestions, setIsLoadingQuestions] = useState(true);
   const { variables } = useDynamicVariables(surveyModel);
   const { processSearchParams, cleanupUrl } = useSearchParamsVariables(formId);
+  const { initGlobals: initAnyAnsweredGlobals } = useAnyAnswered();
   const { initGlobals: initQuestionLoopsGlobals, bindToSurvey: bindQuestionLoops } = useQuestionLoops();
   const isInitializedRef = useRef(false);
   const submissionRef = useInitOnly(submission);
@@ -82,6 +84,7 @@ export function useSurveyModel({
       return;
     }
 
+    initAnyAnsweredGlobals();
     initQuestionLoopsGlobals();
     const model = new SurveyModel(definition);
 
@@ -114,6 +117,7 @@ export function useSurveyModel({
     cleanupUrl,
     submissionRef,
     onModelCreated,
+    initAnyAnsweredGlobals,
     initQuestionLoopsGlobals,
     bindQuestionLoops,
   ]);

--- a/features/submissions/ui/shared/use-survey-model.hook.ts
+++ b/features/submissions/ui/shared/use-survey-model.hook.ts
@@ -6,6 +6,7 @@ import { Submission } from "@/lib/endatix-api";
 import { initializeCustomQuestions } from "@/lib/questions/infrastructure/specialized-survey-question";
 import { Result } from "@/lib/result";
 import { useQuestionLoops } from "@/lib/survey-features/question-loops";
+import { useAnyAnswered } from "@/lib/survey-features/any-answered";
 import { useEndatixSurveyTheme } from "@/lib/themes/use-endatix-themes";
 import { useEffect, useRef, useState } from "react";
 import { Model } from "survey-core";
@@ -27,6 +28,7 @@ export function useSurveyModel(
     initGlobals: initQuestionLoopsGlobals,
     bindToSurvey: bindQuestionLoops,
   } = useQuestionLoops();
+  const { initGlobals: initAnyAnsweredGlobals } = useAnyAnswered();
 
   const surveyTheme = useEndatixSurveyTheme();
   const surveyThemeRef = useRef(surveyTheme);
@@ -64,6 +66,7 @@ export function useSurveyModel(
           initializeCustomQuestions(questionsList);
         }
 
+        initAnyAnsweredGlobals();
         initQuestionLoopsGlobals();
         const definitionJson = JSON.parse(submission.formDefinition.jsonData);
         const submissionData = JSON.parse(submission.jsonData);
@@ -121,6 +124,7 @@ export function useSurveyModel(
     customQuestions,
     readOnly,
     onModelCreated,
+    initAnyAnsweredGlobals,
     initQuestionLoopsGlobals,
     bindQuestionLoops,
   ]);

--- a/lib/survey-features/any-answered/__tests__/functions.test.ts
+++ b/lib/survey-features/any-answered/__tests__/functions.test.ts
@@ -5,62 +5,62 @@ import {
 } from "../functions";
 
 describe("anyAnsweredFunction", () => {
-  it("returns true when any explicitly listed question is answered", () => {
-    const result = anyAnsweredFunction(
-      ["qAB101_C103_D_E4_F5", "qAB101_C103_D_E4_F7", "qAB101_Z001_D_E4_F17"],
-      {
-        qAB101_C103_D_E4_F5: [],
-        qAB101_C103_D_E4_F7: "Item 1",
-        qAB101_Z001_D_E4_F17: "",
-      },
-    );
+  it("returns true when any passed value is answered", () => {
+    const result = anyAnsweredFunction([[], "Item 1", ""]);
 
     expect(result).toBe(true);
   });
 
-  it("returns false when all explicitly listed question values are empty", () => {
-    const result = anyAnsweredFunction(
-      ["qAB101_C103_D_E4_F5", "qAB101_C103_D_E4_F7"],
-      {
-        qAB101_C103_D_E4_F5: [],
-        qAB101_C103_D_E4_F7: "   ",
-      },
-    );
+  it("returns false when all passed values are empty", () => {
+    const result = anyAnsweredFunction([[], "", null, undefined]);
 
     expect(result).toBe(false);
   });
 
-  it("returns false for empty params, unknown names, and non-string params", () => {
-    expect(anyAnsweredFunction([], { q1: "x" })).toBe(false);
-    expect(anyAnsweredFunction(["unknown"], { q1: "x" })).toBe(false);
-    expect(anyAnsweredFunction([42, null], { q1: "x" })).toBe(false);
+  it("returns false for empty params and true for non-empty primitives", () => {
+    expect(anyAnsweredFunction([])).toBe(false);
+    expect(anyAnsweredFunction([42, null])).toBe(true);
   });
 });
 
 describe("anyAnsweredByPrefixFunction", () => {
   it("returns true when a matching-prefixed question is answered", () => {
-    const result = anyAnsweredByPrefixFunction(["qAB101_C103_D_E4"], {
-      qAB101_C103_D_E4_F5: [],
-      qAB101_C103_D_E4_F7: "Item 2",
-      qAB101_Z001_D_E4_F17: "Item 1",
-    });
+    const survey = {
+      getAllQuestions: () => [
+        { name: "qAB101_C103_D_E4_F5", isEmpty: () => true },
+        { name: "qAB101_C103_D_E4_F7", isEmpty: () => false },
+        { name: "qAB101_Z001_D_E4_F17", isEmpty: () => false },
+      ],
+    };
+    const result = anyAnsweredByPrefixFunction.call(
+      { survey },
+      ["qAB101_C103_D_E4"],
+    );
 
     expect(result).toBe(true);
   });
 
   it("returns false when matching-prefixed questions are all empty", () => {
-    const result = anyAnsweredByPrefixFunction(["qAB101_C103_D_E4"], {
-      qAB101_C103_D_E4_F5: [],
-      qAB101_C103_D_E4_F7: "",
-      qAB101_Z001_D_E4_F17: "Item 1",
-    });
+    const survey = {
+      getAllQuestions: () => [
+        { name: "qAB101_C103_D_E4_F5", isEmpty: () => true },
+        { name: "qAB101_C103_D_E4_F7", isEmpty: () => true },
+        { name: "qAB101_Z001_D_E4_F17", isEmpty: () => false },
+      ],
+    };
+    const result = anyAnsweredByPrefixFunction.call(
+      { survey },
+      ["qAB101_C103_D_E4"],
+    );
 
     expect(result).toBe(false);
   });
 
   it("returns false for missing prefix, empty prefix, and non-string prefix", () => {
-    expect(anyAnsweredByPrefixFunction([], { q1: "x" })).toBe(false);
-    expect(anyAnsweredByPrefixFunction([""], { q1: "x" })).toBe(false);
-    expect(anyAnsweredByPrefixFunction([123], { q1: "x" })).toBe(false);
+    const survey = { getAllQuestions: () => [] };
+    expect(anyAnsweredByPrefixFunction.call({ survey }, [])).toBe(false);
+    expect(anyAnsweredByPrefixFunction.call({ survey }, [""])).toBe(false);
+    expect(anyAnsweredByPrefixFunction.call({ survey }, [123])).toBe(false);
+    expect(anyAnsweredByPrefixFunction.call({}, ["q"])).toBe(false);
   });
 });

--- a/lib/survey-features/any-answered/__tests__/functions.test.ts
+++ b/lib/survey-features/any-answered/__tests__/functions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  anyAnsweredByPrefixFunction,
+  anyAnsweredFunction,
+} from "../functions";
+
+describe("anyAnsweredFunction", () => {
+  it("returns true when any explicitly listed question is answered", () => {
+    const result = anyAnsweredFunction(
+      ["qAB101_C103_D_E4_F5", "qAB101_C103_D_E4_F7", "qAB101_Z001_D_E4_F17"],
+      {
+        qAB101_C103_D_E4_F5: [],
+        qAB101_C103_D_E4_F7: "Item 1",
+        qAB101_Z001_D_E4_F17: "",
+      },
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when all explicitly listed question values are empty", () => {
+    const result = anyAnsweredFunction(
+      ["qAB101_C103_D_E4_F5", "qAB101_C103_D_E4_F7"],
+      {
+        qAB101_C103_D_E4_F5: [],
+        qAB101_C103_D_E4_F7: "   ",
+      },
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false for empty params, unknown names, and non-string params", () => {
+    expect(anyAnsweredFunction([], { q1: "x" })).toBe(false);
+    expect(anyAnsweredFunction(["unknown"], { q1: "x" })).toBe(false);
+    expect(anyAnsweredFunction([42, null], { q1: "x" })).toBe(false);
+  });
+});
+
+describe("anyAnsweredByPrefixFunction", () => {
+  it("returns true when a matching-prefixed question is answered", () => {
+    const result = anyAnsweredByPrefixFunction(["qAB101_C103_D_E4"], {
+      qAB101_C103_D_E4_F5: [],
+      qAB101_C103_D_E4_F7: "Item 2",
+      qAB101_Z001_D_E4_F17: "Item 1",
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when matching-prefixed questions are all empty", () => {
+    const result = anyAnsweredByPrefixFunction(["qAB101_C103_D_E4"], {
+      qAB101_C103_D_E4_F5: [],
+      qAB101_C103_D_E4_F7: "",
+      qAB101_Z001_D_E4_F17: "Item 1",
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false for missing prefix, empty prefix, and non-string prefix", () => {
+    expect(anyAnsweredByPrefixFunction([], { q1: "x" })).toBe(false);
+    expect(anyAnsweredByPrefixFunction([""], { q1: "x" })).toBe(false);
+    expect(anyAnsweredByPrefixFunction([123], { q1: "x" })).toBe(false);
+  });
+});

--- a/lib/survey-features/any-answered/__tests__/registry.test.ts
+++ b/lib/survey-features/any-answered/__tests__/registry.test.ts
@@ -1,0 +1,52 @@
+import { Model } from "survey-core";
+import { beforeAll, describe, expect, it } from "vitest";
+import { registerAnyAnsweredGlobals } from "../infrastructure/registry";
+
+describe("registerAnyAnsweredGlobals", () => {
+  beforeAll(() => {
+    registerAnyAnsweredGlobals();
+    registerAnyAnsweredGlobals();
+  });
+
+  it("evaluates anyAnswered(...) with explicit question names", () => {
+    const survey = new Model({
+      elements: [
+        { type: "checkbox", name: "qAB101_C103_D_E4_F5", choices: ["Item 1"] },
+        { type: "radiogroup", name: "qAB101_C103_D_E4_F7", choices: ["Item 1"] },
+        { type: "dropdown", name: "qAB101_Z001_D_E4_F17", choices: ["Item 1"] },
+      ],
+    });
+
+    survey.data = {
+      qAB101_C103_D_E4_F5: [],
+      qAB101_C103_D_E4_F7: "",
+      qAB101_Z001_D_E4_F17: "Item 1",
+    };
+
+    const result = survey.runCondition(
+      "anyAnswered('qAB101_C103_D_E4_F5', 'qAB101_C103_D_E4_F7', 'qAB101_Z001_D_E4_F17')",
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("evaluates anyAnsweredByPrefix(...) for prefixed question names", () => {
+    const survey = new Model({
+      elements: [
+        { type: "checkbox", name: "qAB101_C103_D_E4_F5", choices: ["Item 1"] },
+        { type: "radiogroup", name: "qAB101_C103_D_E4_F7", choices: ["Item 1"] },
+        { type: "dropdown", name: "qAB101_Z001_D_E4_F17", choices: ["Item 1"] },
+      ],
+    });
+
+    survey.data = {
+      qAB101_C103_D_E4_F5: [],
+      qAB101_C103_D_E4_F7: "Item 2",
+      qAB101_Z001_D_E4_F17: "",
+    };
+
+    const result = survey.runCondition("anyAnsweredByPrefix('qAB101_C103_D_E4')");
+
+    expect(result).toBe(true);
+  });
+});

--- a/lib/survey-features/any-answered/__tests__/registry.test.ts
+++ b/lib/survey-features/any-answered/__tests__/registry.test.ts
@@ -8,7 +8,7 @@ describe("registerAnyAnsweredGlobals", () => {
     registerAnyAnsweredGlobals();
   });
 
-  it("evaluates anyAnswered(...) with explicit question names", () => {
+  it("evaluates anyAnswered(...) with reactive value references", () => {
     const survey = new Model({
       elements: [
         { type: "checkbox", name: "qAB101_C103_D_E4_F5", choices: ["Item 1"] },
@@ -24,7 +24,7 @@ describe("registerAnyAnsweredGlobals", () => {
     };
 
     const result = survey.runCondition(
-      "anyAnswered('qAB101_C103_D_E4_F5', 'qAB101_C103_D_E4_F7', 'qAB101_Z001_D_E4_F17')",
+      "anyAnswered({qAB101_C103_D_E4_F5}, {qAB101_C103_D_E4_F7}, {qAB101_Z001_D_E4_F17})",
     );
 
     expect(result).toBe(true);

--- a/lib/survey-features/any-answered/functions.ts
+++ b/lib/survey-features/any-answered/functions.ts
@@ -1,71 +1,38 @@
-import { SurveyModel } from "survey-core";
+import { Helpers, SurveyModel } from "survey-core";
 
-interface FunctionContext {
+interface ExpressionRunnerContext {
   survey?: SurveyModel;
 }
 
-function isSurveyValueEmpty(value: unknown): boolean {
-  if (value === null || value === undefined) {
-    return true;
-  }
-
-  if (typeof value === "string") {
-    return value.trim().length === 0;
-  }
-
-  if (Array.isArray(value)) {
-    return value.length === 0;
-  }
-
-  return false;
-}
-
-function hasAnsweredValue(
-  questionName: string,
-  values: Record<string, unknown>,
-): boolean {
-  return !isSurveyValueEmpty(values[questionName]);
-}
-
-function getValues(properties: unknown): Record<string, unknown> {
-  if (!properties || typeof properties !== "object") {
-    return {};
-  }
-
-  return properties as Record<string, unknown>;
-}
-
 export function anyAnsweredFunction(
-  this: FunctionContext,
   params: unknown[],
-  properties: unknown,
 ): boolean {
-  const context = this as FunctionContext | undefined;
-  const values = context?.survey?.data ?? getValues(properties);
-  const questionNames = params.filter(
-    (param): param is string => typeof param === "string" && param.length > 0,
-  );
-
-  if (questionNames.length === 0) {
+  if (!Array.isArray(params) || params.length === 0) {
     return false;
   }
 
-  return questionNames.some((questionName) => hasAnsweredValue(questionName, values));
+  return params.some((param) => !Helpers.isValueEmpty(param));
 }
 
 export function anyAnsweredByPrefixFunction(
-  this: FunctionContext,
+  this: ExpressionRunnerContext,
   params: unknown[],
-  properties: unknown,
 ): boolean {
-  const context = this as FunctionContext | undefined;
-  const values = context?.survey?.data ?? getValues(properties);
-  const [prefixParam] = params;
-  if (typeof prefixParam !== "string" || prefixParam.length === 0) {
+  const survey = this?.survey;
+  const prefix = params?.[0];
+
+  if (!survey || typeof prefix !== "string" || prefix.length === 0) {
     return false;
   }
 
-  return Object.keys(values)
-    .filter((questionName) => questionName.startsWith(prefixParam))
-    .some((questionName) => hasAnsweredValue(questionName, values));
+  const questions = survey.getAllQuestions();
+
+  for (let i = 0; i < questions.length; i++) {
+    const question = questions[i];
+    if (question.name.startsWith(prefix) && !question.isEmpty()) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/lib/survey-features/any-answered/functions.ts
+++ b/lib/survey-features/any-answered/functions.ts
@@ -25,7 +25,7 @@ export function anyAnsweredByPrefixFunction(
     return false;
   }
 
-  const questions = survey.getAllQuestions();
+  const questions = survey.getAllQuestions(false, false, false);
 
   for (let i = 0; i < questions.length; i++) {
     const question = questions[i];

--- a/lib/survey-features/any-answered/functions.ts
+++ b/lib/survey-features/any-answered/functions.ts
@@ -1,0 +1,71 @@
+import { SurveyModel } from "survey-core";
+
+interface FunctionContext {
+  survey?: SurveyModel;
+}
+
+function isSurveyValueEmpty(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length === 0;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  return false;
+}
+
+function hasAnsweredValue(
+  questionName: string,
+  values: Record<string, unknown>,
+): boolean {
+  return !isSurveyValueEmpty(values[questionName]);
+}
+
+function getValues(properties: unknown): Record<string, unknown> {
+  if (!properties || typeof properties !== "object") {
+    return {};
+  }
+
+  return properties as Record<string, unknown>;
+}
+
+export function anyAnsweredFunction(
+  this: FunctionContext,
+  params: unknown[],
+  properties: unknown,
+): boolean {
+  const context = this as FunctionContext | undefined;
+  const values = context?.survey?.data ?? getValues(properties);
+  const questionNames = params.filter(
+    (param): param is string => typeof param === "string" && param.length > 0,
+  );
+
+  if (questionNames.length === 0) {
+    return false;
+  }
+
+  return questionNames.some((questionName) => hasAnsweredValue(questionName, values));
+}
+
+export function anyAnsweredByPrefixFunction(
+  this: FunctionContext,
+  params: unknown[],
+  properties: unknown,
+): boolean {
+  const context = this as FunctionContext | undefined;
+  const values = context?.survey?.data ?? getValues(properties);
+  const [prefixParam] = params;
+  if (typeof prefixParam !== "string" || prefixParam.length === 0) {
+    return false;
+  }
+
+  return Object.keys(values)
+    .filter((questionName) => questionName.startsWith(prefixParam))
+    .some((questionName) => hasAnsweredValue(questionName, values));
+}

--- a/lib/survey-features/any-answered/index.ts
+++ b/lib/survey-features/any-answered/index.ts
@@ -1,0 +1,2 @@
+export { useAnyAnswered } from "./ui/use-any-answered.hook";
+export * from "./types";

--- a/lib/survey-features/any-answered/infrastructure/registry.ts
+++ b/lib/survey-features/any-answered/infrastructure/registry.ts
@@ -1,0 +1,35 @@
+import { FunctionFactory } from "survey-core";
+import {
+  anyAnsweredByPrefixFunction,
+  anyAnsweredFunction,
+} from "../functions";
+import {
+  ANY_ANSWERED_BY_PREFIX_FUNCTION_NAME,
+  ANY_ANSWERED_FUNCTION_NAME,
+} from "../types";
+
+let areGlobalsRegistered = false;
+
+/**
+ * Registers any-answered expression globals.
+ * Call once before any SurveyModel or SurveyCreator is created.
+ */
+export function registerAnyAnsweredGlobals() {
+  if (areGlobalsRegistered) return;
+
+  FunctionFactory.Instance.register(
+    ANY_ANSWERED_FUNCTION_NAME,
+    anyAnsweredFunction,
+    false,
+    false,
+  );
+
+  FunctionFactory.Instance.register(
+    ANY_ANSWERED_BY_PREFIX_FUNCTION_NAME,
+    anyAnsweredByPrefixFunction,
+    false,
+    false,
+  );
+
+  areGlobalsRegistered = true;
+}

--- a/lib/survey-features/any-answered/types.ts
+++ b/lib/survey-features/any-answered/types.ts
@@ -1,0 +1,2 @@
+export const ANY_ANSWERED_FUNCTION_NAME = "anyAnswered";
+export const ANY_ANSWERED_BY_PREFIX_FUNCTION_NAME = "anyAnsweredByPrefix";

--- a/lib/survey-features/any-answered/ui/use-any-answered.hook.ts
+++ b/lib/survey-features/any-answered/ui/use-any-answered.hook.ts
@@ -1,0 +1,19 @@
+import { useCallback } from "react";
+import { registerAnyAnsweredGlobals } from "../infrastructure/registry";
+
+interface AnyAnsweredInstallApi {
+  /**
+   * Registers globals (FunctionFactory). Call once before creating any SurveyModel or SurveyCreator.
+   */
+  initGlobals: () => void;
+}
+
+export function useAnyAnswered(): AnyAnsweredInstallApi {
+  const initGlobals = useCallback(() => {
+    registerAnyAnsweredGlobals();
+  }, []);
+
+  return {
+    initGlobals,
+  };
+}

--- a/scripts/build-embed.mjs
+++ b/scripts/build-embed.mjs
@@ -1,10 +1,11 @@
 import * as esbuild from "esbuild";
-import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const configPath = join(__dirname, "..", "esbuild.embed.config.js");
-const config = await import(configPath).then(m => m.default || m);
+
+const config = await import(pathToFileURL(configPath).href).then(m => m.default || m);
 
 const isWatch = process.argv.includes("--watch");
 


### PR DESCRIPTION
## Description
This PR introduces two custom SurveyJS expression functions - `anyAnswered` and `anyAnsweredByPrefix` - designed to replace massive, CPU-blocking chains of `notempty` checks in complex forms. 

During implementation, I identified a critical performance bottlenecks related to how SurveyJS handles reactivity and state cloning. The requirements and syntax for these functions were updated to ensure they run efficiently on low-powered mobile devices without freezing the main UI thread.

## Technical Context
The initial approach allowed form builders to pass question names as strings (e.g., `anyAnswered('q1', 'q2')`). However, this introduced two architectural flaws:
1. **AST Bypass:** Passing strings hides dependencies from the SurveyJS `ExpressionRunner`. Without an Abstract Syntax Tree (AST) dependency graph, SurveyJS forces a global re-evaluation of the expression on *every single keystroke* across the entire form.
2. **The `survey.data` Penalty:** The original functions evaluated state by calling `context.survey.data`. In SurveyJS, `.data` is a computed getter that recursively traverses all elements to generate a deep-cloned JSON payload. Calling this globally on every value change severely blocks the main thread.

## Implementation Details

### 1. `anyAnswered` (AST-Compliant)
We changed the function signature to evaluate literal values rather than resolving string names. By requiring form builders to use the `{questionName}` syntax, the `ExpressionRunner` successfully registers the exact dependencies and only fires evaluations when those specific questions change. 

**JSON Usage Example:**
```json
{
  "type": "comment",
  "name": "question2",
  "visibleIf": "anyAnswered({qAB101_C103_D_E4_F5}, {qAB101_C103_D_E4_F7}, {qAB101_Z001_D_E4_F17})"
}
```

### 2. `anyAnsweredByPrefix` (Memory-Reference Optimization)
Because dynamic prefix lookups cannot be parsed into an AST at initialization, this function inherently runs globally on every change. To make this safe for mobile CPUs, we dropped the `survey.data` deep-clone entirely. 

The function now calls `survey.getAllQuestions()` and iterates through the direct memory references of the internal question objects, checking their state via the native, highly optimized `.isEmpty()` method.

**JSON Usage Example:**
```json
{
  "type": "comment",
  "name": "question1",
  "visibleIf": "anyAnsweredByPrefix('qAB101_C103_D_E4')"
}
```

## Acceptance Criteria Met
- [x] Replaces long `notempty or notempty` strings.
- [x] `anyAnswered` triggers localized, reactive updates without global state cloning.
- [x] `anyAnsweredByPrefix` safely evaluates without freezing the UI thread.
- [x] Automatically handles complex SurveyJS types (File arrays, Matrices) via `Helpers.isValueEmpty(param)` and `q.isEmpty()`.

## Related Issues
#537 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above