### PR TITLE
chore: Bump SurveyJS to 2.5.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,11 +81,11 @@
     "semver": "^7.6.3",
     "sharp": "^0.34.2",
     "sonner": "^1.7.1",
-    "survey-analytics": "^2.5.18",
-    "survey-core": "^2.5.18",
-    "survey-creator-core": "^2.5.18",
-    "survey-creator-react": "^2.5.18",
-    "survey-react-ui": "^2.5.18",
+    "survey-analytics": "^2.5.24",
+    "survey-core": "^2.5.24",
+    "survey-creator-core": "^2.5.24",
+    "survey-creator-react": "^2.5.24",
+    "survey-react-ui": "^2.5.24",
     "tailwind-merge": "^3.4.1",
     "uuid": "^11.1.1",
     "vaul": "^1.1.2",
@@ -161,7 +161,7 @@
       "unrs-resolver"
     ],
     "comments": {
-      "overrides": "[@types/react] & [@types/react-dom] are managed by Next.js. |  [preact] 10.29.1 bump is to address CVE-2026-22028. Remove with better auth and next posthog-js bump | [fast-xml-parser] 5.7.0 bump is to address CVE-2026-25128, CVE-2026-27942, CVE-2026-33036, CVE-2026-33349 & CVE-2026-41650. Remove once we upgrade @azure/storage-blob | [fast-xml-builder] 1.1.7 to fix CVE-2026-44665. Remove with next @azure/storage-blob bump| [lodash] 4.18.0 bump is to address CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Multiple peer dependenices hold outdated versions | [lodash-es] 4.18.00 bump is to address CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Fix with quill & react-quill-new bump | [axios] 1.16.0 bump is to address 10+ CVEs. Remove when @flags-sdk/posthog is updated or removed | [minimatch] 10.2.4 bump is to address CVE-2026-27904. Remove with vitest 4x & eslint-config-next | [immutable] 5.1.5 bump is to address CVE-2026-29063. Multiple peer dependenices hold outdated versions. | [flatted] 3.4.2 bump is to address CVE-2026-33228. Remove with next vitest bump | [picomatch] 2.3.2 & 4.0.4 bump is to address CVE-2026-33671 & CVE-2026-33671. Multiple peer dependenices hold outdated versions. | [brace-expansion] 5.0.5 bump is to address CVE-2026-33750. Fix with new minimatch& eslintbump | [yaml] 2.8.3 bump is to address CVE-2026-33532 . Fix with vite bump | [vite] 7.3.2 bump is to address GHSA-4w7w-66w2-5vf9, GHSA-v2wj-q39q-566r & CVE-2026-39363. Fix with vitest bump | [follow-redirects] 1.16.0 bump is to address GHSA-r4q5-vmmm-2653. Remove with next Axios bump > 1.15.0 | [fast-uri] 3.1.2 bump to adress CVE-2026-6321 & CVE-2026-6322. Remove on next shadcn bump | [postcss] Bump to 8.5.10 to address CVE-2026-41305. Remove with removal of next-auth if possible | [hono] bump to 4.12.18 is to address CVE-2026-44457, CVE-2026-44455, CVE-2026-44458 & CVE-2026-44459. Remove with next shadcn bump | [ip-address] bump to 10.1.1 is to fix CVE-2026-42338. Remove on the next shadcn bump" 
+      "overrides": "[@types/react] & [@types/react-dom] are managed by Next.js. |  [preact] 10.29.1 bump is to address CVE-2026-22028. Remove with better auth and next posthog-js bump | [fast-xml-parser] 5.7.0 bump is to address CVE-2026-25128, CVE-2026-27942, CVE-2026-33036, CVE-2026-33349 & CVE-2026-41650. Remove once we upgrade @azure/storage-blob | [fast-xml-builder] 1.1.7 to fix CVE-2026-44665. Remove with next @azure/storage-blob bump| [lodash] 4.18.0 bump is to address CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Multiple peer dependenices hold outdated versions | [lodash-es] 4.18.00 bump is to address CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Fix with quill & react-quill-new bump | [axios] 1.16.0 bump is to address 10+ CVEs. Remove when @flags-sdk/posthog is updated or removed | [minimatch] 10.2.4 bump is to address CVE-2026-27904. Remove with vitest 4x & eslint-config-next | [immutable] 5.1.5 bump is to address CVE-2026-29063. Multiple peer dependenices hold outdated versions. | [flatted] 3.4.2 bump is to address CVE-2026-33228. Remove with next vitest bump | [picomatch] 2.3.2 & 4.0.4 bump is to address CVE-2026-33671 & CVE-2026-33671. Multiple peer dependenices hold outdated versions. | [brace-expansion] 5.0.5 bump is to address CVE-2026-33750. Fix with new minimatch& eslintbump | [yaml] 2.8.3 bump is to address CVE-2026-33532 . Fix with vite bump | [vite] 7.3.2 bump is to address GHSA-4w7w-66w2-5vf9, GHSA-v2wj-q39q-566r & CVE-2026-39363. Fix with vitest bump | [follow-redirects] 1.16.0 bump is to address GHSA-r4q5-vmmm-2653. Remove with next Axios bump > 1.15.0 | [fast-uri] 3.1.2 bump to adress CVE-2026-6321 & CVE-2026-6322. Remove on next shadcn bump | [postcss] Bump to 8.5.10 to address CVE-2026-41305. Remove with removal of next-auth if possible | [hono] bump to 4.12.18 is to address CVE-2026-44457, CVE-2026-44455, CVE-2026-44458 & CVE-2026-44459. Remove with next shadcn bump | [ip-address] bump to 10.1.1 is to fix CVE-2026-42338. Remove on the next shadcn bump"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,20 +191,20 @@ importers:
         specifier: ^1.7.1
         version: 1.7.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       survey-analytics:
-        specifier: ^2.5.18
-        version: 2.5.18(@types/mongodb@4.0.7)(@types/plotly.js-dist-min@2.3.4)(@types/tabulator-tables@6.3.1)(survey-core@2.5.18)
+        specifier: ^2.5.24
+        version: 2.5.24(@types/mongodb@4.0.7)(@types/plotly.js-dist-min@2.3.4)(@types/tabulator-tables@6.3.1)(survey-core@2.5.24)
       survey-core:
-        specifier: ^2.5.18
-        version: 2.5.18
+        specifier: ^2.5.24
+        version: 2.5.24
       survey-creator-core:
-        specifier: ^2.5.18
-        version: 2.5.18(ace-builds@1.43.6)(survey-core@2.5.18)
+        specifier: ^2.5.24
+        version: 2.5.24(ace-builds@1.43.6)(survey-core@2.5.24)
       survey-creator-react:
-        specifier: ^2.5.18
-        version: 2.5.18(ace-builds@1.43.6)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.18)(survey-creator-core@2.5.18(ace-builds@1.43.6)(survey-core@2.5.18))(survey-react-ui@2.5.18(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.18))
+        specifier: ^2.5.24
+        version: 2.5.24(ace-builds@1.43.6)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.24)(survey-creator-core@2.5.24(ace-builds@1.43.6)(survey-core@2.5.24))(survey-react-ui@2.5.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.24))
       survey-react-ui:
