### PR TITLE
feat: Step two of the feature implementation - gating UI

### DIFF
--- a/__tests__/pages/embed-form.test.tsx
+++ b/__tests__/pages/embed-form.test.tsx
@@ -1,0 +1,170 @@
+import EmbedFormPage from "@/app/(public)/embed/[formId]/page";
+import { SurveyJsWrapperProps } from "@/features/public-form/ui/survey-js-wrapper";
+import { getActiveDefinitionUseCase } from "@/features/public-form/use-cases/get-active-definition.use-case";
+import {
+  getPartialSubmissionUseCase,
+  PartialSubmissionResult,
+} from "@/features/public-form/use-cases/get-partial-submission.use-case";
+import { getSubmissionByAccessTokenUseCase } from "@/features/public-submissions/edit/get-submission-by-access-token.use-case";
+import { ApiResult, Submission } from "@/lib/endatix-api";
+import { Result } from "@/lib/result";
+import { ActiveDefinition } from "@/types";
+import { render, screen } from "@testing-library/react";
+import { notFound } from "next/navigation";
+import { ScriptProps } from "next/script";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/server", () => ({}));
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(),
+  forbidden: vi.fn(),
+  useSearchParams: vi.fn(() => ({
+    get: vi.fn((key: string) => (key === "token" ? "test-token" : null)),
+  })),
+  useRouter: vi.fn(),
+}));
+
+vi.mock("next/script", () => ({
+  default: ({ children, ...props }: ScriptProps) => (
+    <script {...props}>{children}</script>
+  ),
+}));
+
+vi.mock(
+  "@/features/public-form/use-cases/get-active-definition.use-case",
+  () => ({
+    getActiveDefinitionUseCase: vi.fn(),
+  }),
+);
+
+vi.mock(
+  "@/features/public-form/use-cases/get-partial-submission.use-case",
+  () => ({
+    getPartialSubmissionUseCase: vi.fn(),
+  }),
+);
+
+vi.mock(
+  "@/features/public-submissions/edit/get-submission-by-access-token.use-case",
+  () => ({
+    getSubmissionByAccessTokenUseCase: vi.fn(),
+  }),
+);
+
+vi.mock("@/features/public-form/infrastructure/cookie-store", () => ({
+  FormTokenCookieStore: vi.fn().mockImplementation(function () {
+    return {};
+  }),
+}));
+
+vi.mock("@/features/public-form/ui/embed-height-reporter", () => ({
+  EmbedHeightReporter: () => <div data-testid="embed-height-reporter" />,
+}));
+
+vi.mock("@/features/recaptcha/recaptcha-config", () => ({
+  recaptchaConfig: {
+    isReCaptchaEnabled: vi.fn().mockReturnValue(false),
+    JS_URL: "https://www.google.com/recaptcha/api.js",
+  },
+}));
+
+vi.mock("@/features/recaptcha/ui/recaptcha-style-fix", () => ({
+  ReCaptchaStyleFix: () => <div data-testid="recaptcha-style-fix" />,
+}));
+
+vi.mock("@/features/asset-storage/server", () => ({
+  AssetStorageProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="asset-storage-provider">{children}</div>
+  ),
+}));
+
+vi.mock("@/features/public-form/ui/survey-js-wrapper", () => ({
+  default: ({ formId }: SurveyJsWrapperProps) => (
+    <div data-testid="survey-js-wrapper">
+      <div data-testid="form-id">{formId}</div>
+    </div>
+  ),
+}));
+
+describe("EmbedForm Page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders already responded when user already submitted without token", async () => {
+    // Arrange
+    const mockDefinition = {
+      jsonData: { title: "Test Form" },
+      hasUserSubmitted: true,
+      metadata: JSON.stringify({
+        alreadyResponded: { message: "You already completed this survey." },
+      }),
+      requiresReCaptcha: false,
+    };
+
+    vi.mocked(getActiveDefinitionUseCase).mockResolvedValue(
+      Result.success(mockDefinition as unknown as ActiveDefinition),
+    );
+    vi.mocked(getPartialSubmissionUseCase).mockResolvedValue(
+      ApiResult.notFoundError("No submission") as PartialSubmissionResult,
+    );
+
+    const props = {
+      params: Promise.resolve({ formId: "valid-id" }),
+      searchParams: Promise.resolve({}),
+    };
+
+    // Act
+    const component = await EmbedFormPage(props);
+    render(component);
+
+    // Assert
+    expect(screen.getByText("Already Responded")).toBeDefined();
+    expect(
+      screen.getByText("You already completed this survey."),
+    ).toBeDefined();
+    expect(screen.queryByTestId("survey-js-wrapper")).toBeNull();
+  });
+
+  it("does not gate token edit flow when user already submitted", async () => {
+    // Arrange
+    const mockDefinition = {
+      jsonData: { title: "Test Form" },
+      hasUserSubmitted: true,
+      metadata: JSON.stringify({
+        alreadyResponded: { message: "You already completed this survey." },
+      }),
+      requiresReCaptcha: false,
+    };
+    const mockSubmission = {
+      data: { q1: "existing answer" },
+      timestamp: "2024-01-01T00:00:00Z",
+    };
+    const validAccessToken = "123.1705824000.rw.abc123def456";
+
+    vi.mocked(getActiveDefinitionUseCase).mockResolvedValue(
+      Result.success(mockDefinition as unknown as ActiveDefinition),
+    );
+    vi.mocked(getSubmissionByAccessTokenUseCase).mockResolvedValue(
+      Result.success(mockSubmission as unknown as Submission),
+    );
+
+    const props = {
+      params: Promise.resolve({ formId: "valid-id" }),
+      searchParams: Promise.resolve({ token: validAccessToken }),
+    };
+
+    // Act
+    const component = await EmbedFormPage(props);
+    render(component);
+
+    // Assert
+    expect(notFound).not.toHaveBeenCalled();
+    expect(screen.getByTestId("survey-js-wrapper")).toBeDefined();
+    expect(screen.queryByText("Already Responded")).toBeNull();
+  });
+});

