### PR TITLE
feat: Maintenance page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,7 +119,6 @@ NEXT_PUBLIC_NAME=
 # [OPTIONAL] List of allowed domains with app.endatix.com robots.txt behavior (User-agent: *, Allow: /login, Disallow: /). Comma-separated list.
 ROBOTS_ALLOWED_DOMAINS=app.endatix.com
 
-
 # Maintenance
 ############################
 # [OPTIONAL] Set to true to enable maintenance mode.

--- a/.env.example
+++ b/.env.example
@@ -118,3 +118,28 @@ NEXT_PUBLIC_NAME=
 ############################
 # [OPTIONAL] List of allowed domains with app.endatix.com robots.txt behavior (User-agent: *, Allow: /login, Disallow: /). Comma-separated list.
 ROBOTS_ALLOWED_DOMAINS=app.endatix.com
+
+
+# Maintenance
+############################
+# [OPTIONAL] Set to true to enable maintenance mode.
+MAINTENANCE_MODE=false
+# [OPTIONAL] The retry after seconds for the maintenance mode.
+MAINTENANCE_RETRY_AFTER_SECONDS=600
+
+# Override if you want different text on the maintenance page. Default values are on lib/maintenance/maintenance-config.ts
+
+# [OPTIONAL] The badge label for the maintenance mode.
+MAINTENANCE_BADGE_LABEL=
+# [OPTIONAL] The title for the maintenance mode.
+MAINTENANCE_TITLE=
+# [OPTIONAL] The card description for the maintenance mode.
+MAINTENANCE_CARD_DESCRIPTION=
+# [OPTIONAL] Main body copy on the maintenance page.
+MAINTENANCE_BODY=
+# [OPTIONAL] Footer line on the maintenance page.
+MAINTENANCE_FOOTER=
+# [OPTIONAL] HTML document title while maintenance mode is on.
+MAINTENANCE_METADATA_TITLE=
+# [OPTIONAL] Meta description for the maintenance page.
+MAINTENANCE_METADATA_DESCRIPTION=

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -1,11 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Session } from "next-auth";
-import { NextMiddleware, NextRequest, NextResponse } from "next/server";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextProxy, NextRequest, NextResponse } from "next/server";
 import {
   SIGNIN_PATH,
   RETURN_URL_PARAM,
 } from "@/features/auth/infrastructure/auth-constants";