-        specifier: ^2.5.18
-        version: 2.5.18(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.18)
+        specifier: ^2.5.24
+        version: 2.5.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.24)
       tailwind-merge:
         specifier: ^3.4.1
         version: 3.4.1
@@ -1274,9 +1274,6 @@ packages:
 
   '@mongodb-js/saslprep@1.4.11':
     resolution: {integrity: sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==}
-
-  '@mongodb-js/saslprep@1.4.6':
-    resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
 
   '@mswjs/interceptors@0.41.4':
     resolution: {integrity: sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==}
@@ -6268,47 +6265,47 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  survey-analytics@2.5.18:
-    resolution: {integrity: sha512-lkrCWAkbFg6PMpYF0cW6c0mfUqC5zhCuzlz81D8WswPtZ4/HpxmFqYqhArA5j5+Yo/qFd7Yyzgpru4d8fR7Glg==}
+  survey-analytics@2.5.24:
+    resolution: {integrity: sha512-XYD55mOb2nrnbXQ23cpRw8ZLcMpbB6ew0eeokUyWhdH9oe+4rM3EQyF2gWS9TDd2qw0WIzhYcYOWEu2gHmyhng==}
     peerDependencies:
       '@types/mongodb': ^4.0.6
       '@types/plotly.js-dist-min': ^2.3.0
       '@types/tabulator-tables': ^6.2.3