--- a/__tests__/pages/embed-form.test.tsx
+++ b/__tests__/pages/embed-form.test.tsx
@@ -128,6 +128,7 @@ describe("EmbedForm Page", () => {
       screen.getByText("You already completed this survey."),
     ).toBeDefined();
     expect(screen.queryByTestId("survey-js-wrapper")).toBeNull();
+    expect(screen.getByTestId("embed-height-reporter")).toBeDefined();
   });
 
   it("does not gate token edit flow when user already submitted", async () => {
@@ -166,5 +167,6 @@ describe("EmbedForm Page", () => {
     expect(notFound).not.toHaveBeenCalled();
     expect(screen.getByTestId("survey-js-wrapper")).toBeDefined();
     expect(screen.queryByText("Already Responded")).toBeNull();
+    expect(screen.getByTestId("embed-height-reporter")).toBeDefined();
   });
 });

--- a/__tests__/pages/share-form.test.tsx
+++ b/__tests__/pages/share-form.test.tsx
@@ -229,4 +229,77 @@ describe("ShareForm Page", () => {
       JSON.stringify(mockDefinition.customQuestions),
     );
   });
+
+  it("renders already responded state when user has submitted", async () => {
+    // Arrange
+    const mockDefinition = {
+      jsonData: { title: "Test Form" },
+      hasUserSubmitted: true,
+      metadata: JSON.stringify({
+        alreadyRespondedMessage: "You already completed this survey.",
+      }),
+    };
+
+    vi.mocked(getActiveDefinitionUseCase).mockResolvedValue(
+      Result.success(mockDefinition as unknown as ActiveDefinition),
+    );
+    vi.mocked(getPartialSubmissionUseCase).mockResolvedValue(
+      ApiResult.notFoundError("No submission") as PartialSubmissionResult,
+    );
+
+    const props = {
+      params: Promise.resolve({ formId: "valid-id" }),
+      searchParams: Promise.resolve({}),
+    };
+
+    // Act
+    const component = await ShareFormPage(props);
+    render(component);
+
+    // Assert
+    expect(screen.getByText("Already Responded")).toBeDefined();
+    expect(
+      screen.getByText("You already completed this survey."),
+    ).toBeDefined();
+    expect(screen.queryByTestId("survey-js-wrapper")).toBeNull();
+  });
+
+  it("does not gate token edit flow when user already submitted", async () => {
+    // Arrange
+    const mockDefinition = {
+      jsonData: { title: "Test Form" },
+      hasUserSubmitted: true,
+      metadata: JSON.stringify({
+        alreadyRespondedMessage: "You already completed this survey.",
+      }),
+      themeModel: {},
+      customQuestions: [],
+      requiresReCaptcha: false,
+    };
+    const mockSubmission = {
+      data: { q1: "existing answer" },
+      timestamp: "2024-01-01T00:00:00Z",
+    };
+    const validAccessToken = "123.1705824000.rw.abc123def456";
+
+    vi.mocked(getActiveDefinitionUseCase).mockResolvedValue(
+      Result.success(mockDefinition as unknown as ActiveDefinition),
+    );
+    vi.mocked(getSubmissionByAccessTokenUseCase).mockResolvedValue(
+      Result.success(mockSubmission as unknown as Submission),
+    );
+
+    const props = {
+      params: Promise.resolve({ formId: "valid-id" }),
+      searchParams: Promise.resolve({ token: validAccessToken }),
+    };
+
+    // Act
+    const component = await ShareFormPage(props);
+    render(component);
+
+    // Assert
+    expect(screen.getByTestId("survey-js-wrapper")).toBeDefined();
+    expect(screen.queryByText("Already Responded")).toBeNull();
+  });
 });

