### PR TITLE
chore: bump follow-redirects to 1.16.0 to address GHSA-r4q5-vmmm-2653

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,8 @@
       "picomatch@>=4 <5": "^4.0.4",
       "brace-expansion": "^5.0.5",
       "yaml": "^2.8.3",
-      "vite": "^7.3.2"
+      "vite": "^7.3.2",
+      "follow-redirects": "^1.16.0"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",
@@ -155,7 +156,7 @@
       "unrs-resolver"
     ],
     "comments": {
-      "overrides": "[@types/react] & [@types/react-dom] are managed by Next.js. |  [preact] 10.27.3 bump is to address CVE-2026-22028. Remove with better auth and next posthog-js bump | [fast-xml-parser] 5.5.9 bump is to address CVE-2026-25128, CVE-2026-27942, CVE-2026-33036 & CVE-2026-33349. Remove once we upgrade @azure/storage-blob | [lodash] 4.18.0 bump is to address CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Multiple peer dependenices hold outdated versions | [lodash-es] 4.18.00 bump is to address CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Fix with quill & react-quill-new bump | [axios] 1.15.0 bump is to address CVE-2026-25639 & CVE-2025-62718. Remove when @flags-sdk/posthog is updated | [minimatch] 10.2.4 bump is to address CVE-2026-27904. Remove with vitest 4x & eslint-config-next | [immutable] 5.1.5 bump is to address CVE-2026-29063. Multiple peer dependenices hold outdated versions. | [flatted] 3.4.2 bump is to address CVE-2026-33228. Remove with next vitest bump | [picomatch] 2.3.2 & 4.0.4 bump is to address CVE-2026-33671 & CVE-2026-33671. Multiple peer dependenices hold outdated versions. | [brace-expansion] 5.0.5 bump is to address CVE-2026-33750. Fix with new minimatch& eslintbump | [yaml] 2.8.3 bump is to address CVE-2026-33532 . Fix with vite bump | [vite] 7.3.2 bump is to address GHSA-4w7w-66w2-5vf9, GHSA-v2wj-q39q-566r & CVE-2026-39363. Fix with vitest bump "
+      "overrides": "[@types/react] & [@types/react-dom] are managed by Next.js. |  [preact] 10.27.3 bump is to address CVE-2026-22028. Remove with better auth and next posthog-js bump | [fast-xml-parser] 5.5.9 bump is to address CVE-2026-25128, CVE-2026-27942, CVE-2026-33036 & CVE-2026-33349. Remove once we upgrade @azure/storage-blob | [lodash] 4.18.0 bump is to address CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Multiple peer dependenices hold outdated versions | [lodash-es] 4.18.00 bump is to address CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Fix with quill & react-quill-new bump | [axios] 1.15.0 bump is to address CVE-2026-25639 & CVE-2025-62718. Remove when @flags-sdk/posthog is updated | [minimatch] 10.2.4 bump is to address CVE-2026-27904. Remove with vitest 4x & eslint-config-next | [immutable] 5.1.5 bump is to address CVE-2026-29063. Multiple peer dependenices hold outdated versions. | [flatted] 3.4.2 bump is to address CVE-2026-33228. Remove with next vitest bump | [picomatch] 2.3.2 & 4.0.4 bump is to address CVE-2026-33671 & CVE-2026-33671. Multiple peer dependenices hold outdated versions. | [brace-expansion] 5.0.5 bump is to address CVE-2026-33750. Fix with new minimatch& eslintbump | [yaml] 2.8.3 bump is to address CVE-2026-33532 . Fix with vite bump | [vite] 7.3.2 bump is to address GHSA-4w7w-66w2-5vf9, GHSA-v2wj-q39q-566r & CVE-2026-39363. Fix with vitest bump | [follow-redirects] 1.16.0 bump is to address GHSA-r4q5-vmmm-2653. Remove with next Axios bump > 1.15.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   brace-expansion: ^5.0.5
   yaml: ^2.8.3
   vite: ^7.3.2
+  follow-redirects: ^1.16.0
 
 importers:
 
@@ -4425,8 +4426,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -10210,7 +10211,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -11221,7 +11222,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   fontkit@2.0.4:
     dependencies:


### PR DESCRIPTION
# chore: bump follow-redirects to 1.16.0 to address GHSA-r4q5-vmmm-2653

## Description
- Using override as Axios delivers this as transient dependency

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/550
- https://github.com/endatix/endatix-hub/security/dependabot/90

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security Update

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.