-import { ProxySession, shouldRedirectToLogin } from "@/proxy";
+import { shouldRedirectToLogin } from "@/proxy";
 
 vi.mock("@/auth", () => ({
   auth: vi.fn(),
@@ -32,7 +31,7 @@ describe("proxy", () => {
   describe("auth routes", () => {
     it("should allow /signin without session", async () => {
       const { auth } = await import("@/auth");
-      vi.mocked(auth).mockResolvedValue(null as unknown as NextMiddleware);
+      vi.mocked(auth).mockResolvedValue(null as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/signin");
@@ -45,7 +44,7 @@ describe("proxy", () => {
 
     it("should allow /create-account without session", async () => {
       const { auth } = await import("@/auth");
-      vi.mocked(auth).mockResolvedValue(null as unknown as NextMiddleware);
+      vi.mocked(auth).mockResolvedValue(null as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/create-account");
@@ -56,7 +55,7 @@ describe("proxy", () => {
 
     it("should allow /auth-error without session", async () => {
       const { auth } = await import("@/auth");
-      vi.mocked(auth).mockResolvedValue(null as unknown as NextMiddleware);
+      vi.mocked(auth).mockResolvedValue(null as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/auth-error");
@@ -69,7 +68,7 @@ describe("proxy", () => {
   describe("hub paths without session", () => {
     it("should redirect to signin when accessing /forms without session", async () => {
       const { auth } = await import("@/auth");
-      vi.mocked(auth).mockResolvedValue(null as unknown as NextMiddleware);
+      vi.mocked(auth).mockResolvedValue(null as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/forms");
@@ -86,7 +85,7 @@ describe("proxy", () => {
 
     it("should redirect to signin when accessing /settings without session", async () => {
       const { auth } = await import("@/auth");
-      vi.mocked(auth).mockResolvedValue(null as unknown as NextMiddleware);
+      vi.mocked(auth).mockResolvedValue(null as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/settings");
@@ -100,7 +99,7 @@ describe("proxy", () => {
 
     it("should redirect to signin when accessing /my-account without session", async () => {
       const { auth } = await import("@/auth");
-      vi.mocked(auth).mockResolvedValue(null as unknown as NextMiddleware);
+      vi.mocked(auth).mockResolvedValue(null as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/my-account");
@@ -118,7 +117,7 @@ describe("proxy", () => {
         user: { id: "u1", email: "a@b.com" },
         error: "AccessDenied",
         expires: "2025-01-01",
-      } as unknown as NextMiddleware);
+      } as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/forms");
@@ -135,7 +134,7 @@ describe("proxy", () => {
       vi.mocked(auth).mockResolvedValue({
         user: { id: "u1", email: "a@b.com" },
         expires: "2025-01-01",
-      } as unknown as NextMiddleware);
+      } as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/forms");
@@ -149,7 +148,7 @@ describe("proxy", () => {
       vi.mocked(auth).mockResolvedValue({
         user: { id: "u1", email: "a@b.com" },
         expires: "2025-01-01",
-      } as unknown as NextMiddleware);
+      } as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/forms/abc-123");
@@ -162,7 +161,7 @@ describe("proxy", () => {
   describe("redirectToLogin behavior", () => {
     it("should include search params in returnUrl when redirecting from hub path", async () => {
       const { auth } = await import("@/auth");
-      vi.mocked(auth).mockResolvedValue(null as unknown as NextMiddleware);
+      vi.mocked(auth).mockResolvedValue(null as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/forms", "tab=submissions");
@@ -177,7 +176,7 @@ describe("proxy", () => {
   describe("non-auth, non-hub paths", () => {
     it("should allow request when path is / (root is not a hub path)", async () => {
       const { auth } = await import("@/auth");
-      vi.mocked(auth).mockResolvedValue(null as unknown as NextMiddleware);
+      vi.mocked(auth).mockResolvedValue(null as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/");
@@ -208,6 +207,39 @@ describe("proxy", () => {
       expect(Array.isArray(config.matcher)).toBe(true);
       expect(config.matcher[0]).toHaveProperty("source");
       expect(config.matcher[0]).toHaveProperty("missing");
+    });
+  });
+
+  describe("maintenance mode", () => {
+    beforeEach(async () => {
+      vi.stubEnv("MAINTENANCE_MODE", "true");
+      const { auth } = await import("@/auth");
+      vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("should rewrite with 503 and not call auth", async () => {
+      const { auth } = await import("@/auth");
+      const proxy = await getProxy();
+      const response = await proxy(createRequest("/forms"));
+
+      expect(auth).not.toHaveBeenCalled();
+      expect(response.status).toBe(503);
+      expect(response.headers.get("location")).toBeNull();
+    });
+
+    it("should set Retry-After when MAINTENANCE_RETRY_AFTER_SECONDS is valid", async () => {
+      vi.stubEnv("MAINTENANCE_RETRY_AFTER_SECONDS", "600");
+      const { auth } = await import("@/auth");
+      const proxy = await getProxy();
+      const response = await proxy(createRequest("/"));
+
+      expect(auth).not.toHaveBeenCalled();
+      expect(response.status).toBe(503);
+      expect(response.headers.get("Retry-After")).toBe("600");
     });
   });
 });

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,20 +1,9 @@
 import "@/app/globals.css";
-import Image from "next/image";
-import localFont from "next/font/local";
-import { AppProvider } from "@/components/providers";
-import { Metadata } from "next";
 import { auth } from "@/auth";
-
-const geistSans = localFont({
-  src: "../../public/fonts/GeistVF.woff",
-  variable: "--font-geist-sans",
-  weight: "100 900",
-});
-const geistMono = localFont({
-  src: "../../public/fonts/GeistMonoVF.woff",
-  variable: "--font-geist-mono",
-  weight: "100 900",
-});
+import { AppProvider } from "@/components/providers";
+import { geistMono, geistSans } from "@/lib/fonts/geist-local";
+import Image from "next/image";
+import { Metadata } from "next";
 
 interface AuthLayoutProps {
   children: React.ReactNode;
@@ -49,18 +38,18 @@ export default async function AuthLayout({ children }: AuthLayoutProps) {
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <AppProvider session={session}>
-          <div className="h-screen w-full bg-muted/40 overflow-hidden">
-            <main className="h-full grid lg:grid-cols-2 p-6">
+          <div className="h-screen w-full overflow-hidden bg-muted/40">
+            <main className="grid h-full p-6 lg:grid-cols-2">
               <div className="flex items-center justify-center">
                 <div className="w-[400px] space-y-6">{children}</div>
               </div>
-              <div className="hidden lg:flex items-center justify-center">
+              <div className="hidden items-center justify-center lg:flex">
                 <Image
                   src="/assets/lines-and-stuff.svg"
                   alt="Lines and dots pattern"
                   width="600"
                   height="600"
-                  className="w-auto h-[60%] max-w-full max-h-full object-contain dark:brightness-[0.6] dark:grayscale"
+                  className="h-[60%] max-h-full w-auto max-w-full object-contain dark:brightness-[0.6] dark:grayscale"
                 />
               </div>
             </main>

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,21 +1,10 @@
 import "@/app/globals.css";
 import { auth } from "@/auth";
 import { AppProvider } from "@/components/providers";
+import { geistMono, geistSans } from "@/lib/fonts/geist-local";
 import { getOsClass } from "@/lib/utils/next-utils";
 import { Metadata } from "next";
-import localFont from "next/font/local";
 import { cookies, headers } from "next/headers";
-
-const geistSans = localFont({
-  src: "../../public/fonts/GeistVF.woff",
-  variable: "--font-geist-sans",
-  weight: "100 900",
-});
-const geistMono = localFont({
-  src: "../../public/fonts/GeistMonoVF.woff",
-  variable: "--font-geist-mono",
-  weight: "100 900",
-});
 
 export const metadata: Metadata = {
   title: "Endatix Hub",

--- a/app/(public)/maintenance/layout.tsx
+++ b/app/(public)/maintenance/layout.tsx
@@ -1,20 +1,9 @@
 import "@/app/globals.css";
 import { AppProvider } from "@/components/providers";
+import { geistMono, geistSans } from "@/lib/fonts/geist-local";
 import { getOsClass } from "@/lib/utils/next-utils";
 import { Metadata } from "next";
-import localFont from "next/font/local";
 import { headers } from "next/headers";
-
-const geistSans = localFont({
-  src: "../../../public/fonts/GeistVF.woff",
-  variable: "--font-geist-sans",
-  weight: "100 900",
-});
-const geistMono = localFont({
-  src: "../../../public/fonts/GeistMonoVF.woff",
-  variable: "--font-geist-mono",
-  weight: "100 900",
-});
 
 const appOptions = {
   enableTheme: true,

--- a/app/(public)/maintenance/layout.tsx
+++ b/app/(public)/maintenance/layout.tsx
@@ -1,6 +1,9 @@
 import "@/app/globals.css";
+import { AppProvider } from "@/components/providers";
+import { getOsClass } from "@/lib/utils/next-utils";
 import { Metadata } from "next";
 import localFont from "next/font/local";
+import { headers } from "next/headers";
 
 const geistSans = localFont({
   src: "../../../public/fonts/GeistVF.woff",
@@ -13,22 +16,39 @@ const geistMono = localFont({
   weight: "100 900",
 });
 
+const appOptions = {
+  enableTheme: true,
+  enableAnalytics: false,
+  enableSession: false,
+  enableToaster: false,
+  enableSidebar: false,
+};
+
 export const metadata: Metadata = {
   title: "Endatix",
   description: "Customizable form management platform",
 };
 
-export default function PublicLayout({
+export default async function PublicLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const requestHeaders = await headers();
+  const osClass = getOsClass(requestHeaders);
+
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html
+      lang="en"
+      className={`${geistSans.variable} ${geistMono.variable} ${osClass}`}
+      suppressHydrationWarning
+    >
       <head>
         <link rel="icon" href="/assets/icons/icon.svg" type="image/svg+xml" />
       </head>
-      <body>{children}</body>
+      <body>
+        <AppProvider options={appOptions}>{children}</AppProvider>
+      </body>
     </html>
   );
 }

--- a/app/(public)/maintenance/layout.tsx
+++ b/app/(public)/maintenance/layout.tsx
@@ -1,0 +1,34 @@
+import "@/app/globals.css";
+import { Metadata } from "next";
+import localFont from "next/font/local";
+
+const geistSans = localFont({
+  src: "../../../public/fonts/GeistVF.woff",
+  variable: "--font-geist-sans",
+  weight: "100 900",
+});
+const geistMono = localFont({
+  src: "../../../public/fonts/GeistMonoVF.woff",
+  variable: "--font-geist-mono",
+  weight: "100 900",
+});
+
+export const metadata: Metadata = {
+  title: "Endatix",
+  description: "Customizable form management platform",
+};
+
+export default function PublicLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
+      <head>
+        <link rel="icon" href="/assets/icons/icon.svg" type="image/svg+xml" />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/(public)/maintenance/not-found.tsx
+++ b/app/(public)/maintenance/not-found.tsx
@@ -3,11 +3,16 @@ import "@/components/error-handling/not-found/not-found-styles-standalone.css";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "404 - Form Not Found",
-  description: "The form you are requesting does not exist.",
+  title: "404 - Page Not Found",
+  description: "The page you are looking for does not exist.",
+  generator: "Endatix",
+  robots: {
+    index: false,
+    follow: false,
+  },
 };
 
-export default function NotFoundSharedForm() {
+export default function NotFoundMaintenancePage() {
   return (
     <div className="not-found-container">
       <NotFoundComponent

--- a/app/(public)/maintenance/not-found.tsx
+++ b/app/(public)/maintenance/not-found.tsx
@@ -1,0 +1,21 @@
+import { NotFoundComponent } from "@/components/error-handling/not-found";
+import "@/components/error-handling/not-found/not-found-styles-standalone.css";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "404 - Form Not Found",
+  description: "The form you are requesting does not exist.",
+};
+
+export default function NotFoundSharedForm() {
+  return (
+    <div className="not-found-container">
+      <NotFoundComponent
+        notFoundTitle="404"
+        notFoundSubtitle="The page you are looking for does not exist."
+        notFoundMessage="Please check the URL and try again."
+        titleSize="large"
+      ></NotFoundComponent>
+    </div>
+  );
+}

--- a/app/(public)/maintenance/page.tsx
+++ b/app/(public)/maintenance/page.tsx
@@ -1,0 +1,77 @@
+import { Construction } from "lucide-react";
+import type { Metadata } from "next";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import {
+  getMaintenanceData,
+  isMaintenanceMode,
+} from "@/lib/maintenance/maintenance-config";
+import { notFound } from "next/navigation";
+
+export async function generateMetadata(): Promise<Metadata> {
+  if (!isMaintenanceMode()) {
+    return {
+      title: "404 - Page Not Found",
+      description: "The page you are looking for does not exist.",
+      generator: "Endatix",
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
+
+  const data = getMaintenanceData();
+  return {
+    title: data.metadataTitle,
+    description: data.metadataDescription,
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
+
+export default function MaintenancePage() {
+  if (!isMaintenanceMode()) {
+    notFound();
+  }
+
+  const data = getMaintenanceData();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-4 md:p-8">
+      <Card className="w-full max-w-xl border-primary/20 shadow-lg">
+        <CardHeader className="flex flex-col items-center gap-4 pb-4 text-center">
+          <Badge variant="secondary">{data.badgeLabel}</Badge>
+          <div className="flex size-20 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <Construction className="size-10" aria-hidden />
+          </div>
+          <CardTitle className="text-3xl tracking-tight md:text-4xl">
+            {data.title}
+          </CardTitle>
+          <CardDescription className="max-w-prose text-base">
+            {data.cardDescription}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center gap-6 text-center">
+          <p className="max-w-prose text-muted-foreground">{data.body}</p>
+
+          <Separator />
+
+          <p className="max-w-prose text-sm text-muted-foreground">
+            {data.footer}
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(public)/maintenance/page.tsx
+++ b/app/(public)/maintenance/page.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/lib/maintenance/maintenance-config";
 import { notFound } from "next/navigation";
 
-export async function generateMetadata(): Promise<Metadata> {
+export function generateMetadata(): Metadata {
   if (!isMaintenanceMode()) {
     return {
       title: "404 - Page Not Found",

--- a/app/unauthorized/layout.tsx
+++ b/app/unauthorized/layout.tsx
@@ -1,19 +1,8 @@
 import "@/app/globals.css";
-import type { Metadata } from "next";
-import localFont from "next/font/local";
-import { AppProvider } from "@/components/providers";
 import { auth } from "@/auth";
-
-const geistSans = localFont({
-  src: "../../public/fonts/GeistVF.woff",
-  variable: "--font-geist-sans",
-  weight: "100 900",
-});
-const geistMono = localFont({
-  src: "../../public/fonts/GeistMonoVF.woff",
-  variable: "--font-geist-mono",
-  weight: "100 900",
-});
+import { AppProvider } from "@/components/providers";
+import { geistMono, geistSans } from "@/lib/fonts/geist-local";
+import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Endatix Hub - Error",
@@ -51,7 +40,7 @@ export default async function UnauthorizedLayout({
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <AppProvider session={session}>
           <div className="flex min-h-screen w-full flex-row bg-muted/40">
-            <main className="flex-1 flex flex-col p-6">{children}</main>
+            <main className="flex flex-1 flex-col p-6">{children}</main>
           </div>
         </AppProvider>
       </body>

--- a/env.d.ts
+++ b/env.d.ts
@@ -64,7 +64,19 @@ declare namespace NodeJS {
     NEXT_PUBLIC_POSTHOG_HOST?: string;
     NEXT_PUBLIC_POSTHOG_UI_HOST?: string;
     ENABLE_POSTHOG_ADAPTER?: string;
+    
     // Application settings
     NEXT_PUBLIC_IS_DEBUG_MODE?: string; // Application-level debug flag
+
+     // Hub maintenance (see docs — proxy rewrite + /maintenance page)
+     MAINTENANCE_MODE?: string;
+     MAINTENANCE_RETRY_AFTER_SECONDS?: string;
+     MAINTENANCE_BADGE_LABEL?: string;
+     MAINTENANCE_TITLE?: string;
+     MAINTENANCE_CARD_DESCRIPTION?: string;
+     MAINTENANCE_BODY?: string;
+     MAINTENANCE_FOOTER?: string;
+     MAINTENANCE_METADATA_TITLE?: string;
+     MAINTENANCE_METADATA_DESCRIPTION?: string;
   }
 }

--- a/env.d.ts
+++ b/env.d.ts
@@ -6,7 +6,7 @@ declare namespace NodeJS {
     ROBOTS_ALLOWED_DOMAINS?: string;
     ENDATIX_BASE_URL?: string;
     AI_API_BASE_URL?: string;
- 
+
     // Experimental features
     ENDATIX_ENABLE_EXTENSIONS?: string;
 
@@ -64,19 +64,19 @@ declare namespace NodeJS {
     NEXT_PUBLIC_POSTHOG_HOST?: string;
     NEXT_PUBLIC_POSTHOG_UI_HOST?: string;
     ENABLE_POSTHOG_ADAPTER?: string;
-    
+
     // Application settings
     NEXT_PUBLIC_IS_DEBUG_MODE?: string; // Application-level debug flag
 
-     // Hub maintenance (see docs — proxy rewrite + /maintenance page)
-     MAINTENANCE_MODE?: string;
-     MAINTENANCE_RETRY_AFTER_SECONDS?: string;
-     MAINTENANCE_BADGE_LABEL?: string;
-     MAINTENANCE_TITLE?: string;
-     MAINTENANCE_CARD_DESCRIPTION?: string;
-     MAINTENANCE_BODY?: string;
-     MAINTENANCE_FOOTER?: string;
-     MAINTENANCE_METADATA_TITLE?: string;
-     MAINTENANCE_METADATA_DESCRIPTION?: string;
+    // Hub maintenance (see docs — proxy rewrite + /maintenance page)
+    MAINTENANCE_MODE?: string;
+    MAINTENANCE_RETRY_AFTER_SECONDS?: string;
+    MAINTENANCE_BADGE_LABEL?: string;
+    MAINTENANCE_TITLE?: string;
+    MAINTENANCE_CARD_DESCRIPTION?: string;
+    MAINTENANCE_BODY?: string;
+    MAINTENANCE_FOOTER?: string;
+    MAINTENANCE_METADATA_TITLE?: string;
+    MAINTENANCE_METADATA_DESCRIPTION?: string;
   }
 }

--- a/lib/fonts/geist-local.ts
+++ b/lib/fonts/geist-local.ts
@@ -1,0 +1,13 @@
+import localFont from "next/font/local";
+
+export const geistSans = localFont({
+  src: "../../public/fonts/GeistVF.woff",
+  variable: "--font-geist-sans",
+  weight: "100 900",
+});
+
+export const geistMono = localFont({
+  src: "../../public/fonts/GeistMonoVF.woff",
+  variable: "--font-geist-mono",
+  weight: "100 900",
+});

--- a/lib/maintenance/__tests__/maintenance-config.test.ts
+++ b/lib/maintenance/__tests__/maintenance-config.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  getMaintenanceData,
+  getMaintenanceRetryAfterSeconds,
+  isMaintenanceMode,
+} from "../maintenance-config";
+
+describe("isMaintenanceMode", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns true only when MAINTENANCE_MODE is the string true", () => {
+    vi.stubEnv("MAINTENANCE_MODE", "true");
+    expect(isMaintenanceMode()).toBe(true);
+  });
+
+  it("returns false when unset, empty, or any other value", () => {
+    vi.unstubAllEnvs();
+    expect(isMaintenanceMode()).toBe(false);
+
+    vi.stubEnv("MAINTENANCE_MODE", "");
+    expect(isMaintenanceMode()).toBe(false);
+
+    vi.stubEnv("MAINTENANCE_MODE", "false");
+    expect(isMaintenanceMode()).toBe(false);
+
+    vi.stubEnv("MAINTENANCE_MODE", "1");
+    expect(isMaintenanceMode()).toBe(false);
+  });
+});
+
+describe("getMaintenanceRetryAfterSeconds", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns undefined when unset or empty", () => {
+    vi.unstubAllEnvs();
+    expect(getMaintenanceRetryAfterSeconds()).toBeUndefined();
+
+    vi.stubEnv("MAINTENANCE_RETRY_AFTER_SECONDS", "");
+    expect(getMaintenanceRetryAfterSeconds()).toBeUndefined();
+  });
+
+  it("returns non-negative integers when valid", () => {
+    vi.stubEnv("MAINTENANCE_RETRY_AFTER_SECONDS", "0");
+    expect(getMaintenanceRetryAfterSeconds()).toBe(0);
+
+    vi.stubEnv("MAINTENANCE_RETRY_AFTER_SECONDS", "600");
+    expect(getMaintenanceRetryAfterSeconds()).toBe(600);
+  });
+
+  it("returns undefined for negative or non-finite values", () => {
+    vi.stubEnv("MAINTENANCE_RETRY_AFTER_SECONDS", "-1");
+    expect(getMaintenanceRetryAfterSeconds()).toBeUndefined();
+
+    vi.stubEnv("MAINTENANCE_RETRY_AFTER_SECONDS", "not-a-number");
+    expect(getMaintenanceRetryAfterSeconds()).toBeUndefined();
+  });
+});
+
+describe("getMaintenanceData", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns default copy when maintenance env vars are unset", () => {
+    vi.unstubAllEnvs();
+    const data = getMaintenanceData();
+
+    expect(data.badgeLabel).toBe("Maintenance");
+    expect(data.title).toBe("We'll be right back");
+    expect(data.cardDescription).toBe(
+      "This application is temporarily unavailable.",
+    );
+    expect(data.body).toContain("scheduled maintenance");
+    expect(data.footer).toBe("Thank you for your patience.");
+    expect(data.metadataTitle).toBe("Scheduled maintenance - Endatix Hub");
+    expect(data.metadataDescription).toContain("temporarily unavailable");
+  });
+
+  it("uses env overrides when set", () => {
+    vi.stubEnv("MAINTENANCE_BADGE_LABEL", "Down");
+    vi.stubEnv("MAINTENANCE_TITLE", "Custom title");
+    vi.stubEnv("MAINTENANCE_CARD_DESCRIPTION", "Card");
+    vi.stubEnv("MAINTENANCE_BODY", "Body");
+    vi.stubEnv("MAINTENANCE_FOOTER", "Foot");
+    vi.stubEnv("MAINTENANCE_METADATA_TITLE", "Meta title");
+    vi.stubEnv("MAINTENANCE_METADATA_DESCRIPTION", "Meta desc");
+
+    const data = getMaintenanceData();
+
+    expect(data).toEqual({
+      badgeLabel: "Down",
+      title: "Custom title",
+      cardDescription: "Card",
+      body: "Body",
+      footer: "Foot",
+      metadataTitle: "Meta title",
+      metadataDescription: "Meta desc",
+    });
+  });
+
+  it("treats empty string as missing and falls back to default for that field", () => {
+    vi.stubEnv("MAINTENANCE_TITLE", "");
+    vi.stubEnv("MAINTENANCE_BODY", "Only body override");
+
+    const data = getMaintenanceData();
+
+    expect(data.title).toBe("We'll be right back");
+    expect(data.body).toBe("Only body override");
+  });
+});

--- a/lib/maintenance/__tests__/maintenance-response.test.ts
+++ b/lib/maintenance/__tests__/maintenance-response.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { rewriteToMaintenance } from "../maintenance-response";
+
+const BASE_URL = "https://example.com";
+
+function createRequest(pathname: string, search = ""): NextRequest {
+  const url = `${BASE_URL}${pathname}${search ? `?${search}` : ""}`;
+  return new NextRequest(url);
+}
+
+describe("rewriteToMaintenance", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 503 without Retry-After when env retry seconds are unset", () => {
+    vi.stubEnv("MAINTENANCE_RETRY_AFTER_SECONDS", "");
+    const response = rewriteToMaintenance(createRequest("/forms", "x=1"));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBeNull();
+  });
+
+  it("sets Retry-After when MAINTENANCE_RETRY_AFTER_SECONDS is valid", () => {
+    vi.stubEnv("MAINTENANCE_RETRY_AFTER_SECONDS", "120");
+    const response = rewriteToMaintenance(createRequest("/"));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("120");
+  });
+});

--- a/lib/maintenance/maintenance-config.ts
+++ b/lib/maintenance/maintenance-config.ts
@@ -1,0 +1,76 @@
+/**
+ * Maintenance mode page data — env-backed with safe defaults (server-only usage).
+ */
+
+export type MaintenancePageData = {
+  badgeLabel: string;
+  title: string;
+  cardDescription: string;
+  body: string;
+  footer: string;
+  metadataTitle: string;
+  metadataDescription: string;
+};
+
+const DEFAULT_COPY: MaintenancePageData = {
+  badgeLabel: "Maintenance",
+  title: "We'll be right back",
+  cardDescription: "This application is temporarily unavailable.",
+  body: "We're performing scheduled maintenance. Please check back soon. We apologize for the inconvenience.",
+  footer: "Thank you for your patience.",
+  metadataTitle: "Scheduled maintenance - Endatix Hub",
+  metadataDescription:
+    "The application is temporarily unavailable while we perform maintenance.",
+};
+
+function envOrDefault(key: string, fallback: string): string {
+  const value = process.env[key];
+  if (value === undefined || value === "") {
+    return fallback;
+  }
+  return value;
+}
+
+/** Reads env each call so tests can stub `MAINTENANCE_MODE` without reloading modules. */
+export function isMaintenanceMode(): boolean {
+  return process.env.MAINTENANCE_MODE === "true";
+}
+
+/**
+ * Optional non-negative integer for `Retry-After` (seconds). Invalid or unset → undefined.
+ */
+export function getMaintenanceRetryAfterSeconds(): number | undefined {
+  const raw = process.env.MAINTENANCE_RETRY_AFTER_SECONDS;
+  if (raw === undefined || raw === "") {
+    return undefined;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    return undefined;
+  }
+  return n;
+}
+
+export function getMaintenanceData(): MaintenancePageData {
+  return {
+    badgeLabel: envOrDefault(
+      "MAINTENANCE_BADGE_LABEL",
+      DEFAULT_COPY.badgeLabel,
+    ),
+    title: envOrDefault("MAINTENANCE_TITLE", DEFAULT_COPY.title),
+    cardDescription: envOrDefault(
+      "MAINTENANCE_CARD_DESCRIPTION",
+      DEFAULT_COPY.cardDescription,
+    ),
+    body: envOrDefault("MAINTENANCE_BODY", DEFAULT_COPY.body),
+    footer: envOrDefault("MAINTENANCE_FOOTER", DEFAULT_COPY.footer),
+    metadataTitle: envOrDefault(
+      "MAINTENANCE_METADATA_TITLE",
+      DEFAULT_COPY.metadataTitle,
+    ),
+    metadataDescription: envOrDefault(
+      "MAINTENANCE_METADATA_DESCRIPTION",
+      DEFAULT_COPY.metadataDescription,
+    ),
+  };
+}

--- a/lib/maintenance/maintenance-response.ts
+++ b/lib/maintenance/maintenance-response.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getMaintenanceRetryAfterSeconds } from "./maintenance-config";
+
+/**
+ * Rewrites eligible requests to `/maintenance` with 503 and optional `Retry-After`.
+ * API routes should be excluded from the middleware matcher — see `proxy.ts` config.
+ */
+export function rewriteToMaintenance(req: NextRequest): NextResponse {
+  const url = req.nextUrl.clone();
+  url.pathname = "/maintenance";
+  url.search = "";
+
+  const retryAfter = getMaintenanceRetryAfterSeconds();
+  const headers = new Headers();
+  if (retryAfter !== undefined) {
+    headers.set("Retry-After", String(retryAfter));
+  }
+
+  return NextResponse.rewrite(url, {
+    status: 503,
+    headers,
+  });
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,4 +1,6 @@
 import { auth } from "@/auth";
+import { isMaintenanceMode } from "@/lib/maintenance/maintenance-config";
+import { rewriteToMaintenance } from "@/lib/maintenance/maintenance-response";
 import { toSafeRelativeUrl } from "@/lib/utils/url-utils";
 import { NextRequest, NextResponse } from "next/server";
 import {
@@ -32,6 +34,10 @@ export function shouldRedirectToLogin(
 }
 
 export default async function proxy(request: NextRequest) {
+  if (isMaintenanceMode()) {
+    return rewriteToMaintenance(request);
+  }
+
   const session = await auth();
   const pathname = request.nextUrl.pathname;
 
@@ -46,20 +52,22 @@ export default async function proxy(request: NextRequest) {
  * Match all request paths except for the ones starting with:
  * - api (API routes)
  * - .swa (Azure static web apps)
+ * - ingest (PostHog proxy)
+ * - maintenance — the maintenance page (must bypass rewrite loop / auth)
+ * - share — the public share page
+ * - slack — the Slack integration page
+ * - assets — all files and folders served from the public folder
  * - _next/static (static files)
  * - _next/image (image optimization files)
  * - favicon.ico, sitemap.xml, robots.txt (metadata files)
- * - assets - all files and folders served from the public folder
- * - login - the login page
- * - create-account - the create account page
- * - ingest - the ingest proxy route for PostHog
- * - Note the the `missing: [{ type: 'header', key: 'next-action' }]` is to exclude server-actions
+ * - .well-known (ACME, security.txt, etc.)
+ * Note: `missing: [{ type: 'header', key: 'next-action' }]` excludes Server Actions.
  */
 export const config = {
   matcher: [
     {
       source:
-        "/((?!api|.swa|ingest|share|slack|assets|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|.well-known).*)",
+        "/((?!api|.swa|ingest|maintenance|share|slack|assets|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|.well-known).*)",
       missing: [{ type: "header", key: "next-action" }],
     },
   ],


### PR DESCRIPTION
# feat: Maintenance page

## Description
- Adds maintenance page
- Adds ability to edi tlabels
- Adds support for dark/light mode
- Adds tests

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/605

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="1208" height="924" alt="maintenance_light" src="https://github.com/user-attachments/assets/3f3f6335-db7e-4077-adec-a2d9eeac3520" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced maintenance mode that displays a customizable maintenance page when enabled via environment configuration.
  * HTTP 503 responses with optional Retry-After header support for guiding client retry behavior.
  * Customizable maintenance page content including badge label, title, description, body, and footer text.

* **Tests**
  * Added comprehensive test coverage for maintenance mode configuration and response handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/endatix/endatix-hub/pull/606)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->