--- a/__tests__/pages/share-form.test.tsx
+++ b/__tests__/pages/share-form.test.tsx
@@ -264,6 +264,68 @@ describe("ShareForm Page", () => {
     expect(screen.queryByTestId("survey-js-wrapper")).toBeNull();
   });
 
+  it("falls back to default already responded message for null metadata JSON", async () => {
+    // Arrange
+    const mockDefinition = {
+      jsonData: { title: "Test Form" },
+      hasUserSubmitted: true,
+      metadata: "null",
+    };
+
+    vi.mocked(getActiveDefinitionUseCase).mockResolvedValue(
+      Result.success(mockDefinition as unknown as ActiveDefinition),
+    );
+    vi.mocked(getPartialSubmissionUseCase).mockResolvedValue(
+      ApiResult.notFoundError("No submission") as PartialSubmissionResult,
+    );
+
+    const props = {
+      params: Promise.resolve({ formId: "valid-id" }),
+      searchParams: Promise.resolve({}),
+    };
+
+    // Act
+    const component = await ShareFormPage(props);
+    render(component);
+
+    // Assert
+    expect(
+      screen.getByText("You have already submitted a response for this form."),
+    ).toBeDefined();
+  });
+
+  it("falls back to default message for empty configured value", async () => {
+    // Arrange
+    const mockDefinition = {
+      jsonData: { title: "Test Form" },
+      hasUserSubmitted: true,
+      metadata: JSON.stringify({
+        alreadyRespondedMessage: "",
+      }),
+    };
+
+    vi.mocked(getActiveDefinitionUseCase).mockResolvedValue(
+      Result.success(mockDefinition as unknown as ActiveDefinition),
+    );
+    vi.mocked(getPartialSubmissionUseCase).mockResolvedValue(
+      ApiResult.notFoundError("No submission") as PartialSubmissionResult,
+    );
+
+    const props = {
+      params: Promise.resolve({ formId: "valid-id" }),
+      searchParams: Promise.resolve({}),
+    };
+
+    // Act
+    const component = await ShareFormPage(props);
+    render(component);
+
+    // Assert
+    expect(
+      screen.getByText("You have already submitted a response for this form."),
+    ).toBeDefined();
+  });
+
   it("does not gate token edit flow when user already submitted", async () => {
     // Arrange
     const mockDefinition = {

--- a/__tests__/pages/share-form.test.tsx
+++ b/__tests__/pages/share-form.test.tsx
@@ -236,7 +236,7 @@ describe("ShareForm Page", () => {
       jsonData: { title: "Test Form" },
       hasUserSubmitted: true,
       metadata: JSON.stringify({
-        alreadyRespondedMessage: "You already completed this survey.",
+        alreadyResponded: { message: "You already completed this survey." },
       }),
     };
 
@@ -300,7 +300,7 @@ describe("ShareForm Page", () => {
       jsonData: { title: "Test Form" },
       hasUserSubmitted: true,
       metadata: JSON.stringify({
-        alreadyRespondedMessage: "",
+        alreadyResponded: { message: "" },
       }),
     };
 
@@ -332,7 +332,7 @@ describe("ShareForm Page", () => {
       jsonData: { title: "Test Form" },
       hasUserSubmitted: true,
       metadata: JSON.stringify({
-        alreadyRespondedMessage: "You already completed this survey.",
+        alreadyResponded: { message: "You already completed this survey." },
       }),
       themeModel: {},
       customQuestions: [],

--- a/app/(public)/embed/[formId]/page.tsx
+++ b/app/(public)/embed/[formId]/page.tsx
@@ -3,6 +3,7 @@
 import { NotFoundComponent } from "@/components/error-handling/not-found/not-found-component";
 import { AssetStorageProvider } from "@/features/asset-storage/server";
 import { FormTokenCookieStore } from "@/features/public-form/infrastructure/cookie-store";
+import AlreadyResponded from "@/features/public-form/ui/already-responded";
 import { EmbedHeightReporter } from "@/features/public-form/ui/embed-height-reporter";
 import SurveyJsWrapper from "@/features/public-form/ui/survey-js-wrapper";
 import { getActiveDefinitionUseCase } from "@/features/public-form/use-cases/get-active-definition.use-case";
@@ -112,6 +113,8 @@ async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
   }
 
   const activeDefinition = activeDefinitionResult.value;
+  const shouldShowAlreadyResponded =
+    !urlToken && (activeDefinition.hasUserSubmitted ?? false);
 
   const shouldLoadReCaptcha =
     activeDefinition.requiresReCaptcha && recaptchaConfig.isReCaptchaEnabled();
@@ -129,6 +132,10 @@ async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
         </>
       )}
 
+      {shouldShowAlreadyResponded ? (
+        <AlreadyResponded metadata={activeDefinition.metadata} />
+      ) : (
+        <>
       <EmbedHeightReporter />
 
       <Suspense fallback={<div>Loading...</div>}>
@@ -145,6 +152,8 @@ async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
           />
         </AssetStorageProvider>
       </Suspense>
+        </>
+      )}
     </div>
   );
 }

--- a/app/(public)/embed/[formId]/page.tsx
+++ b/app/(public)/embed/[formId]/page.tsx
@@ -132,27 +132,25 @@ async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
         </>
       )}
 