-      survey-core: 2.5.18
+      survey-core: 2.5.24
 
-  survey-core@2.5.18:
-    resolution: {integrity: sha512-eorlj28E2GZtaH6q/7k1LQZvOlsWHwpElDRxldTAw8pFj3jEqQvYK3B8EQxVqCeX6oO31BLOZMdFtZvm4rq3bg==}
+  survey-core@2.5.24:
+    resolution: {integrity: sha512-tyvHhxHW1fuCl804GftTX0iaxjgfMvZZztmuvaSMeshSHa4CzUGyKmfOgftg2cpPeauGKowvC3iviN1N+paV7Q==}
 
-  survey-creator-core@2.5.18:
-    resolution: {integrity: sha512-AIBqLNcE5ZhgJYngDZmuoqu4wvv8I47aegp/N42bBeMgSRTm0wIaaVlzgbFVmRTiWsdF5sqdNbBKKYgXyzITuw==}
+  survey-creator-core@2.5.24:
+    resolution: {integrity: sha512-ZMexlUNg6GT46H98n+ZPCe//W42TcHa4nJaPeqTnvovhoN0L7ddZWq6widHWMagF6zlP4bLfSKiUv3egIxDeCw==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
       ace-builds: ^1.4.12
-      survey-core: 2.5.18
+      survey-core: 2.5.24
     peerDependenciesMeta:
       ace-builds:
         optional: true
 
-  survey-creator-react@2.5.18:
-    resolution: {integrity: sha512-LtRwyX/+9DHKHPof4EmxhCg+OYJT0pAnpjjbXBhapt2u6ASGHWqeWrxghHFIjKisz9K+vOrGVd8oMq/aT3iIqA==}
+  survey-creator-react@2.5.24:
+    resolution: {integrity: sha512-97iV+6KqDs6F7SZANlp+z6/wGWCLINhM0Wncj5/flC6Bq7PDjXI1e/TK/4GsXa34K64zDuSzZV09GIkMPVtUnQ==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
       ace-builds: ^1.4.12
       react: ^16.5.0 || ^17.0.1 || ^18.1.0 || ^19.0.0
       react-dom: ^16.5.0 || ^17.0.1 || ^18.1.0 || ^19.0.0
-      survey-core: 2.5.18
-      survey-creator-core: 2.5.18
-      survey-react-ui: 2.5.18
+      survey-core: 2.5.24
+      survey-creator-core: 2.5.24
+      survey-react-ui: 2.5.24
     peerDependenciesMeta:
       ace-builds:
         optional: true
 
-  survey-react-ui@2.5.18:
-    resolution: {integrity: sha512-vYTeRkvjm4b5GeN5Pd+rgp3iAS8u3xokaNJ0sIdRXjiDRW4AQcpUWSHDZu7YhXppz55BziIuEtVWPi4Yj8hRHw==}
+  survey-react-ui@2.5.24:
+    resolution: {integrity: sha512-fjI+kXVl5GWtIWInRUgp5bq+83bJwQI0M66dM8wlfXCWdNOPE2DI8T9AUzXoKmORljDlTXaQbAOVlRYsMhbZLg==}
     peerDependencies:
       react: ^16.5.0 || ^17.0.1 || ^18.1.0 || ^19.0.0
       react-dom: ^16.5.0 || ^17.0.1 || ^18.1.0 || ^19.0.0
-      survey-core: 2.5.18
+      survey-core: 2.5.24
 
   svg-arc-to-cubic-bezier@3.2.0:
     resolution: {integrity: sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==}
@@ -7745,10 +7742,6 @@ snapshots:
       - supports-color
 
   '@mongodb-js/saslprep@1.4.11':
-    dependencies:
-      sparse-bitfield: 3.0.3
-
-  '@mongodb-js/saslprep@1.4.6':
     dependencies:
       sparse-bitfield: 3.0.3
 
@@ -12025,7 +12018,7 @@ snapshots:
 
   mongodb@6.21.0:
     dependencies:
-      '@mongodb-js/saslprep': 1.4.6
+      '@mongodb-js/saslprep': 1.4.11
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
 
@@ -13166,7 +13159,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  survey-analytics@2.5.18(@types/mongodb@4.0.7)(@types/plotly.js-dist-min@2.3.4)(@types/tabulator-tables@6.3.1)(survey-core@2.5.18):
+  survey-analytics@2.5.24(@types/mongodb@4.0.7)(@types/plotly.js-dist-min@2.3.4)(@types/tabulator-tables@6.3.1)(survey-core@2.5.24):
     dependencies:
       '@types/mongodb': 4.0.7
       '@types/plotly.js-dist-min': 2.3.4
@@ -13174,7 +13167,7 @@ snapshots:
       mongodb: 6.21.0
       muuri: 0.8.0
       plotly.js-dist-min: 2.35.3
-      survey-core: 2.5.18
+      survey-core: 2.5.24
       tabulator-tables: 6.3.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
@@ -13185,29 +13178,29 @@ snapshots:
       - snappy
       - socks
 
-  survey-core@2.5.18: {}
+  survey-core@2.5.24: {}
 
-  survey-creator-core@2.5.18(ace-builds@1.43.6)(survey-core@2.5.18):
+  survey-creator-core@2.5.24(ace-builds@1.43.6)(survey-core@2.5.24):
     dependencies:
-      survey-core: 2.5.18
+      survey-core: 2.5.24
     optionalDependencies:
       ace-builds: 1.43.6
 
-  survey-creator-react@2.5.18(ace-builds@1.43.6)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.18)(survey-creator-core@2.5.18(ace-builds@1.43.6)(survey-core@2.5.18))(survey-react-ui@2.5.18(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.18)):
+  survey-creator-react@2.5.24(ace-builds@1.43.6)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.24)(survey-creator-core@2.5.24(ace-builds@1.43.6)(survey-core@2.5.24))(survey-react-ui@2.5.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.24)):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      survey-core: 2.5.18
-      survey-creator-core: 2.5.18(ace-builds@1.43.6)(survey-core@2.5.18)
-      survey-react-ui: 2.5.18(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.18)
+      survey-core: 2.5.24
+      survey-creator-core: 2.5.24(ace-builds@1.43.6)(survey-core@2.5.24)
+      survey-react-ui: 2.5.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.24)
     optionalDependencies:
       ace-builds: 1.43.6
 
-  survey-react-ui@2.5.18(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.18):
+  survey-react-ui@2.5.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(survey-core@2.5.24):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      survey-core: 2.5.18
+      survey-core: 2.5.24
 
   svg-arc-to-cubic-bezier@3.2.0: {}
 


### PR DESCRIPTION
# chore: Bump SurveyJS to 2.5.24

## Description
- Release notes - https://github.com/surveyjs/survey-library/releases/tag/v2.5.24

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/626

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.