### PR TITLE
feat: Admin and end-user UI for single-submission surveys

### DIFF
--- a/__tests__/pages/embed-form.test.tsx
+++ b/__tests__/pages/embed-form.test.tsx
@@ -169,4 +169,43 @@ describe("EmbedForm Page", () => {
     expect(screen.queryByText("Already Responded")).toBeNull();
     expect(screen.getByTestId("embed-height-reporter")).toBeDefined();
   });
+
+  it("does not gate cookie draft flow when user already submitted but current draft exists", async () => {
+    // Arrange
+    const mockDefinition = {
+      jsonData: { title: "Test Form" },
+      hasUserSubmitted: true,
+      metadata: JSON.stringify({
+        alreadyResponded: { message: "You already completed this survey." },
+      }),
+      requiresReCaptcha: false,
+    };
+    const mockSubmission = {
+      id: "submission-1",
+      data: { q1: "draft answer" },
+      timestamp: "2024-01-01T00:00:00Z",
+    };
+
+    vi.mocked(getActiveDefinitionUseCase).mockResolvedValue(
+      Result.success(mockDefinition as unknown as ActiveDefinition),
+    );
+    vi.mocked(getPartialSubmissionUseCase).mockResolvedValue(
+      ApiResult.success(mockSubmission as unknown as Submission),
+    );
+
+    const props = {
+      params: Promise.resolve({ formId: "valid-id" }),
+      searchParams: Promise.resolve({}),
+    };
+
+    // Act
+    const component = await EmbedFormPage(props);
+    render(component);
+
+    // Assert
+    expect(notFound).not.toHaveBeenCalled();
+    expect(screen.getByTestId("survey-js-wrapper")).toBeDefined();
+    expect(screen.queryByText("Already Responded")).toBeNull();
+    expect(screen.getByTestId("embed-height-reporter")).toBeDefined();
+  });
 });

--- a/__tests__/pages/share-form.test.tsx
+++ b/__tests__/pages/share-form.test.tsx
@@ -364,4 +364,43 @@ describe("ShareForm Page", () => {
     expect(screen.getByTestId("survey-js-wrapper")).toBeDefined();
     expect(screen.queryByText("Already Responded")).toBeNull();
   });
+
+  it("does not gate cookie draft flow when user already submitted but current draft exists", async () => {
+    // Arrange
+    const mockDefinition = {
+      jsonData: { title: "Test Form" },
+      hasUserSubmitted: true,
+      metadata: JSON.stringify({
+        alreadyResponded: { message: "You already completed this survey." },
+      }),
+      themeModel: {},
+      customQuestions: [],
+      requiresReCaptcha: false,
+    };
+    const mockSubmission = {
+      id: "submission-1",
+      data: { q1: "draft answer" },
+      timestamp: "2024-01-01T00:00:00Z",
+    };
+
+    vi.mocked(getActiveDefinitionUseCase).mockResolvedValue(
+      Result.success(mockDefinition as unknown as ActiveDefinition),
+    );
+    vi.mocked(getPartialSubmissionUseCase).mockResolvedValue(
+      ApiResult.success(mockSubmission as unknown as Submission),
+    );
+
+    const props = {
+      params: Promise.resolve({ formId: "valid-id" }),
+      searchParams: Promise.resolve({}),
+    };
+
+    // Act
+    const component = await ShareFormPage(props);
+    render(component);
+
+    // Assert
+    expect(screen.getByTestId("survey-js-wrapper")).toBeDefined();
+    expect(screen.queryByText("Already Responded")).toBeNull();
+  });
 });

--- a/app/(main)/forms/[formId]/submissions/page.tsx
+++ b/app/(main)/forms/[formId]/submissions/page.tsx
@@ -15,6 +15,7 @@ type Params = {
     pageSize?: string;
     isComplete?: string;
     status?: string;
+    isTestSubmission?: string;
   }>;
 };
 