+      <EmbedHeightReporter />
+
       {shouldShowAlreadyResponded ? (
         <AlreadyResponded metadata={activeDefinition.metadata} />
       ) : (
-        <>
-      <EmbedHeightReporter />
-
-      <Suspense fallback={<div>Loading...</div>}>
-        <AssetStorageProvider>
-          <SurveyJsWrapper
-            formId={formId}
-            definition={activeDefinition.jsonData}
-            submission={submission}
-            theme={activeDefinition.themeModel}
-            customQuestions={activeDefinition.customQuestions}
-            requiresReCaptcha={activeDefinition.requiresReCaptcha}
-            isEmbed={true}
-            urlToken={urlToken}
-          />
-        </AssetStorageProvider>
-      </Suspense>
-        </>
+        <Suspense fallback={<div>Loading...</div>}>
+          <AssetStorageProvider>
+            <SurveyJsWrapper
+              formId={formId}
+              definition={activeDefinition.jsonData}
+              submission={submission}
+              theme={activeDefinition.themeModel}
+              customQuestions={activeDefinition.customQuestions}
+              requiresReCaptcha={activeDefinition.requiresReCaptcha}
+              isEmbed={true}
+              urlToken={urlToken}
+            />
+          </AssetStorageProvider>
+        </Suspense>
       )}
     </div>
   );

