### PR TITLE
fix: Ensure create dialog closes before opening delete dialog

### DIFF
--- a/features/data-lists/view-lists/ui/data-list-row-actions.tsx
+++ b/features/data-lists/view-lists/ui/data-list-row-actions.tsx
@@ -43,7 +43,10 @@ export function DataListRowActions({
         </DropdownMenuItem>
         <DropdownMenuItem
           className="text-destructive focus:text-destructive"
-          onClick={() => onDelete(dataList)}
+          onSelect={(event) => {
+            event.preventDefault();
+            onDelete(dataList);
+          }}
         >
           <Trash2 className="mr-2 h-4 w-4" />
           Delete

--- a/features/data-lists/view-lists/ui/data-lists-page.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-page.tsx
@@ -50,9 +50,7 @@ export function DataListsPage({
   const [isLoadingDependencies, startDependenciesTransition] = useTransition();
 
   useEffect(() => {
-    if (openCreateOnLoad) {
-      setIsCreateDialogOpen(true);
-    }
+    setIsCreateDialogOpen(openCreateOnLoad);
   }, [openCreateOnLoad]);
 
   const refreshDataLists = async () => {
@@ -66,6 +64,9 @@ export function DataListsPage({
   };
 
   const handleOpenDelete = (dataList: DataList) => {
+    setIsCreateDialogOpen(false);
+    router.replace("/data-lists");
+
     setSelectedForDelete(dataList);
     setDependencies([]);
     setIsDeleteBlocked(false);
@@ -111,7 +112,7 @@ export function DataListsPage({
   const handleCreateDialogClose = (open: boolean) => {
     setIsCreateDialogOpen(open);
     if (!open) {
-      router.push("/data-lists");
+      router.replace("/data-lists");
     }
   };
 


### PR DESCRIPTION
# fix: Ensure create dialog closes before opening delete dialog

## Description
- Add explicit commands to close the create dialog and reset the route to list view when we open delete dialog
- 
## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/591

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.