@@ -76,6 +77,7 @@ async function SubmissionsTableData({
   searchParams: {
     isComplete?: string;
     status?: string;
+    isTestSubmission?: string;
   };
 }) {
   const isCompleteFilter = searchParams.isComplete
@@ -85,6 +87,9 @@ async function SubmissionsTableData({
   const statusFilter = searchParams.status
     ? searchParams.status.split(",")
     : [];
+  const isTestSubmissionFilter = searchParams.isTestSubmission
+    ? searchParams.isTestSubmission.split(",")
+    : [];
 
   const session = await getSession();
   const api = new EndatixApi(session ?? undefined);
@@ -93,6 +98,7 @@ async function SubmissionsTableData({
     api.submissions.list(formId, {
       isComplete: isCompleteFilter,
       status: statusFilter,
+      isTestSubmission: isTestSubmissionFilter,
     }),
     api.definitions.getFields(formId),
   ]);
@@ -107,6 +113,7 @@ async function SubmissionsTableData({
       definitionFields={definitionFields}
       initialIsComplete={isCompleteFilter}
       initialStatus={statusFilter}
+      initialIsTestSubmission={isTestSubmissionFilter}
     />
   );
 }

--- a/app/(main)/forms/[formId]/submissions/ui/submissions-with-filters.tsx
+++ b/app/(main)/forms/[formId]/submissions/ui/submissions-with-filters.tsx
@@ -26,6 +26,7 @@ interface SubmissionsWithFiltersProps {
   definitionFields?: DefinitionField[];
   initialIsComplete?: string[];
   initialStatus?: string[];
+  initialIsTestSubmission?: string[];
 }
 
 function SubmissionsContent({
@@ -34,8 +35,10 @@ function SubmissionsContent({
   definitionFields,
   isCompleteFilter,
   statusFilter,
+  testSubmissionFilter,
   onIsCompleteChange,
   onStatusChange,
+  onTestSubmissionChange,
   onResetFilters,
   isPending,
   tableKey,
@@ -49,8 +52,10 @@ function SubmissionsContent({
   definitionFields: DefinitionField[];
   isCompleteFilter: Set<string>;
   statusFilter: Set<string>;
+  testSubmissionFilter: Set<string>;
   onIsCompleteChange: (values: Set<string>) => void;
   onStatusChange: (values: Set<string>) => void;
+  onTestSubmissionChange: (values: Set<string>) => void;
   onResetFilters: () => void;
   isPending: boolean;
   tableKey: string;
@@ -120,8 +125,10 @@ function SubmissionsContent({
         <SubmissionsFilterToolbar
           isCompleteFilter={isCompleteFilter}
           statusFilter={statusFilter}
+          testSubmissionFilter={testSubmissionFilter}
           onIsCompleteChange={onIsCompleteChange}
           onStatusChange={onStatusChange}
+          onTestSubmissionChange={onTestSubmissionChange}
           onResetFilters={onResetFilters}
         />
         <div className="flex items-center gap-2">
@@ -156,6 +163,7 @@ export function SubmissionsWithFilters({
   definitionFields = [],
   initialIsComplete = [],
   initialStatus = [],
+  initialIsTestSubmission = [],
 }: SubmissionsWithFiltersProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -166,9 +174,16 @@ export function SubmissionsWithFilters({
   const [statusFilter, setStatusFilter] = useState<Set<string>>(
     new Set(initialStatus)
   );
+  const [testSubmissionFilter, setTestSubmissionFilter] = useState<Set<string>>(
+    new Set(initialIsTestSubmission),
+  );
   const [sorting, setSorting] = useState<SortingState>([]);
 
-  const updateURL = (isComplete: Set<string>, status: Set<string>) => {
+  const updateURL = (
+    isComplete: Set<string>,
+    status: Set<string>,
+    isTestSubmission: Set<string>,
+  ) => {
     const params = new URLSearchParams();
 
     if (isComplete.size > 0) {
@@ -176,6 +191,9 @@ export function SubmissionsWithFilters({
     }
     if (status.size > 0) {
       params.set("status", Array.from(status).join(","));
+    }
+    if (isTestSubmission.size > 0) {
+      params.set("isTestSubmission", Array.from(isTestSubmission).join(","));
     }
 
     const queryString = params.toString();
@@ -188,19 +206,25 @@ export function SubmissionsWithFilters({
 
   const handleIsCompleteChange = (values: Set<string>) => {
     setIsCompleteFilter(values);
-    updateURL(values, statusFilter);
+    updateURL(values, statusFilter, testSubmissionFilter);
   };
 
   const handleStatusChange = (values: Set<string>) => {
     setStatusFilter(values);
-    updateURL(isCompleteFilter, values);
+    updateURL(isCompleteFilter, values, testSubmissionFilter);
+  };
+
+  const handleTestSubmissionChange = (values: Set<string>) => {
+    setTestSubmissionFilter(values);
+    updateURL(isCompleteFilter, statusFilter, values);
   };
 
   const handleResetFilters = () => {
     const emptySet = new Set<string>();
     setIsCompleteFilter(emptySet);
     setStatusFilter(emptySet);
-    updateURL(emptySet, emptySet);
+    setTestSubmissionFilter(emptySet);
+    updateURL(emptySet, emptySet, emptySet);
   };
 
   const handleResetSorting = () => {
@@ -208,7 +232,7 @@ export function SubmissionsWithFilters({
   };
 
   // Create a key that changes when filters change to force table re-mount
-  const tableKey = `${Array.from(isCompleteFilter).sort((a, b) => a.localeCompare(b)).join(',')}-${Array.from(statusFilter).sort((a, b) => a.localeCompare(b)).join(',')}-${data.length}`;
+  const tableKey = `${Array.from(isCompleteFilter).sort((a, b) => a.localeCompare(b)).join(',')}-${Array.from(statusFilter).sort((a, b) => a.localeCompare(b)).join(',')}-${Array.from(testSubmissionFilter).sort((a, b) => a.localeCompare(b)).join(',')}-${data.length}`;
 
   const allColumns = [...COLUMNS_DEFINITION, ...buildSubmissionDataColumns(definitionFields)];
 
@@ -221,8 +245,10 @@ export function SubmissionsWithFilters({
           definitionFields={definitionFields}
           isCompleteFilter={isCompleteFilter}
           statusFilter={statusFilter}
+          testSubmissionFilter={testSubmissionFilter}
           onIsCompleteChange={handleIsCompleteChange}
           onStatusChange={handleStatusChange}
+          onTestSubmissionChange={handleTestSubmissionChange}
           onResetFilters={handleResetFilters}
           isPending={isPending}
           tableKey={tableKey}

--- a/app/(public)/embed/[formId]/page.tsx
+++ b/app/(public)/embed/[formId]/page.tsx
@@ -113,8 +113,11 @@ async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
   }
 
   const activeDefinition = activeDefinitionResult.value;
+  const hasCurrentDraftSubmission = Boolean(submission?.id);
   const shouldShowAlreadyResponded =
-    !urlToken && (activeDefinition.hasUserSubmitted ?? false);
+    !urlToken &&
+    (activeDefinition.hasUserSubmitted ?? false) &&
+    !hasCurrentDraftSubmission;
 
   const shouldLoadReCaptcha =
     activeDefinition.requiresReCaptcha && recaptchaConfig.isReCaptchaEnabled();

--- a/app/(public)/share/[formId]/page.tsx
+++ b/app/(public)/share/[formId]/page.tsx
@@ -119,8 +119,11 @@ async function ShareSurveyPage({ params, searchParams }: ShareSurveyPage) {
   }
 
   const activeDefinition = activeDefinitionResult.value;
+  const hasCurrentDraftSubmission = Boolean(submission?.id);
   const shouldShowAlreadyResponded =
-    !urlToken && (activeDefinition.hasUserSubmitted ?? false);
+    !urlToken &&
+    (activeDefinition.hasUserSubmitted ?? false) &&
+    !hasCurrentDraftSubmission;
 
   const shouldLoadReCaptcha =
     activeDefinition.requiresReCaptcha && recaptchaConfig.isReCaptchaEnabled();

--- a/e2e/tests/submissions/single-submission-enforcement.spec.ts
+++ b/e2e/tests/submissions/single-submission-enforcement.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+
+const createSubmissionPayload = {
+  jsonData: JSON.stringify({ q1: "answer" }),
+  isComplete: true,
+  currentPage: 0,
+};
+
+test.describe("Single submission enforcement", () => {
+  test("blocks duplicate submission for non-test user", async ({ request }) => {
+    // Arrange
+    const apiBaseUrl = process.env.ENDATIX_API_URL;
+    const formId = process.env.E2E_PRIVATE_FORM_ID;
+    const nonTestToken = process.env.E2E_NON_TEST_USER_TOKEN;
+
+    test.skip(!apiBaseUrl || !formId || !nonTestToken);
+
+    const endpoint = `${apiBaseUrl}/forms/${formId}/submissions`;
+
+    // Act
+    await request.post(endpoint, {
+      headers: { Authorization: `Bearer ${nonTestToken}` },
+      data: createSubmissionPayload,
+    });
+    const duplicateResponse = await request.post(endpoint, {
+      headers: { Authorization: `Bearer ${nonTestToken}` },
+      data: createSubmissionPayload,
+    });
+
+    // Assert
+    expect(duplicateResponse.status()).toBe(409);
+  });
+
+  test("allows duplicate submission for user with test permission", async ({ request }) => {
+    // Arrange
+    const apiBaseUrl = process.env.ENDATIX_API_URL;
+    const formId = process.env.E2E_PRIVATE_FORM_ID;
+    const testUserToken = process.env.E2E_TEST_USER_TOKEN;
+
+    test.skip(!apiBaseUrl || !formId || !testUserToken);
+
+    const endpoint = `${apiBaseUrl}/forms/${formId}/submissions`;
+
+    // Act
+    const firstResponse = await request.post(endpoint, {
+      headers: { Authorization: `Bearer ${testUserToken}` },
+      data: createSubmissionPayload,
+    });
+    const secondResponse = await request.post(endpoint, {
+      headers: { Authorization: `Bearer ${testUserToken}` },
+      data: createSubmissionPayload,
+    });
+
+    // Assert
+    expect(firstResponse.ok()).toBeTruthy();
+    expect(secondResponse.ok()).toBeTruthy();
+  });
+});

--- a/features/forms/application/actions/update-form-settings.action.ts
+++ b/features/forms/application/actions/update-form-settings.action.ts
@@ -26,7 +26,9 @@ export async function updateFormSettingsAction(
 
   if (!result.success) {
     console.error("Failed to update form settings", result.error);
-    return Result.error("Failed to update form settings");
+    return Result.error(
+      result.error.message || "Failed to update form settings",
+    );
   }
 
   revalidatePath("/(main)/forms");

--- a/features/forms/application/actions/update-form-settings.action.ts
+++ b/features/forms/application/actions/update-form-settings.action.ts
@@ -2,27 +2,31 @@
 
 import { auth } from "@/auth";
 import { authorization } from "@/features/auth/authorization";
-import { Result } from "@/lib/result";
 import { EndatixApi } from "@/lib/endatix-api";
+import { Result } from "@/lib/result";
 import { revalidatePath } from "next/cache";
 
-export type UpdateFormVisibilityResult = Result<string>;
+export type UpdateFormSettingsResult = Result<string>;
 
-export async function updateFormVisibilityAction(
+interface UpdateFormSettingsPayload {
+  limitOnePerUser?: boolean;
+  metadata?: string | null;
+}
+
+export async function updateFormSettingsAction(
   formId: string,
-  isPublic: boolean,
-  limitOnePerUser?: boolean,
-): Promise<UpdateFormVisibilityResult | never> {
+  payload: UpdateFormSettingsPayload,
+): Promise<UpdateFormSettingsResult | never> {
   const session = await auth();
   const { requireHubAccess } = await authorization(session);
   await requireHubAccess();
 
   const api = new EndatixApi(session?.accessToken);
-  const result = await api.forms.update(formId, { isPublic, limitOnePerUser });
+  const result = await api.forms.update(formId, payload);
 
   if (!result.success) {
-    console.error("Failed to update form visibility", result.error);
-    return Result.error("Failed to update form visibility");
+    console.error("Failed to update form settings", result.error);
+    return Result.error("Failed to update form settings");
   }
 
   revalidatePath("/(main)/forms");

--- a/features/forms/application/actions/update-form-visibility.action.ts
+++ b/features/forms/application/actions/update-form-visibility.action.ts
@@ -11,14 +11,13 @@ export type UpdateFormVisibilityResult = Result<string>;
 export async function updateFormVisibilityAction(
   formId: string,
   isPublic: boolean,
-  limitOnePerUser?: boolean,
 ): Promise<UpdateFormVisibilityResult | never> {
   const session = await auth();
   const { requireHubAccess } = await authorization(session);
   await requireHubAccess();
 
   const api = new EndatixApi(session?.accessToken);
-  const result = await api.forms.update(formId, { isPublic, limitOnePerUser });
+  const result = await api.forms.update(formId, { isPublic });
 
   if (!result.success) {
     console.error("Failed to update form visibility", result.error);

--- a/features/forms/ui/__tests__/form-details.test.tsx
+++ b/features/forms/ui/__tests__/form-details.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import FormDetails from "../form-details";
+
+const mockUpdateFormSettingsAction = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/ui/toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../application/actions/update-form-status.action", () => ({
+  updateFormStatusAction: vi.fn(),
+}));
+
+vi.mock("../../application/actions/update-form-visibility.action", () => ({
+  updateFormVisibilityAction: vi.fn(),
+}));
+
+vi.mock("../../application/actions/update-form-settings.action", () => ({
+  updateFormSettingsAction: (...args: unknown[]) =>
+    mockUpdateFormSettingsAction(...args),
+}));
+
+vi.mock("../../application/actions/delete-form.action", () => ({
+  deleteFormAction: vi.fn(),
+}));
+
+vi.mock("../webhook-settings", () => ({
+  WebhookSettings: () => <div data-testid="webhook-settings" />,
+}));
+
+vi.mock("../share-dialog", () => ({
+  ShareDialog: () => <div data-testid="share-dialog" />,
+}));
+
+vi.mock("../save-as-template-dialog", () => ({
+  SaveAsTemplateDialog: () => <div data-testid="save-as-template-dialog" />,
+}));
+
+describe("FormDetails", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateFormSettingsAction.mockResolvedValue({ kind: 0, value: "form-1" });
+  });
+
+  it("disables limit one per user switch when already enabled", () => {
+    // Arrange
+    const form = {
+      id: "form-1",
+      name: "Form",
+      isEnabled: true,
+      isPublic: false,
+      limitOnePerUser: true,
+      createdAt: new Date(),
+    };
+
+    // Act
+    render(<FormDetails form={form} enableEditing />);
+    const switchElement = document.getElementById("form-limit-one");
+
+    // Assert
+    expect(switchElement).toBeDefined();
+    expect(switchElement?.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("shows irreversible warning confirmation before enabling", async () => {
+    // Arrange
+    const form = {
+      id: "form-1",
+      name: "Form",
+      isEnabled: true,
+      isPublic: false,
+      limitOnePerUser: false,
+      createdAt: new Date(),
+    };
+
+    render(<FormDetails form={form} enableEditing />);
+    const switchElement = document.getElementById("form-limit-one");
+
+    // Act
+    fireEvent.click(switchElement!);
+
+    // Assert
+    expect(
+      screen.getByText(
+        "After this is enabled, each authenticated user can submit this form only once. This setting cannot be disabled later.",
+      ),
+    ).toBeDefined();
+    expect(mockUpdateFormSettingsAction).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Enable single submission gate"));
+
+    await waitFor(() => {
+      expect(mockUpdateFormSettingsAction).toHaveBeenCalledWith("form-1", {
+        limitOnePerUser: true,
+      });
+    });
+  });
+
+  it("disables visibility toggle when single submission is enabled", () => {
+    // Arrange
+    const form = {
+      id: "form-1",
+      name: "Form",
+      isEnabled: true,
+      isPublic: false,
+      limitOnePerUser: true,
+      createdAt: new Date(),
+    };
+
+    render(<FormDetails form={form} enableEditing />);
+    const switchElement = document.getElementById("form-visibility");
+
+    // Assert
+    expect(switchElement).toBeDefined();
+    expect(switchElement?.hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/features/forms/ui/__tests__/form-details.test.tsx
+++ b/features/forms/ui/__tests__/form-details.test.tsx
@@ -93,7 +93,20 @@ describe("FormDetails", () => {
     // Assert
     expect(
       screen.getByText(
-        "After you turn this on, each signed-in person can submit this form only once. To protect the integrity of collected responses, this setting is permanent. You will also not be able to make the form public later.",
+        /After you turn this on, each signed-in person can submit this form only once\./,
+        { selector: "p" },
+      ),
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        "To protect the integrity of collected responses, this setting is permanent.",
+        { selector: "strong" },
+      ),
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        "You will also not be able to make the form public later.",
+        { selector: "strong" },
       ),
     ).toBeDefined();
     expect(mockUpdateFormSettingsAction).not.toHaveBeenCalled();

--- a/features/forms/ui/__tests__/form-details.test.tsx
+++ b/features/forms/ui/__tests__/form-details.test.tsx
@@ -93,9 +93,7 @@ describe("FormDetails", () => {
     // Assert
     expect(
       screen.getByText(
-        "After you turn this on, each signed-in person can submit this form only once.\n" +
-             "To protect the integrity of collected responses, this setting is permanent.\n" +
-             "You will also not be able to make the form public later.",
+        "After you turn this on, each signed-in person can submit this form only once. To protect the integrity of collected responses, this setting is permanent. You will also not be able to make the form public later.",
       ),
     ).toBeDefined();
     expect(mockUpdateFormSettingsAction).not.toHaveBeenCalled();

--- a/features/forms/ui/__tests__/form-details.test.tsx
+++ b/features/forms/ui/__tests__/form-details.test.tsx
@@ -93,12 +93,14 @@ describe("FormDetails", () => {
     // Assert
     expect(
       screen.getByText(
-        "After this is enabled, each authenticated user can submit this form only once. This setting cannot be disabled later.",
+        "After you turn this on, each signed-in person can submit this form only once.\n" +
+             "To protect the integrity of collected responses, this setting is permanent.\n" +
+             "You will also not be able to make the form public later.",
       ),
     ).toBeDefined();
     expect(mockUpdateFormSettingsAction).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByText("Enable single submission gate"));
+    fireEvent.click(screen.getByText("Enable permanently"));
 
     await waitFor(() => {
       expect(mockUpdateFormSettingsAction).toHaveBeenCalledWith("form-1", {

--- a/features/forms/ui/__tests__/form-details.test.tsx
+++ b/features/forms/ui/__tests__/form-details.test.tsx
@@ -138,4 +138,44 @@ describe("FormDetails", () => {
     expect(switchElement).toBeDefined();
     expect(switchElement?.hasAttribute("disabled")).toBe(true);
   });
+
+  it("shows dismiss-required modal with backend message when enabling fails", async () => {
+    // Arrange
+    const backendMessage =
+      "Cannot enable single submission gate because this form already has duplicate submissions.";
+    mockUpdateFormSettingsAction.mockResolvedValue({
+      kind: 1,
+      errorType: 1,
+      message: backendMessage,
+    });
+    const form = {
+      id: "form-1",
+      name: "Form",
+      isEnabled: true,
+      isPublic: false,
+      limitOnePerUser: false,
+      createdAt: new Date(),
+    };
+
+    render(<FormDetails form={form} enableEditing />);
+    const switchElement = document.getElementById("form-limit-one");
+
+    // Act
+    fireEvent.click(switchElement!);
+    fireEvent.click(screen.getByText("Enable permanently"));
+
+    // Assert
+    expect(
+      await screen.findByText('Could not enable "one response per person"'),
+    ).toBeDefined();
+    expect(await screen.findByText(backendMessage)).toBeDefined();
+
+    fireEvent.click(screen.getByText("Dismiss"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Could not enable "one response per person"'),
+      ).toBeNull();
+    });
+  });
 });

--- a/features/forms/ui/form-details.tsx
+++ b/features/forms/ui/form-details.tsx
@@ -155,11 +155,13 @@ const FormDetails = ({
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isSaveAsTemplateOpen, setIsSaveAsTemplateOpen] = useState(false);
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
+  const [isEnableLimitWarningOpen, setIsEnableLimitWarningOpen] = useState(false);
   const router = useRouter();
 
   const enabledLabel = form?.isEnabled ? "Enabled" : "Disabled";
   const visibilityLabel = isPublic ? "Public" : "Private";
-  const limitOnePerUserDisabled = isPublic || pending;
+  const limitOnePerUserDisabled = limitOnePerUser || isPublic || pending;
+  const visibilityDisabled = pending || limitOnePerUser;
 
   const toggleEnabled = async (enabled: boolean) => {
     setIsEnabled(enabled);
@@ -183,18 +185,10 @@ const FormDetails = ({
   };
 
   const toggleVisibility = async (publicValue: boolean) => {
-    const nextLimitOnePerUser = publicValue ? false : limitOnePerUser;
     setIsPublic(publicValue);
-    if (publicValue) {
-      setLimitOnePerUser(false);
-    }
 
     startTransition(async () => {
-      const result = await updateFormVisibilityAction(
-        form.id,
-        publicValue,
-        publicValue ? false : undefined,
-      );
+      const result = await updateFormVisibilityAction(form.id, publicValue);
       if (result === undefined) {
         toast.error("Could not proceed with updating form visibility");
         return;
@@ -202,7 +196,6 @@ const FormDetails = ({
 
       if (Result.isError(result)) {
         setIsPublic(!publicValue);
-        setLimitOnePerUser(nextLimitOnePerUser);
         toast.error(
           "Failed to update form visibility. Error: " + result.message,
         );
@@ -213,7 +206,7 @@ const FormDetails = ({
     });
   };
 
-  const handleLimitOnePerUserChange = async (checked: boolean) => {
+  const updateLimitOnePerUser = async (checked: boolean) => {
     setLimitOnePerUser(checked);
     startTransition(async () => {
       const result = await updateFormSettingsAction(form.id, {
@@ -235,6 +228,20 @@ const FormDetails = ({
           : "Single response per user is disabled",
       );
     });
+  };
+
+  const handleLimitOnePerUserChange = async (checked: boolean) => {
+    if (checked && !limitOnePerUser) {
+      setIsEnableLimitWarningOpen(true);
+      return;
+    }
+
+    await updateLimitOnePerUser(checked);
+  };
+
+  const handleConfirmEnableLimitOnePerUser = async () => {
+    setIsEnableLimitWarningOpen(false);
+    await updateLimitOnePerUser(true);
   };
 
   const handleSaveMetadata = async () => {
@@ -433,7 +440,7 @@ const FormDetails = ({
                   id="form-visibility"
                   checked={isPublic}
                   onCheckedChange={toggleVisibility}
-                  disabled={pending}
+                  disabled={visibilityDisabled}
                   aria-readonly
                 />
                 <Label htmlFor="form-visibility" className="flex items-center gap-1">
@@ -530,6 +537,28 @@ const FormDetails = ({
         submissionsCount={form.submissionsCount || 0}
         onDelete={handleDelete}
       />
+
+      <AlertDialog
+        open={isEnableLimitWarningOpen}
+        onOpenChange={setIsEnableLimitWarningOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Enable "one response per person"?</AlertDialogTitle>
+            <AlertDialogDescription>
+            After you turn this on, each signed-in person can submit this form only once.
+             To protect the integrity of collected responses, this setting is permanent.
+             You will also not be able to make the form public later.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmEnableLimitOnePerUser}>
+            Enable permanently
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/features/forms/ui/form-details.tsx
+++ b/features/forms/ui/form-details.tsx
@@ -51,6 +51,12 @@ import PageTitle from "@/components/headings/page-title";
 import { WebhookSettings } from "./webhook-settings";
 import { ShareDialog } from "./share-dialog";
 import { updateFormSettingsAction } from "../application/actions/update-form-settings.action";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface DeleteFormDialogProps {
   isOpen: boolean;
@@ -162,6 +168,18 @@ const FormDetails = ({
   const visibilityLabel = isPublic ? "Public" : "Private";
   const limitOnePerUserDisabled = limitOnePerUser || isPublic || pending;
   const visibilityDisabled = pending || limitOnePerUser;
+  const visibilityDisabledReason = limitOnePerUser
+    ? 'Visibility cannot be changed while "one response per person" is enabled.'
+    : pending
+      ? "Please wait for the current update to finish."
+      : undefined;
+  const limitOnePerUserDisabledReason = limitOnePerUser
+    ? "This setting is permanent once enabled."
+    : isPublic
+      ? "This option is available only for private forms."
+      : pending
+        ? "Please wait for the current update to finish."
+        : undefined;
 
   const toggleEnabled = async (enabled: boolean) => {
     setIsEnabled(enabled);
@@ -436,13 +454,29 @@ const FormDetails = ({
           <div className="col-span-3 flex items-center space-x-2">
             {enableEditing ? (
               <>
-                <Switch
-                  id="form-visibility"
-                  checked={isPublic}
-                  onCheckedChange={toggleVisibility}
-                  disabled={visibilityDisabled}
-                  aria-readonly
-                />
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        className="inline-flex"
+                        data-testid="form-visibility-tooltip-trigger"
+                      >
+                        <Switch
+                          id="form-visibility"
+                          checked={isPublic}
+                          onCheckedChange={toggleVisibility}
+                          disabled={visibilityDisabled}
+                          aria-readonly
+                        />
+                      </span>
+                    </TooltipTrigger>
+                    {visibilityDisabled && visibilityDisabledReason && (
+                      <TooltipContent side="top" sideOffset={6}>
+                        {visibilityDisabledReason}
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                </TooltipProvider>
                 <Label htmlFor="form-visibility" className="flex items-center gap-1">
                   {isPublic ? (
                     <Globe className="h-3 w-3" />
@@ -469,13 +503,29 @@ const FormDetails = ({
           <span className="text-right self-start">Limit one per user</span>
           <div className="col-span-3 flex flex-col gap-1">
             <div className="flex items-center space-x-2">
-              <Switch
-                id="form-limit-one"
-                checked={limitOnePerUser}
-                onCheckedChange={handleLimitOnePerUserChange}
-                disabled={limitOnePerUserDisabled}
-                aria-readonly
-              />
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className="inline-flex"
+                      data-testid="form-limit-one-tooltip-trigger"
+                    >
+                      <Switch
+                        id="form-limit-one"
+                        checked={limitOnePerUser}
+                        onCheckedChange={handleLimitOnePerUserChange}
+                        disabled={limitOnePerUserDisabled}
+                        aria-readonly
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  {limitOnePerUserDisabled && limitOnePerUserDisabledReason && (
+                    <TooltipContent side="top" sideOffset={6}>
+                      {limitOnePerUserDisabledReason}
+                    </TooltipContent>
+                  )}
+                </Tooltip>
+              </TooltipProvider>
               <Label htmlFor="form-limit-one">
                 {limitOnePerUser ? "Enabled" : "Disabled"}
               </Label>
@@ -546,7 +596,15 @@ const FormDetails = ({
           <AlertDialogHeader>
             <AlertDialogTitle>Enable "one response per person"?</AlertDialogTitle>
             <AlertDialogDescription>
-            After you turn this on, each signed-in person can submit this form only once. To protect the integrity of collected responses, this setting is permanent. You will also not be able to make the form public later.
+              After you turn this on, each signed-in person can submit this form
+              only once.{" "}
+              <strong>
+                To protect the integrity of collected responses, this setting is
+                permanent.
+              </strong>{" "}
+              <strong>
+                You will also not be able to make the form public later.
+              </strong>
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/features/forms/ui/form-details.tsx
+++ b/features/forms/ui/form-details.tsx
@@ -162,6 +162,8 @@ const FormDetails = ({
   const [isSaveAsTemplateOpen, setIsSaveAsTemplateOpen] = useState(false);
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const [isEnableLimitWarningOpen, setIsEnableLimitWarningOpen] = useState(false);
+  const [isEnableLimitErrorOpen, setIsEnableLimitErrorOpen] = useState(false);
+  const [enableLimitErrorMessage, setEnableLimitErrorMessage] = useState("");
   const router = useRouter();
 
   const enabledLabel = form?.isEnabled ? "Enabled" : "Disabled";
@@ -233,6 +235,16 @@ const FormDetails = ({
 
       if (result === undefined || Result.isError(result)) {
         setLimitOnePerUser(!checked);
+        if (checked) {
+          setEnableLimitErrorMessage(
+            result && Result.isError(result)
+              ? result.message
+              : "Could not proceed with updating single-response setting.",
+          );
+          setIsEnableLimitErrorOpen(true);
+          return;
+        }
+
         toast.error(
           "Failed to update single-response setting. Error: " +
             (result && Result.isError(result) ? result.message : ""),
@@ -612,6 +624,25 @@ const FormDetails = ({
             <AlertDialogAction onClick={handleConfirmEnableLimitOnePerUser}>
             Enable permanently
             </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={isEnableLimitErrorOpen}
+        onOpenChange={setIsEnableLimitErrorOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Could not enable "one response per person"
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {enableLimitErrorMessage}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction>Dismiss</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/features/forms/ui/form-details.tsx
+++ b/features/forms/ui/form-details.tsx
@@ -546,9 +546,7 @@ const FormDetails = ({
           <AlertDialogHeader>
             <AlertDialogTitle>Enable "one response per person"?</AlertDialogTitle>
             <AlertDialogDescription>
-            After you turn this on, each signed-in person can submit this form only once.
-             To protect the integrity of collected responses, this setting is permanent.
-             You will also not be able to make the form public later.
+            After you turn this on, each signed-in person can submit this form only once. To protect the integrity of collected responses, this setting is permanent. You will also not be able to make the form public later.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/features/forms/ui/form-details.tsx
+++ b/features/forms/ui/form-details.tsx
@@ -24,6 +24,7 @@ import { updateFormVisibilityAction } from "../application/actions/update-form-v
 import { toast } from "@/components/ui/toast";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -49,6 +50,7 @@ import { AlertTriangle } from "lucide-react";
 import PageTitle from "@/components/headings/page-title";
 import { WebhookSettings } from "./webhook-settings";
 import { ShareDialog } from "./share-dialog";
+import { updateFormSettingsAction } from "../application/actions/update-form-settings.action";
 
 interface DeleteFormDialogProps {
   isOpen: boolean;
@@ -147,6 +149,8 @@ const FormDetails = ({
   const [pending, startTransition] = useTransition();
   const [isEnabled, setIsEnabled] = useState(form?.isEnabled);
   const [isPublic, setIsPublic] = useState(form?.isPublic);
+  const [limitOnePerUser, setLimitOnePerUser] = useState(form?.limitOnePerUser ?? false);
+  const [metadata, setMetadata] = useState(form?.metadata ?? "");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isSaveAsTemplateOpen, setIsSaveAsTemplateOpen] = useState(false);
@@ -155,6 +159,7 @@ const FormDetails = ({
 
   const enabledLabel = form?.isEnabled ? "Enabled" : "Disabled";
   const visibilityLabel = isPublic ? "Public" : "Private";
+  const limitOnePerUserDisabled = isPublic || pending;
 
   const toggleEnabled = async (enabled: boolean) => {
     setIsEnabled(enabled);
@@ -178,9 +183,18 @@ const FormDetails = ({
   };
 
   const toggleVisibility = async (publicValue: boolean) => {
+    const nextLimitOnePerUser = publicValue ? false : limitOnePerUser;
     setIsPublic(publicValue);
+    if (publicValue) {
+      setLimitOnePerUser(false);
+    }
+
     startTransition(async () => {
-      const result = await updateFormVisibilityAction(form.id, publicValue);
+      const result = await updateFormVisibilityAction(
+        form.id,
+        publicValue,
+        publicValue ? false : undefined,
+      );
       if (result === undefined) {
         toast.error("Could not proceed with updating form visibility");
         return;
@@ -188,6 +202,7 @@ const FormDetails = ({
 
       if (Result.isError(result)) {
         setIsPublic(!publicValue);
+        setLimitOnePerUser(nextLimitOnePerUser);
         toast.error(
           "Failed to update form visibility. Error: " + result.message,
         );
@@ -195,6 +210,48 @@ const FormDetails = ({
       }
 
       toast.success(`Form is now ${publicValue ? "public" : "private"}`);
+    });
+  };
+
+  const handleLimitOnePerUserChange = async (checked: boolean) => {
+    setLimitOnePerUser(checked);
+    startTransition(async () => {
+      const result = await updateFormSettingsAction(form.id, {
+        limitOnePerUser: checked,
+      });
+
+      if (result === undefined || Result.isError(result)) {
+        setLimitOnePerUser(!checked);
+        toast.error(
+          "Failed to update single-response setting. Error: " +
+            (result && Result.isError(result) ? result.message : ""),
+        );
+        return;
+      }
+
+      toast.success(
+        checked
+          ? "Single response per user is enabled"
+          : "Single response per user is disabled",
+      );
+    });
+  };
+
+  const handleSaveMetadata = async () => {
+    startTransition(async () => {
+      const result = await updateFormSettingsAction(form.id, {
+        metadata: metadata.trim() === "" ? null : metadata,
+      });
+
+      if (result === undefined || Result.isError(result)) {
+        toast.error(
+          "Failed to update metadata. Error: " +
+            (result && Result.isError(result) ? result.message : ""),
+        );
+        return;
+      }
+
+      toast.success("Form metadata updated");
     });
   };
 
@@ -333,6 +390,19 @@ const FormDetails = ({
         </div>
 
         <div className="grid grid-cols-4 py-2 items-center gap-4">
+          <span className="col-span-1 text-right self-start">Submissions</span>
+          <div className="col-span-3 text-sm">
+            {(form?.submissionsCount ?? 0) === 0 ? (
+              <span className="text-muted-foreground">No submissions yet</span>
+            ) : (
+              <span className="text-base font-medium">
+                {form.submissionsCount ?? 0}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-4 py-2 items-center gap-4">
           <span className="text-right self-start">Status</span>
           <div className="col-span-3 flex items-center space-x-2">
             {enableEditing ? (
@@ -389,17 +459,49 @@ const FormDetails = ({
         </div>
 
         <div className="grid grid-cols-4 py-2 items-center gap-4">
-          <span className="col-span-1 text-right self-start">Submissions</span>
-          <div className="col-span-3 text-sm">
-            {(form?.submissionsCount ?? 0) === 0 ? (
-              <span className="text-muted-foreground">No submissions yet</span>
-            ) : (
-              <span className="text-base font-medium">
-                {form.submissionsCount ?? 0}
+          <span className="text-right self-start">Limit one per user</span>
+          <div className="col-span-3 flex flex-col gap-1">
+            <div className="flex items-center space-x-2">
+              <Switch
+                id="form-limit-one"
+                checked={limitOnePerUser}
+                onCheckedChange={handleLimitOnePerUserChange}
+                disabled={limitOnePerUserDisabled}
+                aria-readonly
+              />
+              <Label htmlFor="form-limit-one">
+                {limitOnePerUser ? "Enabled" : "Disabled"}
+              </Label>
+            </div>
+            {isPublic && (
+              <span className="text-xs text-muted-foreground">
+                This option is available only for private forms.
               </span>
             )}
           </div>
         </div>
+
+        <div className="grid grid-cols-4 py-2 items-start gap-4">
+          <span className="text-right self-start pt-2">Metadata (JSON)</span>
+          <div className="col-span-3 space-y-2">
+            <Textarea
+              value={metadata}
+              onChange={(event) => setMetadata(event.target.value)}
+              rows={6}
+              disabled={pending}
+              placeholder='{"key":"value"}'
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleSaveMetadata}
+              disabled={pending}
+            >
+              Save metadata
+            </Button>
+          </div>
+        </div>
+
       </div>
 
       {/* Webhook Configuration Section */}

--- a/features/forms/ui/form-details.tsx
+++ b/features/forms/ui/form-details.tsx
@@ -606,7 +606,9 @@ const FormDetails = ({
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Enable "one response per person"?</AlertDialogTitle>
+            <AlertDialogTitle>
+              Enable &quot;one response per person&quot;?
+            </AlertDialogTitle>
             <AlertDialogDescription>
               After you turn this on, each signed-in person can submit this form
               only once.{" "}
@@ -635,7 +637,7 @@ const FormDetails = ({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              Could not enable "one response per person"
+              Could not enable &quot;one response per person&quot;
             </AlertDialogTitle>
             <AlertDialogDescription>
               {enableLimitErrorMessage}

--- a/features/public-form/ui/__tests__/already-responded.test.tsx
+++ b/features/public-form/ui/__tests__/already-responded.test.tsx
@@ -3,10 +3,29 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 describe("AlreadyResponded", () => {
-  it("renders nested metadata message", () => {
+  it("renders nested metadata title and message", () => {
     // Arrange
     const metadata = JSON.stringify({
-      alreadyResponded: { message: "A custom already-responded message." },
+      alreadyResponded: {
+        title: "Custom heading",
+        message: "A custom already-responded message.",
+      },
+    });
+
+    // Act
+    render(<AlreadyResponded metadata={metadata} />);
+
+    // Assert
+    expect(screen.getByText("Custom heading")).toBeDefined();
+    expect(
+      screen.getByText("A custom already-responded message."),
+    ).toBeDefined();
+  });
+
+  it("renders default title when only message is provided", () => {
+    // Arrange
+    const metadata = JSON.stringify({
+      alreadyResponded: { message: "Message only custom value." },
     });
 
     // Act
@@ -14,9 +33,7 @@ describe("AlreadyResponded", () => {
 
     // Assert
     expect(screen.getByText("Already Responded")).toBeDefined();
-    expect(
-      screen.getByText("A custom already-responded message."),
-    ).toBeDefined();
+    expect(screen.getByText("Message only custom value.")).toBeDefined();
   });
 
   it("falls back to default message for invalid metadata", () => {
@@ -24,6 +41,7 @@ describe("AlreadyResponded", () => {
     render(<AlreadyResponded metadata="null" />);
 
     // Assert
+    expect(screen.getByText("Already Responded")).toBeDefined();
     expect(
       screen.getByText("You have already submitted a response for this form."),
     ).toBeDefined();

--- a/features/public-form/ui/already-responded.tsx
+++ b/features/public-form/ui/already-responded.tsx
@@ -1,42 +1,82 @@
+import { ClipboardCheck } from "lucide-react";
+
 interface AlreadyRespondedProps {
   metadata?: string;
 }
 
-const DEFAULT_TITLE = 'Already Responded';
+const DEFAULT_TITLE = "Already Responded";
 const DEFAULT_ALREADY_RESPONDED_MESSAGE =
-  'You have already submitted a response for this form.';
+  "You have already submitted a response for this form.";
 
-function getAlreadyRespondedMessage(metadata?: string): string {
+type AlreadyRespondedMetadata = {
+  alreadyResponded?: {
+    title?: string;
+    message?: string;
+  };
+};
+
+function getAlreadyRespondedContent(metadata?: string): {
+  title: string;
+  message: string;
+} {
   if (!metadata) {
-    return DEFAULT_ALREADY_RESPONDED_MESSAGE;
+    return {
+      title: DEFAULT_TITLE,
+      message: DEFAULT_ALREADY_RESPONDED_MESSAGE,
+    };
   }
 
   try {
-    const parsedMetadata = JSON.parse(metadata) as unknown;
+    const parsedMetadata = JSON.parse(metadata) as AlreadyRespondedMetadata;
 
     if (typeof parsedMetadata !== 'object' || parsedMetadata === null) {
-      return DEFAULT_ALREADY_RESPONDED_MESSAGE;
+      return {
+        title: DEFAULT_TITLE,
+        message: DEFAULT_ALREADY_RESPONDED_MESSAGE,
+      };
     }
 
-    const parsedMetadataObject = parsedMetadata as {
-      alreadyResponded?: { message?: string };
-    };
+    const nestedTitle = parsedMetadata.alreadyResponded?.title?.trim();
+    const nestedMessage = parsedMetadata.alreadyResponded?.message?.trim();
 
-    const nestedMessage = parsedMetadataObject.alreadyResponded?.message?.trim();
-    return nestedMessage || DEFAULT_ALREADY_RESPONDED_MESSAGE;
+    return {
+      title: nestedTitle || DEFAULT_TITLE,
+      message: nestedMessage || DEFAULT_ALREADY_RESPONDED_MESSAGE,
+    };
   } catch {
-    return DEFAULT_ALREADY_RESPONDED_MESSAGE;
+    return {
+      title: DEFAULT_TITLE,
+      message: DEFAULT_ALREADY_RESPONDED_MESSAGE,
+    };
   }
 }
 
 export default function AlreadyResponded({ metadata }: AlreadyRespondedProps) {
-  const message = getAlreadyRespondedMessage(metadata);
+  const { title, message } = getAlreadyRespondedContent(metadata);
 
   return (
-    <div className='flex min-h-screen items-center justify-center p-6'>
-      <div className='w-full max-w-2xl rounded-lg border bg-background p-8 text-center shadow-sm'>
-        <h1 className='text-2xl font-semibold'>{DEFAULT_TITLE}</h1>
-        <p className='mt-4 text-muted-foreground'>{message}</p>
+    <div className="mx-auto flex h-full max-w-2xl flex-col items-center justify-center py-16 text-center">
+      <h1 className="endatix-error-h1 text-6xl text-primary mb-4">{title}</h1>
+      <p className="mt-2 text-muted-foreground">{message}</p>
+      <div className="mt-6 flex justify-center">
+        <div
+          className="flex items-center justify-center"
+          style={{
+            width: "96px",
+            height: "96px",
+            borderRadius: "9999px",
+            backgroundColor: "#e0f2fe",
+          }}
+        >
+          <ClipboardCheck
+            size={48}
+            strokeWidth={1.8}
+            style={{
+              color: "hsl(var(--primary, 221 83% 53%))",
+              stroke: "hsl(var(--primary, 221 83% 53%))",
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/features/submissions/__tests__/ui/filters/submissions-filter-toolbar.test.tsx
+++ b/features/submissions/__tests__/ui/filters/submissions-filter-toolbar.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SubmissionsFilterToolbar } from "../../../ui/filters/submissions-filter-toolbar";
+
+describe("SubmissionsFilterToolbar", () => {
+  it("renders submission type filter", () => {
+    // Arrange
+    const onChange = vi.fn();
+
+    // Act
+    render(
+      <SubmissionsFilterToolbar
+        isCompleteFilter={new Set()}
+        statusFilter={new Set()}
+        testSubmissionFilter={new Set()}
+        onIsCompleteChange={onChange}
+        onStatusChange={onChange}
+        onTestSubmissionChange={onChange}
+        onResetFilters={onChange}
+      />,
+    );
+
+    // Assert
+    expect(screen.getByText("Submission Type")).toBeDefined();
+  });
+
+  it("shows reset button when test filter is active", () => {
+    // Arrange
+    const onChange = vi.fn();
+
+    // Act
+    render(
+      <SubmissionsFilterToolbar
+        isCompleteFilter={new Set()}
+        statusFilter={new Set()}
+        testSubmissionFilter={new Set(["true"])}
+        onIsCompleteChange={onChange}
+        onStatusChange={onChange}
+        onTestSubmissionChange={onChange}
+        onResetFilters={onChange}
+      />,
+    );
+
+    // Assert
+    expect(screen.getByRole("button", { name: /reset filters/i })).toBeDefined();
+  });
+});

--- a/features/submissions/ui/filters/submissions-filter-toolbar.tsx
+++ b/features/submissions/ui/filters/submissions-filter-toolbar.tsx
@@ -7,8 +7,10 @@ import { FacetedFilter } from "./faceted-filter";
 interface SubmissionsFilterToolbarProps {
   isCompleteFilter: Set<string>;
   statusFilter: Set<string>;
+  testSubmissionFilter: Set<string>;
   onIsCompleteChange: (values: Set<string>) => void;
   onStatusChange: (values: Set<string>) => void;
+  onTestSubmissionChange: (values: Set<string>) => void;
   onResetFilters: () => void;
 }
 
@@ -23,14 +25,22 @@ const statusOptions = [
   { label: "Approved", value: "approved", icon: CheckSquare },
 ];
 
+const testSubmissionOptions = [
+  { label: "Production", value: "false" },
+  { label: "Test", value: "true" },
+];
+
 export function SubmissionsFilterToolbar({
   isCompleteFilter,
   statusFilter,
+  testSubmissionFilter,
   onIsCompleteChange,
   onStatusChange,
+  onTestSubmissionChange,
   onResetFilters,
 }: SubmissionsFilterToolbarProps) {
-  const hasActiveFilters = isCompleteFilter.size > 0 || statusFilter.size > 0;
+  const hasActiveFilters =
+    isCompleteFilter.size > 0 || statusFilter.size > 0 || testSubmissionFilter.size > 0;
 
   return (
     <div className="flex items-center gap-2">
@@ -45,6 +55,12 @@ export function SubmissionsFilterToolbar({
         options={statusOptions}
         selectedValues={statusFilter}
         onValueChange={onStatusChange}
+      />
+      <FacetedFilter
+        title="Submission Type"
+        options={testSubmissionOptions}
+        selectedValues={testSubmissionFilter}
+        onValueChange={onTestSubmissionChange}
       />
       {hasActiveFilters && (
         <Button variant="ghost" onClick={onResetFilters} className="px-2 lg:px-3">

--- a/lib/endatix-api/forms/types.ts
+++ b/lib/endatix-api/forms/types.ts
@@ -6,6 +6,8 @@ export interface UpdateFormRequest {
   name?: string;
   isEnabled?: boolean;
   isPublic?: boolean;
+  limitOnePerUser?: boolean;
+  metadata?: string | null;
   themeId?: string | null;
   webHookSettingsJson?: string;
 }

--- a/lib/endatix-api/submissions/submissions.ts
+++ b/lib/endatix-api/submissions/submissions.ts
@@ -170,6 +170,7 @@ export class Submissions {
     filters?: {
       isComplete?: string[];
       status?: string[];
+      isTestSubmission?: string[];
     },
   ): Promise<ApiResult<Submission[]>> {
     const validateFormIdResult = validateEndatixId(formId, "formId");
@@ -185,6 +186,12 @@ export class Submissions {
     }
     if (filters?.status && filters.status.length > 0) {
       params.append("filter", `status:${filters.status.join("|")}`);
+    }
+    if (filters?.isTestSubmission && filters.isTestSubmission.length > 0) {
+      params.append(
+        "filter",
+        `isTestSubmission:${filters.isTestSubmission.join("|")}`,
+      );
     }
 
     const queryString = params.toString();

--- a/lib/endatix-api/submissions/types.ts
+++ b/lib/endatix-api/submissions/types.ts
@@ -33,6 +33,7 @@ export interface Submission extends ApiEntity {
   formId: EntityId;
   formDefinitionId: EntityId;
   isComplete: boolean;
+  isTestSubmission?: boolean;
   jsonData: JsonData;
   currentPage: number;
   metadata: JsonData;
@@ -117,6 +118,7 @@ export type ExportSubmissionsResponse = ApiResult<Response>;
 export interface SubmissionQuery extends PaginationQuery {
   status?: SubmissionStatus;
   isComplete?: boolean;
+  isTestSubmission?: boolean;
   dateRange?: {
     from: Date;
     to: Date;

--- a/services/api.ts
+++ b/services/api.ts
@@ -96,6 +96,8 @@ export const updateForm = async (
     name?: string;
     isEnabled?: boolean;
     isPublic?: boolean;
+    limitOnePerUser?: boolean;
+    metadata?: string | null;
     themeId?: string;
     webHookSettingsJson?: string | null;
   },
@@ -520,6 +522,7 @@ export const getSubmissions = async (
   filters?: {
     isComplete?: string[];
     status?: string[];
+    isTestSubmission?: string[];
   }
 ): Promise<Submission[]> => {
   const session = await getSession();
@@ -538,6 +541,9 @@ export const getSubmissions = async (
   }
   if (filters?.status && filters.status.length > 0) {
     params.append("filter", `status:${filters.status.join("|")}`);
+  }
+  if (filters?.isTestSubmission && filters.isTestSubmission.length > 0) {
+    params.append("filter", `isTestSubmission:${filters.isTestSubmission.join("|")}`);
   }
 
   const url = `${API_BASE_URL}/forms/${formId}/submissions?${params.toString()}`;

--- a/types/index.ts
+++ b/types/index.ts
@@ -4,6 +4,8 @@ export type Form = {
   description?: string;
   isEnabled: boolean;
   isPublic: boolean;
+  limitOnePerUser?: boolean;
+  metadata?: string;
   createdAt: Date;
   modifiedAt?: Date;
   submissionsCount?: number;


### PR DESCRIPTION
## Description
- Added admin UI for enabling “one response per person” on private forms.
- Added irreversible enablement warning dialog explaining:
  - each signed-in person can submit once
  - the setting is permanent
  - the form cannot be made public afterward
- Disabled visibility changes after single-submission mode is enabled.
- Disabled single-submission enablement for public forms and added explanatory UI/tooltips.
- Added dismiss-required error dialog when enabling fails, showing the backend conflict reason.
- Added already-responded public form state for `/share` and `/embed`.
- Preserved token-edit and existing draft flows so they do not incorrectly show already-responded.
- Added configurable already-responded title/message via form metadata.
- Added submission type filtering for production vs test submissions.
- Added/updated tests for form details, share/embed gating, already-responded UI, and submission filters.

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/580

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="700" alt="Screenshot 2026-04-30 170810" src="https://github.com/user-attachments/assets/edf47f16-c653-4b31-9f37-5d48a1b62dcd" />
<img width="600" alt="Screenshot 2026-04-30 171526" src="https://github.com/user-attachments/assets/df69b8cb-cf97-4cee-996c-4d3d65a47382" />
<img width="700" alt="Screenshot 2026-04-30 171850" src="https://github.com/user-attachments/assets/062d9d78-f1e1-4dea-a3a2-a261a083a415" />
<img width="600"  alt="Screenshot 2026-04-30 171924" src="https://github.com/user-attachments/assets/94c146ab-ff19-415f-8f84-828a1625ed2d" />
<img width="600"  alt="Screenshot 2026-04-30 174608" src="https://github.com/user-attachments/assets/84bb05d4-223f-4631-97c9-4eed9ce62f0f" />