--- a/app/(public)/share/[formId]/page.tsx
+++ b/app/(public)/share/[formId]/page.tsx
@@ -20,34 +20,6 @@ import { notFound } from "next/navigation";
 import Script from "next/script";
 import { Suspense } from "react";
 
-const DEFAULT_ALREADY_RESPONDED_MESSAGE =
-  "You have already submitted a response for this form.";
-
-function getAlreadyRespondedMessage(metadata?: string): string {
-  if (!metadata) {
-    return DEFAULT_ALREADY_RESPONDED_MESSAGE;
-  }
-
-  try {
-    const parsedMetadata = JSON.parse(metadata) as unknown;
-
-    if (typeof parsedMetadata !== "object" || parsedMetadata === null) {
-      return DEFAULT_ALREADY_RESPONDED_MESSAGE;
-    }
-
-    const parsedMetadataObject = parsedMetadata as {
-      alreadyRespondedMessage?: string;
-      alreadyResponded?: { message?: string };
-    };
-    const nestedMessage = parsedMetadataObject.alreadyResponded?.message?.trim();
-    const directMessage = parsedMetadataObject.alreadyRespondedMessage?.trim();
-
-    return nestedMessage || directMessage || DEFAULT_ALREADY_RESPONDED_MESSAGE;
-  } catch {
-    return DEFAULT_ALREADY_RESPONDED_MESSAGE;
-  }
-}
-
 type ShareSurveyPage = {
   params: Promise<{ formId: string }>;
   searchParams: Promise<{ token?: string }>;
@@ -157,9 +129,7 @@ async function ShareSurveyPage({ params, searchParams }: ShareSurveyPage) {
     return (
       <div className={styles.surveyPage}>
         <div className={styles.surveyContent}>
-          <AlreadyResponded
-            message={getAlreadyRespondedMessage(activeDefinition.metadata)}
-          />
+          <AlreadyResponded metadata={activeDefinition.metadata} />
         </div>
       </div>
     );

--- a/app/(public)/share/[formId]/page.tsx
+++ b/app/(public)/share/[formId]/page.tsx
@@ -4,6 +4,7 @@ import { NotFoundComponent } from "@/components/error-handling/not-found/not-fou
 import "@/components/error-handling/not-found/not-found-styles-standalone.css";
 import { AssetStorageProvider } from "@/features/asset-storage/server";
 import { FormTokenCookieStore } from "@/features/public-form/infrastructure/cookie-store";
+import AlreadyResponded from "@/features/public-form/ui/already-responded";
 import SurveyJsWrapper from "@/features/public-form/ui/survey-js-wrapper";
 import styles from "./page.module.css";
 import { getActiveDefinitionUseCase } from "@/features/public-form/use-cases/get-active-definition.use-case";
@@ -18,6 +19,30 @@ import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import Script from "next/script";
 import { Suspense } from "react";
+
+const DEFAULT_ALREADY_RESPONDED_MESSAGE =
+  "You have already submitted a response for this form.";
+
+function getAlreadyRespondedMessage(metadata?: string): string {
+  if (!metadata) {
+    return DEFAULT_ALREADY_RESPONDED_MESSAGE;
+  }
+
+  try {
+    const parsedMetadata = JSON.parse(metadata) as {
+      alreadyRespondedMessage?: string;
+      alreadyResponded?: { message?: string };
+    };
+
+    return (
+      parsedMetadata.alreadyResponded?.message ??
+      parsedMetadata.alreadyRespondedMessage ??
+      DEFAULT_ALREADY_RESPONDED_MESSAGE
+    );
+  } catch {
+    return DEFAULT_ALREADY_RESPONDED_MESSAGE;
+  }
+}
 
 type ShareSurveyPage = {
   params: Promise<{ formId: string }>;
@@ -118,9 +143,19 @@ async function ShareSurveyPage({ params, searchParams }: ShareSurveyPage) {
   }
 
   const activeDefinition = activeDefinitionResult.value;
+  const shouldShowAlreadyResponded =
+    !urlToken && (activeDefinition.hasUserSubmitted ?? false);
 
   const shouldLoadReCaptcha =
     activeDefinition.requiresReCaptcha && recaptchaConfig.isReCaptchaEnabled();
+
+  if (shouldShowAlreadyResponded) {
+    return (
+      <AlreadyResponded
+        message={getAlreadyRespondedMessage(activeDefinition.metadata)}
+      />
+    );
+  }
 
   return (
     <div className={styles.surveyPage}>

--- a/app/(public)/share/[formId]/page.tsx
+++ b/app/(public)/share/[formId]/page.tsx
@@ -29,16 +29,20 @@ function getAlreadyRespondedMessage(metadata?: string): string {
   }
 
   try {
-    const parsedMetadata = JSON.parse(metadata) as {
+    const parsedMetadata = JSON.parse(metadata) as unknown;
+
+    if (typeof parsedMetadata !== "object" || parsedMetadata === null) {
+      return DEFAULT_ALREADY_RESPONDED_MESSAGE;
+    }
+
+    const parsedMetadataObject = parsedMetadata as {
       alreadyRespondedMessage?: string;
       alreadyResponded?: { message?: string };
     };
+    const nestedMessage = parsedMetadataObject.alreadyResponded?.message?.trim();
+    const directMessage = parsedMetadataObject.alreadyRespondedMessage?.trim();
 
-    return (
-      parsedMetadata.alreadyResponded?.message ??
-      parsedMetadata.alreadyRespondedMessage ??
-      DEFAULT_ALREADY_RESPONDED_MESSAGE
-    );
+    return nestedMessage || directMessage || DEFAULT_ALREADY_RESPONDED_MESSAGE;
   } catch {
     return DEFAULT_ALREADY_RESPONDED_MESSAGE;
   }
@@ -151,9 +155,13 @@ async function ShareSurveyPage({ params, searchParams }: ShareSurveyPage) {
 
   if (shouldShowAlreadyResponded) {
     return (
-      <AlreadyResponded
-        message={getAlreadyRespondedMessage(activeDefinition.metadata)}
-      />
+      <div className={styles.surveyPage}>
+        <div className={styles.surveyContent}>
+          <AlreadyResponded
+            message={getAlreadyRespondedMessage(activeDefinition.metadata)}
+          />
+        </div>
+      </div>
     );
   }
 

--- a/features/public-form/ui/__tests__/already-responded.test.tsx
+++ b/features/public-form/ui/__tests__/already-responded.test.tsx
@@ -3,15 +3,29 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 describe("AlreadyResponded", () => {
-  it("renders title and message", () => {
+  it("renders nested metadata message", () => {
     // Arrange
-    const message = "A custom already-responded message.";
+    const metadata = JSON.stringify({
+      alreadyResponded: { message: "A custom already-responded message." },
+    });
 
     // Act
-    render(<AlreadyResponded message={message} />);
+    render(<AlreadyResponded metadata={metadata} />);
 
     // Assert
     expect(screen.getByText("Already Responded")).toBeDefined();
-    expect(screen.getByText(message)).toBeDefined();
+    expect(
+      screen.getByText("A custom already-responded message."),
+    ).toBeDefined();
+  });
+
+  it("falls back to default message for invalid metadata", () => {
+    // Act
+    render(<AlreadyResponded metadata="null" />);
+
+    // Assert
+    expect(
+      screen.getByText("You have already submitted a response for this form."),
+    ).toBeDefined();
   });
 });

--- a/features/public-form/ui/__tests__/already-responded.test.tsx
+++ b/features/public-form/ui/__tests__/already-responded.test.tsx
@@ -1,0 +1,17 @@
+import AlreadyResponded from "@/features/public-form/ui/already-responded";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("AlreadyResponded", () => {
+  it("renders title and message", () => {
+    // Arrange
+    const message = "A custom already-responded message.";
+
+    // Act
+    render(<AlreadyResponded message={message} />);
+
+    // Assert
+    expect(screen.getByText("Already Responded")).toBeDefined();
+    expect(screen.getByText(message)).toBeDefined();
+  });
+});

--- a/features/public-form/ui/already-responded.tsx
+++ b/features/public-form/ui/already-responded.tsx
@@ -1,0 +1,16 @@
+interface AlreadyRespondedProps {
+  message: string;
+}
+
+const DEFAULT_TITLE = 'Already Responded';
+
+export default function AlreadyResponded({ message }: AlreadyRespondedProps) {
+  return (
+    <div className='flex min-h-screen items-center justify-center p-6'>
+      <div className='w-full max-w-2xl rounded-lg border bg-background p-8 text-center shadow-sm'>
+        <h1 className='text-2xl font-semibold'>{DEFAULT_TITLE}</h1>
+        <p className='mt-4 text-muted-foreground'>{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/features/public-form/ui/already-responded.tsx
+++ b/features/public-form/ui/already-responded.tsx
@@ -1,10 +1,37 @@
 interface AlreadyRespondedProps {
-  message: string;
+  metadata?: string;
 }
 
 const DEFAULT_TITLE = 'Already Responded';
+const DEFAULT_ALREADY_RESPONDED_MESSAGE =
+  'You have already submitted a response for this form.';
 
-export default function AlreadyResponded({ message }: AlreadyRespondedProps) {
+function getAlreadyRespondedMessage(metadata?: string): string {
+  if (!metadata) {
+    return DEFAULT_ALREADY_RESPONDED_MESSAGE;
+  }
+
+  try {
+    const parsedMetadata = JSON.parse(metadata) as unknown;
+
+    if (typeof parsedMetadata !== 'object' || parsedMetadata === null) {
+      return DEFAULT_ALREADY_RESPONDED_MESSAGE;
+    }
+
+    const parsedMetadataObject = parsedMetadata as {
+      alreadyResponded?: { message?: string };
+    };
+
+    const nestedMessage = parsedMetadataObject.alreadyResponded?.message?.trim();
+    return nestedMessage || DEFAULT_ALREADY_RESPONDED_MESSAGE;
+  } catch {
+    return DEFAULT_ALREADY_RESPONDED_MESSAGE;
+  }
+}
+
+export default function AlreadyResponded({ metadata }: AlreadyRespondedProps) {
+  const message = getAlreadyRespondedMessage(metadata);
+
   return (
     <div className='flex min-h-screen items-center justify-center p-6'>
       <div className='w-full max-w-2xl rounded-lg border bg-background p-8 text-center shadow-sm'>

--- a/types/index.ts
+++ b/types/index.ts
@@ -26,6 +26,8 @@ export type ActiveDefinition = FormDefinition & {
   themeModel?: string;
   requiresReCaptcha?: boolean;
   customQuestions?: string[];
+  hasUserSubmitted?: boolean;
+  metadata?: string;
 };
 
 export type FormTemplate = {


### PR DESCRIPTION
## Description

- Extended active-definition type with `hasUserSubmitted` and `metadata` in `hub/types/index.ts`.
- Implemented public share-page gating: show `AlreadyResponded` only for fresh-submit flow (`!urlToken && hasUserSubmitted`), preserving token edit/resume flow.
- Added new `AlreadyResponded` UI component for the blocked state.
- Improved metadata message parsing in share page: explicit object/null guard, no exception-based property access for `"null"` JSON, and fallback for empty/whitespace messages.
- Wrapped `AlreadyResponded` path in the same page shell containers (`surveyPage`/`surveyContent`) for consistent layout/theming.
- Added/updated tests:
  - Hub share-page tests for gated render, token-edit non-gating regression, null-metadata fallback, and empty-message fallback.
  - New unit test for `AlreadyResponded` component.


## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

