### PR TITLE
refactor: Rewrite hub storage api routes to support multi provider setup

### DIFF
--- a/app/api/hub/v0/storage/content/upload-urls/route.ts
+++ b/app/api/hub/v0/storage/content/upload-urls/route.ts
@@ -9,19 +9,16 @@ import { generateUniqueFileName } from "@/features/asset-storage";
 import { buildContentFolderPath } from "@/features/asset-storage/infrastructure/storage-utils";
 import { Result } from "@/lib/result";
 import { apiResponses } from "@/lib/utils/route-handlers";
+import type { UploadUrlDescriptor } from "@/features/asset-storage/infrastructure/storage-gateway";
 
-interface ContentSASTokenRequest {
+interface ContentUploadUrlsRequest {
   itemId: string;
   itemType: ContentItemType;
   fileNames: string[];
   questionName?: string;
 }
 
-interface SASOperationResult {
-  success: boolean;
-  message?: string;
-  url?: string;
-}
+export type UploadUrlEntry = UploadUrlDescriptor | { error: string };
 
 /** Server-provided metadata for the client to set on each blob upload. */
 interface ContentUploadMetadata {
@@ -31,8 +28,8 @@ interface ContentUploadMetadata {
   questionName: string;
 }
 
-interface ContentSASTokenResponse {
-  sasTokens: Record<string, SASOperationResult>;
+interface ContentUploadUrlsResponse {
+  uploads: Record<string, UploadUrlEntry>;
   uploadMetadata: ContentUploadMetadata;
 }
 
@@ -41,7 +38,7 @@ export async function POST(request: Request): Promise<Response> {
   const { requireHubAccess } = await authorization(session);
   await requireHubAccess();
 
-  let data: ContentSASTokenRequest;
+  let data: ContentUploadUrlsRequest;
   try {
     data = await request.json();
   } catch {
@@ -70,29 +67,25 @@ export async function POST(request: Request): Promise<Response> {
   const containerNames = getContainerNames();
   const containerName = containerNames.CONTENT;
   const folderPath = folderPathResult.value;
-  const sasTokens: Record<string, SASOperationResult> = {};
+  const uploads: Record<string, UploadUrlEntry> = {};
 
   for (const fileName of fileNames) {
     const uniqueFileNameResult = generateUniqueFileName(fileName);
     if (Result.isError(uniqueFileNameResult)) {
-      sasTokens[fileName] = {
-        success: false,
-        message: uniqueFileNameResult.message,
-      };
+      uploads[fileName] = { error: uniqueFileNameResult.message };
       continue;
     }
 
     try {
-      const sasUrl = await generateUploadUrl({
+      const descriptor = await generateUploadUrl({
         containerName,
         folderPath,
         fileName: uniqueFileNameResult.value,
       });
-      sasTokens[fileName] = { success: true, url: sasUrl };
+      uploads[fileName] = descriptor;
     } catch (error) {
-      sasTokens[fileName] = {
-        success: false,
-        message: error instanceof Error ? error.message : "Unknown error",
+      uploads[fileName] = {
+        error: error instanceof Error ? error.message : "Unknown error",
       };
     }
   }
@@ -104,6 +97,6 @@ export async function POST(request: Request): Promise<Response> {
     questionName: questionName ?? "",
   };
 
-  const body: ContentSASTokenResponse = { sasTokens, uploadMetadata };
+  const body: ContentUploadUrlsResponse = { uploads, uploadMetadata };
   return Response.json(body);
 }

--- a/app/api/hub/v0/storage/content/upload-urls/route.ts
+++ b/app/api/hub/v0/storage/content/upload-urls/route.ts
@@ -10,12 +10,15 @@ import { buildContentFolderPath } from "@/features/asset-storage/infrastructure/
 import { Result } from "@/lib/result";
 import { apiResponses } from "@/lib/utils/route-handlers";
 import type { UploadUrlDescriptor } from "@/features/asset-storage/infrastructure/storage-gateway";
+import type { FileMetadata, ProcessedState } from "@/features/asset-storage/types";
 
 interface ContentUploadUrlsRequest {
   itemId: string;
   itemType: ContentItemType;
   fileNames: string[];
   questionName?: string;
+  fileTypes?: Record<string, string>;
+  fileStates?: Record<string, ProcessedState>;
 }
 
 export type UploadUrlEntry = UploadUrlDescriptor | { error: string };
@@ -45,7 +48,8 @@ export async function POST(request: Request): Promise<Response> {
     return apiResponses.badRequest({ detail: "Invalid JSON body" });
   }
 
-  const { itemId, itemType, fileNames, questionName } = data;
+  const { itemId, itemType, fileNames, questionName, fileTypes, fileStates } =
+    data;
 
   if (!itemId?.trim()) {
     return apiResponses.badRequest({ detail: "Item ID is required" });
@@ -77,10 +81,25 @@ export async function POST(request: Request): Promise<Response> {
     }
 
     try {
+      const contentType =
+        fileTypes?.[fileName] ?? "application/octet-stream";
+      const fileState = fileStates?.[fileName];
+      const blobUploadFileMetadata: FileMetadata = {
+        kind: "content",
+        uploadedBy: session!.user?.id ?? "",
+        itemId: itemId.trim(),
+        contentItemType: itemType,
+        displayName: fileName,
+        contentType,
+        questionName: questionName ?? "",
+        ...(fileState !== undefined ? { fileState } : {}),
+      };
+
       const descriptor = await generateUploadUrl({
         containerName,
         folderPath,
         fileName: uniqueFileNameResult.value,
+        blobUploadFileMetadata,
       });
       uploads[fileName] = descriptor;
     } catch (error) {

--- a/app/api/public/v0/storage/read-urls/__tests__/route.test.ts
+++ b/app/api/public/v0/storage/read-urls/__tests__/route.test.ts
@@ -47,7 +47,7 @@ import { POST } from "../route";
 const sampleUrl =
   "https://test.blob.core.windows.net/user-files/s/form-123/submission-123/test.pdf";
 
-describe("POST /api/public/v0/storage/read-token", () => {
+describe("POST /api/public/v0/storage/read-urls", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -84,7 +84,7 @@ describe("POST /api/public/v0/storage/read-token", () => {
   });
 
   const createRequest = (body: object) => {
-    return new Request("http://localhost/api/public/v0/storage/read-token", {
+    return new Request("http://localhost/api/public/v0/storage/read-urls", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -178,7 +178,7 @@ describe("POST /api/public/v0/storage/read-token", () => {
     expect(response.status).toBe(400);
     const data = await response.json();
     expect(data.detail).toBe(
-      "Read-token route requires Azure storage configuration",
+      "read-urls route requires Azure storage configuration",
     );
     expect(mockResolveContainerFromUrl).not.toHaveBeenCalled();
     expect(mockBulkGenerateReadTokens).not.toHaveBeenCalled();
@@ -186,7 +186,7 @@ describe("POST /api/public/v0/storage/read-token", () => {
 
   it("should return 400 if body is not valid JSON", async () => {
     const request = new Request(
-      "http://localhost/api/public/v0/storage/read-token",
+      "http://localhost/api/public/v0/storage/read-urls",
       {
         method: "POST",
         body: "invalid json",

--- a/app/api/public/v0/storage/read-urls/route.ts
+++ b/app/api/public/v0/storage/read-urls/route.ts
@@ -6,42 +6,23 @@ import { bulkGenerateReadTokens } from "@/features/asset-storage/infrastructure/
 import { resolveContainerFromUrl } from "@/features/asset-storage/utils";
 
 /**
- * Request body for the read-urls route.
+ * Generate read tokens for a list of URLs. The URLs must be in the format of:
+ * - https://<storage-account-hostname>/<container>/<blob>
+ * - https://<storage-account-hostname>/<container>/<folder>/<blob>
+ * - https://<storage-account-hostname>/<container>/<folder>/<subfolder>/<blob>
+ * - etc.
+ *
+ * If the storage is private, the URLs will be returned with a SAS token.
+ * If the storage is public, the URLs will be returned as is.
+ *
+ * The response will be a JSON object with the URLs as keys and the resolved URLs as values.
+ * The resolved URLs will be in the format of:
+ * - https://<storage-account-hostname>/<container>/<blob>?sv=2021-06-08&se=2023-01-01T00:00:00Z&sig=abc
+ * - https://<storage-account-hostname>/<container>/<folder>/<blob>?sv=2021-06-08&se=2023-01-01T00:00:00Z&sig=abc
+ * - https://<storage-account-hostname>/<container>/<folder>/<subfolder>/<blob>?sv=2021-06-08&se=2023-01-01T00:00:00Z&sig=abc
+ * - etc.
+ *
  */
-interface ReadUrlsRequest {
-  /**
-   * The URLs to generate read tokens for.
-   */
-  urls: string[];
-}
-
-export type ReadUrlResolvedEntry = { url: string } | { error: string };
-
-export interface ReadUrlsResponse {
-  resolved: Record<string, ReadUrlResolvedEntry>;
-}
-
-function appendSasQueryToUrl(baseUrl: string, sasQuery: string): string {
-  if (sasQuery.length === 0) {
-    return baseUrl;
-  }
-  const sep = baseUrl.includes("?") ? "&" : "?";
-  return `${baseUrl}${sep}${sasQuery}`;
-}
-
-function isUrlsFieldValid(urls: unknown): urls is string[] {
-  if (!Array.isArray(urls)) {
-    return false;
-  }
-  return urls.every((u) => typeof u === "string");
-}
-
-interface ParsedReadUrl {
-  originalUrl: string;
-  containerName: string;
-  blobName: string;
-}
-
 export async function POST(request: Request): Promise<Response> {
   const storageSettings = getStorageRuntimeSettings();
 
@@ -49,24 +30,12 @@ export async function POST(request: Request): Promise<Response> {
     return apiResponses.badRequest({ detail: "Storage is not enabled" });
   }
 
-  let body: ReadUrlsRequest;
-  try {
-    body = await request.json();
-  } catch {
-    return apiResponses.badRequest({ detail: "Invalid JSON body" });
+  const urlsResult = await getUrlsFromRequest(request);
+  if (Result.isError(urlsResult)) {
+    return apiResponses.badRequest({ detail: urlsResult.message });
   }
 
-  if (body.urls === undefined) {
-    return apiResponses.badRequest({ detail: "urls is required" });
-  }
-
-  if (!isUrlsFieldValid(body.urls)) {
-    return apiResponses.badRequest({
-      detail: "urls must be an array of strings",
-    });
-  }
-
-  const urls = body.urls;
+  const urls = urlsResult.value;
 
   if (!storageSettings.isPrivate) {
     const resolved: Record<string, ReadUrlResolvedEntry> = {};
@@ -150,4 +119,65 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   return Response.json({ resolved } satisfies ReadUrlsResponse);
+}
+
+/**
+ * Request body for the read-urls route.
+ */
+interface ReadUrlsRequest {
+  /**
+   * The URLs to generate read tokens for.
+   */
+  urls: string[];
+}
+
+export type ReadUrlResolvedEntry = { url: string } | { error: string };
+
+export interface ReadUrlsResponse {
+  resolved: Record<string, ReadUrlResolvedEntry>;
+}
+
+function appendSasQueryToUrl(baseUrl: string, sasQuery: string): string {
+  if (sasQuery.length === 0) {
+    return baseUrl;
+  }
+  const sep = baseUrl.includes("?") ? "&" : "?";
+  return `${baseUrl}${sep}${sasQuery}`;
+}
+
+function isUrlsFieldValid(urls: unknown): urls is string[] {
+  if (!Array.isArray(urls)) {
+    return false;
+  }
+  return urls.every((u) => typeof u === "string");
+}
+
+interface ParsedReadUrl {
+  originalUrl: string;
+  containerName: string;
+  blobName: string;
+}
+
+/**
+ * Get the URLs from the request body and validate them.
+ * @param request - The request body to get the URLs from.
+ * @returns A Result containing the URLs or an error message.
+ */
+async function getUrlsFromRequest(request: Request): Promise<Result<string[]>> {
+  let body: ReadUrlsRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return Result.validationError("Invalid JSON body");
+  }
+
+  if (body.urls === undefined) {
+    return Result.validationError("urls is required");
+  }
+
+  if (!isUrlsFieldValid(body.urls)) {
+    return Result.validationError("urls must be an array of strings");
+  }
+
+  return Result.success(body.urls);
 }

--- a/app/api/public/v0/storage/read-urls/route.ts
+++ b/app/api/public/v0/storage/read-urls/route.ts
@@ -5,13 +5,17 @@ import { getStorageRuntimeSettings } from "@/features/asset-storage/storage-runt
 import { bulkGenerateReadTokens } from "@/features/asset-storage/infrastructure/storage-gateway";
 import { resolveContainerFromUrl } from "@/features/asset-storage/utils";
 
+/**
+ * Request body for the read-urls route.
+ */
 interface ReadUrlsRequest {
+  /**
+   * The URLs to generate read tokens for.
+   */
   urls: string[];
 }
 
-export type ReadUrlResolvedEntry =
-  | { url: string }
-  | { error: string };
+export type ReadUrlResolvedEntry = { url: string } | { error: string };
 
 export interface ReadUrlsResponse {
   resolved: Record<string, ReadUrlResolvedEntry>;
@@ -82,7 +86,7 @@ export async function POST(request: Request): Promise<Response> {
   const config = storageSettings.azure;
   if (config === null) {
     return apiResponses.badRequest({
-      detail: "Read-token route requires Azure storage configuration",
+      detail: "read-urls route requires Azure storage configuration",
     });
   }
 

--- a/app/api/public/v0/storage/upload-urls/route.ts
+++ b/app/api/public/v0/storage/upload-urls/route.ts
@@ -8,14 +8,22 @@ import { generateUniqueFileName } from "@/features/asset-storage";
 import { ApiResult } from "@/lib/endatix-api";
 import { Result } from "@/lib/result";
 import { apiResponses } from "@/lib/utils/route-handlers";
-import { buildUserFileFolderPath } from "@/features/asset-storage/infrastructure/storage-utils";
+import {
+  buildUserFileFolderPath,
+  buildUserFileMetadata,
+} from "@/features/asset-storage/infrastructure/storage-utils";
 import type { UploadUrlDescriptor } from "@/features/asset-storage/infrastructure/storage-gateway";
+import type { ProcessedState } from "@/features/asset-storage/types";
 
 interface UploadUrlsRequest {
   formId: string;
   fileNames: string[];
   formLocale: string;
   submissionId: string;
+  /** Original client file name → MIME type after optional resize (must match PUT bytes). */
+  fileTypes?: Record<string, string>;
+  fileStates?: Record<string, ProcessedState>;
+  questionName?: string;
 }
 
 export type UploadUrlEntry = UploadUrlDescriptor | { error: string };
@@ -61,7 +69,12 @@ export async function POST(request: Request): Promise<Response> {
 
   const containerNames = getContainerNames();
   const containerName = containerNames.USER_FILES;
-
+  const folderPathResult = buildUserFileFolderPath(formId, submissionId);
+  if (Result.isError(folderPathResult)) {
+    return apiResponses.badRequest({ detail: folderPathResult.message });
+  }
+  const folderPath = folderPathResult.value;
+  
   for (const fileName of fileNames) {
     const uniqueFileNameResult = generateUniqueFileName(fileName);
     if (Result.isError(uniqueFileNameResult)) {
@@ -69,17 +82,27 @@ export async function POST(request: Request): Promise<Response> {
       continue;
     }
 
-    const folderPathResult = buildUserFileFolderPath(formId, submissionId);
-    if (Result.isError(folderPathResult)) {
-      uploads[fileName] = { error: folderPathResult.message };
-      continue;
-    }
-
     try {
+      const contentType =
+        data.fileTypes?.[fileName] ?? "application/octet-stream";
+      const fileState = data.fileStates?.[fileName];
+      const blobUploadFileMetadata = buildUserFileMetadata({
+        kind: "user",
+        uploadedBy: userId,
+        displayName: fileName,
+        contentType,
+        formId,
+        submissionId,
+        formLang: data.formLocale,
+        questionName: data.questionName ?? "",
+        ...(fileState !== undefined ? { fileState } : {}),
+      });
+
       const descriptor = await generateUploadUrl({
         containerName,
-        folderPath: folderPathResult.value,
+        folderPath,
         fileName: uniqueFileNameResult.value,
+        blobUploadFileMetadata,
       });
       uploads[fileName] = descriptor;
     } catch (error) {

--- a/app/api/public/v0/storage/upload-urls/route.ts
+++ b/app/api/public/v0/storage/upload-urls/route.ts
@@ -9,22 +9,19 @@ import { ApiResult } from "@/lib/endatix-api";
 import { Result } from "@/lib/result";
 import { apiResponses } from "@/lib/utils/route-handlers";
 import { buildUserFileFolderPath } from "@/features/asset-storage/infrastructure/storage-utils";
+import type { UploadUrlDescriptor } from "@/features/asset-storage/infrastructure/storage-gateway";
 
-interface SASTokenRequest {
+interface UploadUrlsRequest {
   formId: string;
   fileNames: string[];
   formLocale: string;
   submissionId: string;
 }
 
-interface SASOperationResult {
-  success: boolean;
-  message?: string;
-  url?: string;
-}
+export type UploadUrlEntry = UploadUrlDescriptor | { error: string };
 
-interface SASTokenResponse {
-  sasTokens: Record<string, SASOperationResult>;
+export interface UploadUrlsResponse {
+  uploads: Record<string, UploadUrlEntry>;
   submissionId: string;
   userId: string;
 }
@@ -33,7 +30,7 @@ export async function POST(request: Request): Promise<Response> {
   const session = await auth();
   const userId = session?.user?.id ?? "anonymous";
 
-  const data: SASTokenRequest = await request.json();
+  const data: UploadUrlsRequest = await request.json();
   const { formId, fileNames, formLocale } = data;
   let submissionId = data.submissionId;
 
@@ -49,7 +46,7 @@ export async function POST(request: Request): Promise<Response> {
     const initialSubmissionResult = await createInitialSubmissionUseCase(
       formId,
       formLocale,
-      "Generate submissionId for sas token generation",
+      "Generate submissionId for upload URL generation",
     );
 
     if (ApiResult.isError(initialSubmissionResult)) {
@@ -60,7 +57,7 @@ export async function POST(request: Request): Promise<Response> {
 
     submissionId = initialSubmissionResult.data.submissionId;
   }
-  const sasTokens: Record<string, SASOperationResult> = {};
+  const uploads: Record<string, UploadUrlEntry> = {};
 
   const containerNames = getContainerNames();
   const containerName = containerNames.USER_FILES;
@@ -68,49 +65,35 @@ export async function POST(request: Request): Promise<Response> {
   for (const fileName of fileNames) {
     const uniqueFileNameResult = generateUniqueFileName(fileName);
     if (Result.isError(uniqueFileNameResult)) {
-      sasTokens[fileName] = failedResult(uniqueFileNameResult.message);
+      uploads[fileName] = { error: uniqueFileNameResult.message };
       continue;
     }
 
     const folderPathResult = buildUserFileFolderPath(formId, submissionId);
     if (Result.isError(folderPathResult)) {
-      sasTokens[fileName] = failedResult(folderPathResult.message);
+      uploads[fileName] = { error: folderPathResult.message };
       continue;
     }
 
     try {
-      const sasToken = await generateUploadUrl({
+      const descriptor = await generateUploadUrl({
         containerName,
         folderPath: folderPathResult.value,
         fileName: uniqueFileNameResult.value,
       });
-      sasTokens[fileName] = successResult(sasToken);
+      uploads[fileName] = descriptor;
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
-      sasTokens[fileName] = failedResult(errorMessage);
+      uploads[fileName] = { error: errorMessage };
     }
   }
 
-  const sasTokenResponse: SASTokenResponse = {
-    sasTokens,
+  const body: UploadUrlsResponse = {
+    uploads,
     submissionId,
     userId,
   };
 
-  return Response.json(sasTokenResponse);
-}
-
-function successResult(url: string): SASOperationResult {
-  return {
-    success: true,
-    url,
-  };
-}
-
-function failedResult(message: string): SASOperationResult {
-  return {
-    success: false,
-    message,
-  };
+  return Response.json(body);
 }

--- a/features/asset-storage/__tests__/infrastructure/storage-service.test.ts
+++ b/features/asset-storage/__tests__/infrastructure/storage-service.test.ts
@@ -284,7 +284,11 @@ describe("StorageGateway", () => {
           protocol: "https",
         }),
       );
-      expect(result).toBe("https://test.blob.core.windows.net/test?sas-token");
+      expect(result).toEqual({
+        url: "https://test.blob.core.windows.net/test?sas-token",
+        key: `${mockFolderPath}/${mockFileName}`,
+        headers: { "x-ms-blob-type": "BlockBlob" },
+      });
     });
 
     it("should throw error when fileName is not provided", async () => {

--- a/features/asset-storage/__tests__/use-cases/upload-content-files/use-content-upload.hook.test.tsx
+++ b/features/asset-storage/__tests__/use-cases/upload-content-files/use-content-upload.hook.test.tsx
@@ -167,6 +167,8 @@ describe("useContentUpload", () => {
           itemType: "form",
           fileNames: ["test.jpg"],
           questionName: "testQuestion",
+          fileTypes: { "test.jpg": "image/jpeg" },
+          fileStates: { "test.jpg": "original" },
         }),
       }),
     );

--- a/features/asset-storage/__tests__/use-cases/upload-content-files/use-content-upload.hook.test.tsx
+++ b/features/asset-storage/__tests__/use-cases/upload-content-files/use-content-upload.hook.test.tsx
@@ -39,24 +39,31 @@ const createMockFile = (name = "test.jpg"): File => {
 };
 
 const mockFetchSuccess = (questionName: string) => {
-  global.fetch = vi.fn().mockResolvedValueOnce({
-    ok: true,
-    json: () =>
-      Promise.resolve({
-        sasTokens: {
-          "test.jpg": {
-            success: true,
-            url: `https://account.blob.core.windows.net/content/f/test-item/unique.jpg?sas=token`,
+  global.fetch = vi
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          uploads: {
+            "test.jpg": {
+              url: `https://account.blob.core.windows.net/content/f/test-item/unique.jpg?sas=token`,
+              headers: { "x-ms-blob-type": "BlockBlob" },
+              key: "f/test-item/unique.jpg",
+            },
           },
-        },
-        uploadMetadata: {
-          userId: "user-1",
-          itemId: "test-item",
-          contentItemType: "form",
-          questionName,
-        },
-      }),
-  });
+          uploadMetadata: {
+            userId: "user-1",
+            itemId: "test-item",
+            contentItemType: "form",
+            questionName,
+          },
+        }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
 };
 
 const mockFetchError = (detail = "Unauthorized") => {
@@ -152,7 +159,7 @@ describe("useContentUpload", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "/api/hub/v0/storage/content/sas-token",
+      "/api/hub/v0/storage/content/upload-urls",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({

--- a/features/asset-storage/__tests__/use-cases/upload-user-files/use-storage-upload.hook.test.tsx
+++ b/features/asset-storage/__tests__/use-cases/upload-user-files/use-storage-upload.hook.test.tsx
@@ -220,6 +220,11 @@ describe("useStorageUpload", () => {
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({
           ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+          headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
           json: () =>
             Promise.resolve({
               uploads: {
@@ -230,11 +235,6 @@ describe("useStorageUpload", () => {
                 },
               },
             }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-          headers: new Headers({ "Content-Type": "image/jpeg" }),
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -259,7 +259,11 @@ describe("useStorageUpload", () => {
         await result.current!.uploadFiles(mockSurveyModel, mockUploadOptions);
       });
 
-      // Should call upload-urls first, then resize-image for small images (browser-to-storage)
+      // Resize-image first (bytes + MIME), then upload-urls, then PUT to blob
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/public/v0/storage/resize-image",
+        expect.objectContaining({ method: "POST" }),
+      );
       expect(global.fetch).toHaveBeenCalledWith(
         "/api/public/v0/storage/upload-urls",
         expect.objectContaining({
@@ -269,12 +273,11 @@ describe("useStorageUpload", () => {
             submissionId: mockSubmissionId,
             formId: mockFormId,
             formLocale: "en",
+            fileTypes: { "test.jpg": "image/jpeg" },
+            fileStates: { "test.jpg": "optimized" },
+            questionName: "",
           }),
         }),
-      );
-      expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/resize-image",
-        expect.objectContaining({ method: "POST" }),
       );
     });
 
@@ -282,6 +285,11 @@ describe("useStorageUpload", () => {
       const runtimeSubmissionId = "runtime-submission-456";
 
       (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+          headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
         .mockResolvedValueOnce({
           ok: true,
           json: () =>
@@ -294,11 +302,6 @@ describe("useStorageUpload", () => {
                 },
               },
             }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-          headers: new Headers({ "Content-Type": "image/jpeg" }),
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -334,6 +337,9 @@ describe("useStorageUpload", () => {
             submissionId: runtimeSubmissionId,
             formId: mockFormId,
             formLocale: "en",
+            fileTypes: { "test.jpg": "image/jpeg" },
+            fileStates: { "test.jpg": "optimized" },
+            questionName: "",
           }),
         }),
       );
@@ -373,6 +379,10 @@ describe("useStorageUpload", () => {
       );
 
       await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
         await result.current.uploadFiles(mockSurveyModel, largeFileOptions);
       });
 
@@ -386,6 +396,9 @@ describe("useStorageUpload", () => {
             submissionId: mockSubmissionId,
             formId: mockFormId,
             formLocale: "en",
+            fileTypes: { "large-video.mp4": "video/mp4" },
+            fileStates: { "large-video.mp4": "original" },
+            questionName: "",
           }),
         }),
       );
@@ -444,38 +457,55 @@ describe("useStorageUpload", () => {
       );
 
       await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
         await result.current.uploadFiles(mockSurveyModel, mixedFilesOptions);
       });
 
-      // SAS token once for all files, then resize-image for the small image
+      // Resize for the small image, then upload-urls for the batch, then PUTs
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/upload-urls",
+        "/api/public/v0/storage/resize-image",
         expect.any(Object),
       );
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/resize-image",
+        "/api/public/v0/storage/upload-urls",
         expect.any(Object),
       );
     });
 
     it("should handle upload errors gracefully", async () => {
+      const largeOnlyOptions: UploadFilesEvent = {
+        files: [mockLargeFile],
+        callback: vi.fn(),
+      } as unknown as UploadFilesEvent;
+
+      let result: ReturnType<typeof renderHook>["result"];
+
+      await act(async () => {
+        const view = renderHook(
+          () =>
+            useStorageUpload(createHookProps({ submissionId: mockSubmissionId })),
+          {
+            wrapper: createWrapper(),
+          },
+        );
+        result = view.result;
+        await Promise.resolve();
+      });
+
+      expect(result!.current).not.toBeNull();
+
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockReset()
         .mockRejectedValue(new Error("Network error"));
 
-      const { result } = renderHook(
-        () =>
-          useStorageUpload(createHookProps({ submissionId: mockSubmissionId })),
-        {
-          wrapper: createWrapper(),
-        },
-      );
-
       await act(async () => {
-        await result.current.uploadFiles(mockSurveyModel, mockUploadOptions);
+        await result.current!.uploadFiles(mockSurveyModel, largeOnlyOptions);
       });
 
-      expect(mockUploadOptions.callback).toHaveBeenCalledWith(
+      expect(largeOnlyOptions.callback).toHaveBeenCalledWith(
         [],
         ["Network error"],
       );
@@ -500,6 +530,11 @@ describe("useStorageUpload", () => {
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({
           ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+          headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
           json: () =>
             Promise.resolve({
               uploads: {
@@ -512,11 +547,6 @@ describe("useStorageUpload", () => {
               submissionId: mockSubmissionId,
               userId: "user-1",
             }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-          headers: new Headers({ "Content-Type": "image/jpeg" }),
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -819,6 +849,11 @@ describe("useStorageUpload", () => {
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({
           ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+          headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
           json: () =>
             Promise.resolve({
               uploads: {
@@ -832,8 +867,7 @@ describe("useStorageUpload", () => {
         })
         .mockResolvedValueOnce({
           ok: true,
-          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-          headers: new Headers({ "Content-Type": "image/jpeg" }),
+          text: () => Promise.resolve(""),
         });
 
       const { result } = renderHook(
@@ -845,16 +879,20 @@ describe("useStorageUpload", () => {
       );
 
       await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
         await result.current.uploadFiles(mockSurveyModel, uploadOptions);
       });
 
-      // Should call SAS token then resize-image for small images
+      // Resize-image then upload-urls for small images
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/upload-urls",
+        "/api/public/v0/storage/resize-image",
         expect.any(Object),
       );
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/resize-image",
+        "/api/public/v0/storage/upload-urls",
         expect.any(Object),
       );
     });
@@ -872,19 +910,24 @@ describe("useStorageUpload", () => {
         callback: vi.fn(),
       } as unknown as UploadFilesEvent;
 
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            uploads: {
-              "large.jpg": {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uploads: {
+                "large.jpg": {
                   url: "https://test.blob.core.windows.net/large?sas-token",
                   headers: { "x-ms-blob-type": "BlockBlob" },
                   key: "mock/blob-key",
                 },
-            },
-          }),
-      });
+              },
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve(""),
+        });
 
       const { result } = renderHook(
         () =>
@@ -893,6 +936,10 @@ describe("useStorageUpload", () => {
           wrapper: createWrapper(),
         },
       );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       await act(async () => {
         await result.current.uploadFiles(mockSurveyModel, uploadOptions);
@@ -916,19 +963,24 @@ describe("useStorageUpload", () => {
         callback: vi.fn(),
       } as unknown as UploadFilesEvent;
 
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            uploads: {
-              "document.pdf": {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uploads: {
+                "document.pdf": {
                   url: "https://test.blob.core.windows.net/document?sas-token",
                   headers: { "x-ms-blob-type": "BlockBlob" },
                   key: "mock/blob-key",
                 },
-            },
-          }),
-      });
+              },
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve(""),
+        });
 
       const { result } = renderHook(
         () =>
@@ -937,6 +989,10 @@ describe("useStorageUpload", () => {
           wrapper: createWrapper(),
         },
       );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       await act(async () => {
         await result.current.uploadFiles(mockSurveyModel, uploadOptions);
@@ -960,6 +1016,11 @@ describe("useStorageUpload", () => {
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({
           ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+          headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
           json: () =>
             Promise.resolve({
               submissionId: "new-submission-id",
@@ -975,8 +1036,7 @@ describe("useStorageUpload", () => {
         })
         .mockResolvedValueOnce({
           ok: true,
-          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-          headers: new Headers({ "Content-Type": "image/jpeg" }),
+          text: () => Promise.resolve(""),
         });
 
       const { result } = renderHook(
@@ -1010,6 +1070,11 @@ describe("useStorageUpload", () => {
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({
           ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+          headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
           json: () =>
             Promise.resolve({
               submissionId: mockSubmissionId, // Same as current
@@ -1025,8 +1090,7 @@ describe("useStorageUpload", () => {
         })
         .mockResolvedValueOnce({
           ok: true,
-          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-          headers: new Headers({ "Content-Type": "video/mp4" }),
+          text: () => Promise.resolve(""),
         });
 
       const { result } = renderHook(
@@ -1321,6 +1385,10 @@ describe("useStorageUpload", () => {
       );
 
       await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
         await result.current.uploadFiles(mockSurveyModel, uploadOptions);
       });
 
@@ -1355,6 +1423,10 @@ describe("useStorageUpload", () => {
           wrapper: createWrapper(),
         },
       );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       await act(async () => {
         await result.current.uploadFiles(mockSurveyModel, uploadOptions);
@@ -1400,6 +1472,10 @@ describe("useStorageUpload", () => {
           wrapper: createWrapper(),
         },
       );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
 
       // Act
       await act(async () => {
@@ -1455,6 +1531,10 @@ describe("useStorageUpload", () => {
       );
 
       await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
         await result.current.uploadFiles(mockSurveyModel, uploadOptions);
       });
 
@@ -1493,7 +1573,7 @@ describe("useStorageUpload", () => {
 
     it("should handle SAS token API errors", async () => {
       const uploadOptions: UploadFilesEvent = {
-        files: [mockFile],
+        files: [mockLargeFile],
         callback: vi.fn(),
       } as unknown as UploadFilesEvent;
 
@@ -1529,6 +1609,11 @@ describe("useStorageUpload", () => {
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({
           ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+          headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
           json: () =>
             Promise.resolve({
               submissionId: "new-submission-id",
@@ -1540,11 +1625,6 @@ describe("useStorageUpload", () => {
                 },
               },
             }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-          headers: new Headers({ "Content-Type": "image/jpeg" }),
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -1582,6 +1662,11 @@ describe("useStorageUpload", () => {
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({
           ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+          headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
           json: () =>
             Promise.resolve({
               uploads: {
@@ -1592,11 +1677,6 @@ describe("useStorageUpload", () => {
                 },
               },
             }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-          headers: new Headers({ "Content-Type": "image/jpeg" }),
         })
         .mockResolvedValueOnce({
           ok: true,

--- a/features/asset-storage/__tests__/use-cases/upload-user-files/use-storage-upload.hook.test.tsx
+++ b/features/asset-storage/__tests__/use-cases/upload-user-files/use-storage-upload.hook.test.tsx
@@ -9,25 +9,11 @@ import {
   ClearFilesEvent,
   DownloadFileEvent,
 } from "survey-core";
-import { BlockBlobClient } from "@azure/storage-blob";
 import { Result } from "@/lib/result";
 import { processUploadError } from "@/features/asset-storage/use-cases/upload";
 
 // Mock fetch globally
 global.fetch = vi.fn();
-
-// Mock BlockBlobClient
-vi.mock("@azure/storage-blob", async () => {
-  const actual = await vi.importActual<typeof import("@azure/storage-blob")>(
-    "@azure/storage-blob",
-  );
-  return {
-    ...actual,
-    BlockBlobClient: vi.fn().mockImplementation(function () {
-      return { uploadData: vi.fn().mockResolvedValue(undefined) };
-    }),
-  };
-});
 
 const resolvedTokenResult = Result.success({
   token: "",
@@ -227,16 +213,20 @@ describe("useStorageUpload", () => {
     } as unknown as UploadFilesEvent;
 
     beforeEach(() => {
-      // Mock: first SAS token, then resize-image response (for small images)
+      vi.clearAllMocks();
+    });
+
+    it("should upload small image via resize then SAS (browser-to-storage)", async () => {
       (global.fetch as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce({
           ok: true,
           json: () =>
             Promise.resolve({
-              sasTokens: {
+              uploads: {
                 "test.jpg": {
-                  success: true,
                   url: "https://test.blob.core.windows.net/test?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
                 },
               },
             }),
@@ -245,16 +235,12 @@ describe("useStorageUpload", () => {
           ok: true,
           arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
           headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve(""),
         });
 
-      // Mock BlockBlobClient
-      const mockUploadData = vi.fn().mockResolvedValue(undefined);
-      (BlockBlobClient as ReturnType<typeof vi.fn>).mockImplementation(function () {
-        return { uploadData: mockUploadData };
-      });
-    });
-
-    it("should upload small image via resize then SAS (browser-to-storage)", async () => {
       const { result } = renderHook(
         () =>
           useStorageUpload(createHookProps({ submissionId: mockSubmissionId })),
@@ -273,9 +259,9 @@ describe("useStorageUpload", () => {
         await result.current!.uploadFiles(mockSurveyModel, mockUploadOptions);
       });
 
-      // Should call SAS token first, then resize-image for small images (browser-to-storage)
+      // Should call upload-urls first, then resize-image for small images (browser-to-storage)
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/sas-token",
+        "/api/public/v0/storage/upload-urls",
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
@@ -294,6 +280,30 @@ describe("useStorageUpload", () => {
 
     it("should resolve submissionId from getSubmissionId when submissionId prop is omitted", async () => {
       const runtimeSubmissionId = "runtime-submission-456";
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uploads: {
+                "test.jpg": {
+                  url: "https://test.blob.core.windows.net/test?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
+                },
+              },
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+          headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve(""),
+        });
 
       const { result } = renderHook(
         () =>
@@ -316,7 +326,7 @@ describe("useStorageUpload", () => {
       });
 
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/sas-token",
+        "/api/public/v0/storage/upload-urls",
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
@@ -335,6 +345,25 @@ describe("useStorageUpload", () => {
         callback: vi.fn(),
       } as unknown as UploadFilesEvent;
 
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uploads: {
+                "large-video.mp4": {
+                  url: "https://test.blob.core.windows.net/large?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
+                },
+              },
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve(""),
+        });
+
       const { result } = renderHook(
         () =>
           useStorageUpload(createHookProps({ submissionId: mockSubmissionId })),
@@ -349,7 +378,7 @@ describe("useStorageUpload", () => {
 
       // Should call SAS token endpoint for large files
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/sas-token",
+        "/api/public/v0/storage/upload-urls",
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
@@ -368,29 +397,43 @@ describe("useStorageUpload", () => {
         callback: vi.fn(),
       } as unknown as UploadFilesEvent;
 
-      // Mock: one SAS request for all files, then resize-image for the small image
-      (global.fetch as ReturnType<typeof vi.fn>)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              sasTokens: {
-                "test.jpg": {
-                  success: true,
-                  url: "https://test.blob.core.windows.net/test?sas-token",
-                },
-                "large-video.mp4": {
-                  success: true,
-                  url: "https://test.blob.core.windows.net/large?sas-token",
-                },
-              },
-            }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-          headers: new Headers({ "Content-Type": "image/jpeg" }),
-        });
+      const uploadsPayload = {
+        uploads: {
+          "test.jpg": {
+            url: "https://test.blob.core.windows.net/test?sas-token",
+            headers: { "x-ms-blob-type": "BlockBlob" },
+            key: "mock/blob-key",
+          },
+          "large-video.mp4": {
+            url: "https://test.blob.core.windows.net/large?sas-token",
+            headers: { "x-ms-blob-type": "BlockBlob" },
+            key: "mock/blob-key",
+          },
+        },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+        async (input: RequestInfo | URL) => {
+          const u = typeof input === "string" ? input : input.toString();
+          if (u.includes("/upload-urls")) {
+            return {
+              ok: true,
+              json: () => Promise.resolve(uploadsPayload),
+            };
+          }
+          if (u.includes("/resize-image")) {
+            return {
+              ok: true,
+              arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+              headers: new Headers({ "Content-Type": "image/jpeg" }),
+            };
+          }
+          return {
+            ok: true,
+            text: () => Promise.resolve(""),
+          };
+        },
+      );
 
       const { result } = renderHook(
         () =>
@@ -406,7 +449,7 @@ describe("useStorageUpload", () => {
 
       // SAS token once for all files, then resize-image for the small image
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/sas-token",
+        "/api/public/v0/storage/upload-urls",
         expect.any(Object),
       );
       expect(global.fetch).toHaveBeenCalledWith(
@@ -439,24 +482,46 @@ describe("useStorageUpload", () => {
     });
 
     it("should call callback with results", async () => {
+      const file = new File(["test content"], "test.jpg", {
+        type: "image/jpeg",
+      });
+      Object.defineProperty(file, "size", { value: 100, writable: true });
+      Object.defineProperty(file, "arrayBuffer", {
+        value: () => Promise.resolve(new ArrayBuffer(8)),
+        writable: true,
+      });
+
       const mockCallback = vi.fn();
       const uploadOptions: UploadFilesEvent = {
-        files: [mockFile],
+        files: [file],
         callback: mockCallback,
       } as unknown as UploadFilesEvent;
 
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            files: [
-              {
-                name: "test.jpg",
-                url: "https://test.blob.core.windows.net/test",
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uploads: {
+                "test.jpg": {
+                  url: "https://test.blob.core.windows.net/test?sas=1",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/key",
+                },
               },
-            ],
-          }),
-      });
+              submissionId: mockSubmissionId,
+              userId: "user-1",
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+          headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve(""),
+        });
 
       const { result } = renderHook(
         () =>
@@ -473,7 +538,7 @@ describe("useStorageUpload", () => {
       expect(mockCallback).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({
-            file: mockFile,
+            file,
             content: "https://test.blob.core.windows.net/test",
           }),
         ]),
@@ -756,10 +821,11 @@ describe("useStorageUpload", () => {
           ok: true,
           json: () =>
             Promise.resolve({
-              sasTokens: {
+              uploads: {
                 "small.jpg": {
-                  success: true,
                   url: "https://test.blob.core.windows.net/small?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
                 },
               },
             }),
@@ -784,7 +850,7 @@ describe("useStorageUpload", () => {
 
       // Should call SAS token then resize-image for small images
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/sas-token",
+        "/api/public/v0/storage/upload-urls",
         expect.any(Object),
       );
       expect(global.fetch).toHaveBeenCalledWith(
@@ -810,11 +876,12 @@ describe("useStorageUpload", () => {
         ok: true,
         json: () =>
           Promise.resolve({
-            sasTokens: {
+            uploads: {
               "large.jpg": {
-                success: true,
-                url: "https://test.blob.core.windows.net/large?sas-token",
-              },
+                  url: "https://test.blob.core.windows.net/large?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
+                },
             },
           }),
       });
@@ -833,7 +900,7 @@ describe("useStorageUpload", () => {
 
       // Should call SAS token endpoint
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/sas-token",
+        "/api/public/v0/storage/upload-urls",
         expect.any(Object),
       );
     });
@@ -853,11 +920,12 @@ describe("useStorageUpload", () => {
         ok: true,
         json: () =>
           Promise.resolve({
-            sasTokens: {
+            uploads: {
               "document.pdf": {
-                success: true,
-                url: "https://test.blob.core.windows.net/document?sas-token",
-              },
+                  url: "https://test.blob.core.windows.net/document?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
+                },
             },
           }),
       });
@@ -876,7 +944,7 @@ describe("useStorageUpload", () => {
 
       // Should call SAS token endpoint for non-image files
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/sas-token",
+        "/api/public/v0/storage/upload-urls",
         expect.any(Object),
       );
     });
@@ -896,10 +964,11 @@ describe("useStorageUpload", () => {
             Promise.resolve({
               submissionId: "new-submission-id",
               userId: "user-1",
-              sasTokens: {
+              uploads: {
                 "test.jpg": {
-                  success: true,
                   url: "https://test.blob.core.windows.net/test?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
                 },
               },
             }),
@@ -945,10 +1014,11 @@ describe("useStorageUpload", () => {
             Promise.resolve({
               submissionId: mockSubmissionId, // Same as current
               userId: "user-1",
-              sasTokens: {
+              uploads: {
                 "test.jpg": {
-                  success: true,
                   url: "https://test.blob.core.windows.net/test?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
                 },
               },
             }),
@@ -1059,7 +1129,7 @@ describe("useStorageUpload", () => {
 
       // Should call read-token API first
       expect(global.fetch).toHaveBeenCalledWith(
-        "/api/public/v0/storage/read-token",
+        "/api/public/v0/storage/read-urls",
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
@@ -1270,10 +1340,9 @@ describe("useStorageUpload", () => {
         ok: true,
         json: () =>
           Promise.resolve({
-            sasTokens: {
+            uploads: {
               "large-video.mp4": {
-                success: false,
-                message: "File not allowed",
+                error: "File not allowed",
               },
             },
           }),
@@ -1307,24 +1376,22 @@ describe("useStorageUpload", () => {
         callback: vi.fn(),
       } as unknown as UploadFilesEvent;
 
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            sasTokens: {
-              "large-video.mp4": {
-                success: true,
-                url: "https://test.blob.core.windows.net/large?sas-token",
+      const uploadError = new Error("Upload failed");
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              uploads: {
+                "large-video.mp4": {
+                  url: "https://test.blob.core.windows.net/large?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
+                },
               },
-            },
-          }),
-      });
-
-      const error = new Error("Upload failed");
-      const mockUploadData = vi.fn().mockRejectedValue(error);
-      (BlockBlobClient as ReturnType<typeof vi.fn>).mockImplementation(function () {
-        return { uploadData: mockUploadData };
-      });
+            }),
+        })
+        .mockRejectedValueOnce(uploadError);
 
       const { result } = renderHook(
         () =>
@@ -1341,7 +1408,7 @@ describe("useStorageUpload", () => {
 
       // Assert
       const callbackSucessses: any[] = [];
-      const callbackErrors = [processUploadError(error)];
+      const callbackErrors = [processUploadError(uploadError)];
       expect(uploadOptions.callback).toHaveBeenCalledWith(
         callbackSucessses,
         callbackErrors,
@@ -1354,24 +1421,25 @@ describe("useStorageUpload", () => {
         callback: vi.fn(),
       } as unknown as UploadFilesEvent;
 
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            submissionId: "new-submission-id",
-            sasTokens: {
-              "large-video.mp4": {
-                success: true,
-                url: "https://test.blob.core.windows.net/large?sas-token",
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              submissionId: "new-submission-id",
+              uploads: {
+                "large-video.mp4": {
+                  url: "https://test.blob.core.windows.net/large?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
+                },
               },
-            },
-          }),
-      });
-
-      const mockUploadData = vi.fn().mockResolvedValue(undefined);
-      (BlockBlobClient as ReturnType<typeof vi.fn>).mockImplementation(function () {
-        return { uploadData: mockUploadData };
-      });
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve(""),
+        });
 
       const { result } = renderHook(
         () =>
@@ -1398,9 +1466,7 @@ describe("useStorageUpload", () => {
 
   describe("upload (SAS + resize) edge cases", () => {
     beforeEach(() => {
-      (BlockBlobClient as ReturnType<typeof vi.fn>).mockImplementation(function () {
-        return { uploadData: vi.fn().mockResolvedValue(undefined) };
-      });
+      vi.clearAllMocks();
     });
 
     it("should handle empty files array", async () => {
@@ -1466,10 +1532,11 @@ describe("useStorageUpload", () => {
           json: () =>
             Promise.resolve({
               submissionId: "new-submission-id",
-              sasTokens: {
+              uploads: {
                 "test.jpg": {
-                  success: true,
                   url: "https://test.blob.core.windows.net/test?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
                 },
               },
             }),
@@ -1478,6 +1545,10 @@ describe("useStorageUpload", () => {
           ok: true,
           arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
           headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve(""),
         });
 
       const { result } = renderHook(
@@ -1513,10 +1584,11 @@ describe("useStorageUpload", () => {
           ok: true,
           json: () =>
             Promise.resolve({
-              sasTokens: {
+              uploads: {
                 "test.jpg": {
-                  success: true,
                   url: "https://test.blob.core.windows.net/test?sas-token",
+                  headers: { "x-ms-blob-type": "BlockBlob" },
+                  key: "mock/blob-key",
                 },
               },
             }),
@@ -1525,6 +1597,10 @@ describe("useStorageUpload", () => {
           ok: true,
           arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
           headers: new Headers({ "Content-Type": "image/jpeg" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => Promise.resolve(""),
         });
 
       const { result } = renderHook(

--- a/features/asset-storage/__tests__/use-cases/upload/upload-blob.test.ts
+++ b/features/asset-storage/__tests__/use-cases/upload/upload-blob.test.ts
@@ -1,127 +1,88 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { RestError } from "@azure/storage-blob";
 import {
   uploadBlob,
   resizeImageOrFallback,
 } from "@/features/asset-storage/use-cases/upload/upload-blob";
 import {
   UploadError,
-  UploadUnauthorizedError,
-  UploadBlockedError,
 } from "@/features/asset-storage/use-cases/upload/upload-errors";
-
-const mockUploadData = vi.fn();
-
-vi.mock("@azure/storage-blob", async (importOriginal) => {
-  const mod = await importOriginal<typeof import("@azure/storage-blob")>();
-  return {
-    ...mod,
-    BlockBlobClient: vi.fn().mockImplementation(function () {
-      return { uploadData: mockUploadData };
-    }),
-  };
-});
 
 global.fetch = vi.fn();
 
 describe("uploadBlob", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUploadData.mockResolvedValue(undefined);
   });
 
-  it("uploads data and returns base URL without query", async () => {
+  it("uploads data via fetch PUT and returns base URL without query", async () => {
     const sasUrl =
       "https://account.blob.core.windows.net/container/file.pdf?sv=2020&sig=abc";
     const data = new ArrayBuffer(8);
-    const options = {
-      metadata: { fileName: "file.pdf", uploadedBy: "user-1" },
-      blobHTTPHeaders: { blobContentType: "application/pdf" },
+    const headers = {
+      "x-ms-blob-type": "BlockBlob",
+      "x-ms-blob-content-type": "application/pdf",
     };
 
-    const url = await uploadBlob(sasUrl, data, options);
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
+
+    const url = await uploadBlob(sasUrl, data, headers);
 
     expect(url).toBe(
       "https://account.blob.core.windows.net/container/file.pdf",
     );
-    expect(mockUploadData).toHaveBeenCalledTimes(1);
-    expect(mockUploadData).toHaveBeenCalledWith(
-      data,
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      sasUrl,
       expect.objectContaining({
-        metadata: options.metadata,
-        blobHTTPHeaders: options.blobHTTPHeaders,
+        method: "PUT",
+        body: data,
+        headers,
       }),
     );
   });
 
   it("returns full URL when no query string", async () => {
     const sasUrl = "https://account.blob.core.windows.net/container/file.pdf";
-    const url = await uploadBlob(sasUrl, new ArrayBuffer(0), {
-      metadata: {},
-      blobHTTPHeaders: {},
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
     });
+
+    const url = await uploadBlob(sasUrl, new ArrayBuffer(0), {});
 
     expect(url).toBe(sasUrl);
   });
 
-  it("throws UploadError when uploadData rejects with generic Error", async () => {
-    mockUploadData.mockRejectedValue(new Error("Network error"));
+  it("throws UploadError when fetch returns not ok", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      text: () => Promise.resolve("body"),
+    });
 
     await expect(
-      uploadBlob("https://x/y?s=1", new ArrayBuffer(0), {
-        metadata: {},
-        blobHTTPHeaders: {},
-      }),
+      uploadBlob("https://x/y?s=1", new ArrayBuffer(0), {}),
     ).rejects.toThrow(UploadError);
 
     try {
-      await uploadBlob("https://x/y?s=1", new ArrayBuffer(0), {
-        metadata: {},
-        blobHTTPHeaders: {},
-      });
+      await uploadBlob("https://x/y?s=1", new ArrayBuffer(0), {});
     } catch (err) {
       expect(err).toBeInstanceOf(UploadError);
-      expect((err as UploadError).message).toBe("Network error");
       expect((err as UploadError).fileUrl).toBe("https://x/y?s=1");
     }
   });
 
-  it("throws UploadUnauthorizedError when uploadData rejects with RestError 403 and AuthenticationFailed", async () => {
-    const restError = new RestError("Authentication failed", {
-      statusCode: 403,
-      code: "AuthenticationFailed",
-    });
-    mockUploadData.mockRejectedValue(restError);
+  it("throws UploadError when fetch rejects", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Network error"),
+    );
 
     await expect(
-      uploadBlob("https://account.blob/core/file?sv=1", new ArrayBuffer(0), {
-        metadata: {},
-        blobHTTPHeaders: {},
-      }),
-    ).rejects.toThrow(UploadUnauthorizedError);
-  });
-
-  it("throws UploadBlockedError when uploadData rejects with RestError 403 without AuthenticationFailed", async () => {
-    const restError = new RestError("Forbidden", { statusCode: 403 });
-    mockUploadData.mockRejectedValue(restError);
-
-    await expect(
-      uploadBlob("https://account.blob/core/file?sv=1", new ArrayBuffer(0), {
-        metadata: {},
-        blobHTTPHeaders: {},
-      }),
-    ).rejects.toThrow(UploadBlockedError);
-  });
-
-  it("throws UploadError when uploadData rejects with RestError other status", async () => {
-    const restError = new RestError("Bad request", { statusCode: 400 });
-    mockUploadData.mockRejectedValue(restError);
-
-    await expect(
-      uploadBlob("https://x/y?s=1", new ArrayBuffer(0), {
-        metadata: {},
-        blobHTTPHeaders: {},
-      }),
+      uploadBlob("https://x/y?s=1", new ArrayBuffer(0), {}),
     ).rejects.toThrow(UploadError);
   });
 });

--- a/features/asset-storage/__tests__/use-cases/upload/upload-blob.test.ts
+++ b/features/asset-storage/__tests__/use-cases/upload/upload-blob.test.ts
@@ -68,11 +68,18 @@ describe("uploadBlob", () => {
       uploadBlob("https://x/y?s=1", new ArrayBuffer(0), {}),
     ).rejects.toThrow(UploadError);
 
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      text: () => Promise.resolve("body"),
+    });
+
     try {
       await uploadBlob("https://x/y?s=1", new ArrayBuffer(0), {});
     } catch (err) {
       expect(err).toBeInstanceOf(UploadError);
-      expect((err as UploadError).fileUrl).toBe("https://x/y?s=1");
+      expect((err as UploadError).fileUrl).toBe("https://x/y");
     }
   });
 

--- a/features/asset-storage/__tests__/use-cases/upload/upload-handler.factory.test.ts
+++ b/features/asset-storage/__tests__/use-cases/upload/upload-handler.factory.test.ts
@@ -72,7 +72,7 @@ describe("createUserUpload", () => {
       ["Failed to generate upload URLs"],
     );
     expect(mockFetchUploadUrls).toHaveBeenCalledWith(
-      "/api/public/v0/storage/sas-token",
+      "/api/public/v0/storage/upload-urls",
       expect.objectContaining({
         fileNames: ["a.pdf"],
         formId: "form-1",
@@ -84,10 +84,11 @@ describe("createUserUpload", () => {
 
   it("calls onSubmissionIdChange when SAS returns new submissionId", async () => {
     const sasData: UploadUrlsData = {
-      sasTokens: {
+      uploads: {
         "a.pdf": {
-          success: true,
           url: "https://storage.blob/core/file?sas",
+          headers: { "x-ms-blob-type": "BlockBlob" },
+          key: "k",
         },
       },
       submissionId: "sub-new",
@@ -135,8 +136,8 @@ describe("createUserUpload", () => {
 
   it("calls callback with error when token missing for file", async () => {
     const sasData: UploadUrlsData = {
-      sasTokens: {
-        "a.pdf": { success: false, message: "No URL for a.pdf" },
+      uploads: {
+        "a.pdf": { error: "No URL for a.pdf" },
       },
       userId: "user-1",
     };
@@ -204,10 +205,11 @@ describe("createContentUpload", () => {
 
   it("calls callback success with first URL when uploads succeed", async () => {
     const sasData: UploadUrlsData = {
-      sasTokens: {
+      uploads: {
         "img.png": {
-          success: true,
           url: "https://storage.blob/core/img?sas",
+          headers: { "x-ms-blob-type": "BlockBlob" },
+          key: "k",
         },
       },
       uploadMetadata: {
@@ -243,10 +245,11 @@ describe("createContentUpload", () => {
 
   it("calls callback error when processAndUploadFile returns error", async () => {
     const sasData: UploadUrlsData = {
-      sasTokens: {
+      uploads: {
         "img.png": {
-          success: true,
           url: "https://storage.blob/core/img?sas",
+          headers: { "x-ms-blob-type": "BlockBlob" },
+          key: "k",
         },
       },
       uploadMetadata: {

--- a/features/asset-storage/__tests__/use-cases/upload/upload-handler.factory.test.ts
+++ b/features/asset-storage/__tests__/use-cases/upload/upload-handler.factory.test.ts
@@ -18,11 +18,17 @@ const { mockFetchUploadUrls, mockProcessAndUploadFile } = vi.hoisted(() => ({
   mockProcessAndUploadFile: vi.fn(),
 }));
 
-vi.mock("@/features/asset-storage/use-cases/upload/upload.utils", () => ({
-  fetchUploadUrls: (...args: unknown[]) => mockFetchUploadUrls(...args),
-  processAndUploadFile: (...args: unknown[]) =>
-    mockProcessAndUploadFile(...args),
-}));
+vi.mock("@/features/asset-storage/use-cases/upload/upload.utils", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/features/asset-storage/use-cases/upload/upload.utils")
+  >("@/features/asset-storage/use-cases/upload/upload.utils");
+  return {
+    ...actual,
+    fetchUploadUrls: (...args: unknown[]) => mockFetchUploadUrls(...args),
+    processAndUploadFile: (...args: unknown[]) =>
+      mockProcessAndUploadFile(...args),
+  };
+});
 
 describe("createUserUpload", () => {
   const userConfig: UserUploadConfig = {
@@ -78,6 +84,9 @@ describe("createUserUpload", () => {
         formId: "form-1",
         submissionId: "sub-1",
         formLocale: "en",
+        fileTypes: { "a.pdf": "application/pdf" },
+        fileStates: { "a.pdf": "original" },
+        questionName: "q1",
       }),
     );
   });

--- a/features/asset-storage/__tests__/use-cases/upload/upload.utils.test.ts
+++ b/features/asset-storage/__tests__/use-cases/upload/upload.utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Result } from "@/lib/result";
 import {
   fetchUploadUrls,
+  prepareUploadBytes,
   processAndUploadFile,
   type UploadUrlsData,
 } from "@/features/asset-storage/use-cases/upload/upload.utils";
@@ -96,20 +97,9 @@ describe("fetchUploadUrls", () => {
   });
 });
 
-describe("processAndUploadFile", () => {
-  const userMeta = {
-    kind: "user" as const,
-    uploadedBy: "user-1",
-    displayName: "doc.pdf",
-    contentType: "application/pdf",
-    formId: "f1",
-    submissionId: "s1",
-    formLang: "en",
-  };
-
+describe("prepareUploadBytes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUploadBlob.mockResolvedValue("https://example.com/container/doc.pdf");
     mockResizeImageOrFallback.mockResolvedValue({
       buffer: new ArrayBuffer(0),
       contentType: "image/png",
@@ -117,89 +107,73 @@ describe("processAndUploadFile", () => {
     });
   });
 
-  it("returns success with url and file when upload succeeds (no resize)", async () => {
-    const file = new File(["content"], "doc.pdf", {
-      type: "application/pdf",
-    });
+  it("reads arrayBuffer when resize URL is omitted", async () => {
+    const file = new File(["x"], "doc.pdf", { type: "application/pdf" });
     Object.defineProperty(file, "arrayBuffer", {
       value: () => Promise.resolve(new ArrayBuffer(8)),
       writable: false,
     });
 
-    const result = await processAndUploadFile(
-      file,
-      sampleDescriptor,
-      userMeta,
-    );
+    const out = await prepareUploadBytes(file, undefined);
+    expect(out.buffer.byteLength).toBe(8);
+    expect(out.contentType).toBe("application/pdf");
+    expect(out.fileState).toBe("original");
+    expect(mockResizeImageOrFallback).not.toHaveBeenCalled();
+  });
+
+  it("calls resize for small images when resize URL is set", async () => {
+    const file = new File([new Uint8Array(10)], "img.png", {
+      type: "image/png",
+    });
+    Object.defineProperty(file, "size", { value: 100, writable: false });
+
+    const out = await prepareUploadBytes(file, "/api/resize");
+    expect(mockResizeImageOrFallback).toHaveBeenCalledWith(file, "/api/resize");
+    expect(out.contentType).toBe("image/png");
+    expect(out.fileState).toBe("optimized");
+  });
+});
+
+describe("processAndUploadFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUploadBlob.mockResolvedValue("https://example.com/container/doc.pdf");
+  });
+
+  it("returns success with url and file when upload succeeds", async () => {
+    const file = new File(["content"], "doc.pdf", {
+      type: "application/pdf",
+    });
+    const buffer = new ArrayBuffer(8);
+
+    const result = await processAndUploadFile(file, sampleDescriptor, buffer);
 
     expect(Result.isSuccess(result)).toBe(true);
     if (Result.isSuccess(result)) {
       expect(result.value.url).toBe("https://example.com/container/doc.pdf");
       expect(result.value.file).toBe(file);
     }
-    expect(mockResizeImageOrFallback).not.toHaveBeenCalled();
     expect(mockUploadBlob).toHaveBeenCalledTimes(1);
-    const putArgs = mockUploadBlob.mock.calls[0];
-    expect(putArgs[0]).toBe(sampleDescriptor.url);
-    expect(putArgs[1]).toBeInstanceOf(ArrayBuffer);
-    expect(typeof putArgs[2]).toBe("object");
-  });
-
-  it("returns success when resize is used for image under threshold", async () => {
-    const file = new File([new Uint8Array(10)], "img.png", {
-      type: "image/png",
-    });
-    Object.defineProperty(file, "size", { value: 100, writable: false });
-
-    const result = await processAndUploadFile(
-      file,
-      sampleDescriptor,
-      userMeta,
-      "/api/resize",
+    expect(mockUploadBlob).toHaveBeenCalledWith(
+      sampleDescriptor.url,
+      buffer,
+      sampleDescriptor.headers,
     );
-
-    expect(Result.isSuccess(result)).toBe(true);
-    expect(mockResizeImageOrFallback).toHaveBeenCalledWith(file, "/api/resize");
-    expect(mockUploadBlob).toHaveBeenCalledTimes(1);
   });
 
   it("returns error when uploadBlob throws", async () => {
     const file = new File(["x"], "doc.pdf", { type: "application/pdf" });
-    Object.defineProperty(file, "arrayBuffer", {
-      value: () => Promise.resolve(new ArrayBuffer(1)),
-      writable: false,
-    });
     mockUploadBlob.mockRejectedValue(new Error("Upload failed"));
 
     const result = await processAndUploadFile(
       file,
       sampleDescriptor,
-      userMeta,
+      new ArrayBuffer(1),
     );
 
     expect(Result.isError(result)).toBe(true);
     if (Result.isError(result)) {
       expect(result.message).toBe("Upload failed");
-    }
-  });
-
-  it("returns error when resize throws", async () => {
-    const file = new File([new Uint8Array(10)], "img.png", {
-      type: "image/png",
-    });
-    Object.defineProperty(file, "size", { value: 100, writable: false });
-    mockResizeImageOrFallback.mockRejectedValue(new Error("Resize failed"));
-
-    const result = await processAndUploadFile(
-      file,
-      sampleDescriptor,
-      userMeta,
-      "/api/resize",
-    );
-
-    expect(Result.isError(result)).toBe(true);
-    if (Result.isError(result)) {
-      expect(result.message).toBe("Resize failed");
     }
   });
 });

--- a/features/asset-storage/__tests__/use-cases/upload/upload.utils.test.ts
+++ b/features/asset-storage/__tests__/use-cases/upload/upload.utils.test.ts
@@ -19,6 +19,12 @@ vi.mock("@/features/asset-storage/use-cases/upload/upload-blob", () => ({
 
 global.fetch = vi.fn();
 
+const sampleDescriptor = {
+  url: "https://example.com/a?sas",
+  key: "folder/a.pdf",
+  headers: { "x-ms-blob-type": "BlockBlob" as const },
+};
+
 describe("fetchUploadUrls", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -26,8 +32,8 @@ describe("fetchUploadUrls", () => {
 
   it("returns success with data when response is ok", async () => {
     const data: UploadUrlsData = {
-      sasTokens: {
-        "a.pdf": { success: true, url: "https://example.com/a?sas" },
+      uploads: {
+        "a.pdf": sampleDescriptor,
       },
       userId: "user-1",
     };
@@ -36,14 +42,14 @@ describe("fetchUploadUrls", () => {
       json: () => Promise.resolve(data),
     });
 
-    const result = await fetchUploadUrls("/api/sas", { fileNames: ["a.pdf"] });
+    const result = await fetchUploadUrls("/api/upload-urls", {
+      fileNames: ["a.pdf"],
+    });
 
     expect(Result.isSuccess(result)).toBe(true);
     if (Result.isSuccess(result)) {
       expect(result.value).toEqual(data);
-      expect(result.value.sasTokens["a.pdf"].url).toBe(
-        "https://example.com/a?sas",
-      );
+      expect(result.value.uploads["a.pdf"]).toEqual(sampleDescriptor);
     }
   });
 
@@ -54,7 +60,7 @@ describe("fetchUploadUrls", () => {
         Promise.resolve({ detail: "Validation failed", error: "Bad request" }),
     });
 
-    const result = await fetchUploadUrls("/api/sas", {});
+    const result = await fetchUploadUrls("/api/upload-urls", {});
 
     expect(Result.isError(result)).toBe(true);
     if (Result.isError(result)) {
@@ -68,7 +74,7 @@ describe("fetchUploadUrls", () => {
       json: () => Promise.resolve({}),
     });
 
-    const result = await fetchUploadUrls("/api/sas", {});
+    const result = await fetchUploadUrls("/api/upload-urls", {});
 
     expect(Result.isError(result)).toBe(true);
     if (Result.isError(result)) {
@@ -81,7 +87,7 @@ describe("fetchUploadUrls", () => {
       new Error("Network error"),
     );
 
-    const result = await fetchUploadUrls("/api/sas", {});
+    const result = await fetchUploadUrls("/api/upload-urls", {});
 
     expect(Result.isError(result)).toBe(true);
     if (Result.isError(result)) {
@@ -122,7 +128,7 @@ describe("processAndUploadFile", () => {
 
     const result = await processAndUploadFile(
       file,
-      "https://example.com/sas",
+      sampleDescriptor,
       userMeta,
     );
 
@@ -133,6 +139,10 @@ describe("processAndUploadFile", () => {
     }
     expect(mockResizeImageOrFallback).not.toHaveBeenCalled();
     expect(mockUploadBlob).toHaveBeenCalledTimes(1);
+    const putArgs = mockUploadBlob.mock.calls[0];
+    expect(putArgs[0]).toBe(sampleDescriptor.url);
+    expect(putArgs[1]).toBeInstanceOf(ArrayBuffer);
+    expect(typeof putArgs[2]).toBe("object");
   });
 
   it("returns success when resize is used for image under threshold", async () => {
@@ -143,7 +153,7 @@ describe("processAndUploadFile", () => {
 
     const result = await processAndUploadFile(
       file,
-      "https://example.com/sas",
+      sampleDescriptor,
       userMeta,
       "/api/resize",
     );
@@ -163,7 +173,7 @@ describe("processAndUploadFile", () => {
 
     const result = await processAndUploadFile(
       file,
-      "https://example.com/sas",
+      sampleDescriptor,
       userMeta,
     );
 
@@ -182,7 +192,7 @@ describe("processAndUploadFile", () => {
 
     const result = await processAndUploadFile(
       file,
-      "https://example.com/sas",
+      sampleDescriptor,
       userMeta,
       "/api/resize",
     );

--- a/features/asset-storage/infrastructure/providers/azure/azure-blob-metadata-parser.ts
+++ b/features/asset-storage/infrastructure/providers/azure/azure-blob-metadata-parser.ts
@@ -159,6 +159,43 @@ export function toBlobUploadOptions(meta: FileMetadata): BlobUploadOptions {
   };
 }
 
+/**
+ * HTTP headers for a client-side `fetch` PUT to an Azure block blob SAS URL
+ * (replaces BlockBlobClient.uploadData header composition in the browser).
+ */
+export function toAzureBlockBlobPutHeaders(
+  options: BlobUploadOptions,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "x-ms-blob-type": "BlockBlob",
+  };
+  const { blobHTTPHeaders, metadata } = options;
+
+  if (blobHTTPHeaders.blobContentType) {
+    headers["x-ms-blob-content-type"] = blobHTTPHeaders.blobContentType;
+  }
+  if (blobHTTPHeaders.blobContentDisposition) {
+    headers["x-ms-blob-content-disposition"] =
+      blobHTTPHeaders.blobContentDisposition;
+  }
+  if (
+    blobHTTPHeaders.blobContentLanguage !== undefined &&
+    blobHTTPHeaders.blobContentLanguage !== ""
+  ) {
+    headers["x-ms-blob-content-language"] = blobHTTPHeaders.blobContentLanguage;
+  }
+
+  for (const [rawKey, value] of Object.entries(metadata)) {
+    if (value === undefined || value === "") {
+      continue;
+    }
+    const metaKey = rawKey.toLowerCase();
+    headers[`x-ms-meta-${metaKey}`] = value;
+  }
+
+  return headers;
+}
+
 function buildUserFileMetadata(
   fileMetadata: UserFileMetadata,
 ): Record<string, string> {

--- a/features/asset-storage/infrastructure/providers/azure/azure-storage-provider.ts
+++ b/features/asset-storage/infrastructure/providers/azure/azure-storage-provider.ts
@@ -16,6 +16,7 @@ import type {
   BulkReadUrlsOptions,
   FileOptions,
   FolderOptions,
+  UploadUrlDescriptor,
 } from "./types";
 
 const READ_ONLY_PERMISSIONS = BlobSASPermissions.parse("r");
@@ -184,7 +185,7 @@ export class AzureBlobStorageProvider implements IStorageProvider {
   async generateUploadUrl(
     fileOptions: FileOptions,
     permissions: "wr" = "wr",
-  ): Promise<string> {
+  ): Promise<UploadUrlDescriptor> {
     const config = this.getConfig();
     if (!config.isEnabled) {
       throw new Error("Azure storage is not enabled");
@@ -215,14 +216,20 @@ export class AzureBlobStorageProvider implements IStorageProvider {
 
       const NOW = new Date(Date.now());
       const EXPIRY_IN_MS = 1000 * 60 * 3; // 3 minutes
-      const sasToken = blobClient.generateSasUrl({
+      const sasToken = await blobClient.generateSasUrl({
         startsOn: NOW,
         permissions: BlobSASPermissions.parse(permissions),
         expiresOn: new Date(NOW.valueOf() + EXPIRY_IN_MS),
         protocol: SASProtocol.Https,
       });
 
-      return sasToken;
+      return {
+        url: sasToken,
+        key: blobName,
+        headers: {
+          "x-ms-blob-type": "BlockBlob",
+        },
+      };
     } catch (error) {
       console.error("Error generating SAS token:", error);
       throw error;

--- a/features/asset-storage/infrastructure/providers/azure/azure-storage-provider.ts
+++ b/features/asset-storage/infrastructure/providers/azure/azure-storage-provider.ts
@@ -11,6 +11,10 @@ import type { ReadTokensResult as BulkReadTokensResult } from "../../../types";
 import type { IStorageProvider } from "../../core/storage-provider.interface";
 import { buildUserFileFolderPath } from "../../storage-utils";
 import { getAzureStorageConfig, type AzureStorageConfig } from "./azure-config";
+import {
+  toAzureBlockBlobPutHeaders,
+  toBlobUploadOptions,
+} from "./azure-blob-metadata-parser";
 import type {
   BlobPropertiesResult,
   BulkReadUrlsOptions,
@@ -223,12 +227,17 @@ export class AzureBlobStorageProvider implements IStorageProvider {
         protocol: SASProtocol.Https,
       });
 
+      const headers =
+        fileOptions.blobUploadFileMetadata !== undefined
+          ? toAzureBlockBlobPutHeaders(
+              toBlobUploadOptions(fileOptions.blobUploadFileMetadata),
+            )
+          : { "x-ms-blob-type": "BlockBlob" };
+
       return {
         url: sasToken,
         key: blobName,
-        headers: {
-          "x-ms-blob-type": "BlockBlob",
-        },
+        headers,
       };
     } catch (error) {
       console.error("Error generating SAS token:", error);

--- a/features/asset-storage/infrastructure/providers/azure/index.ts
+++ b/features/asset-storage/infrastructure/providers/azure/index.ts
@@ -13,6 +13,7 @@ export { AzureBlobStorageProvider } from "./azure-storage-provider";
 export {
   blobMetadataParser,
   toBlobUploadOptions,
+  toAzureBlockBlobPutHeaders,
 } from "./azure-blob-metadata-parser";
 export type {
   BlobPropertiesResult,

--- a/features/asset-storage/infrastructure/providers/azure/types.ts
+++ b/features/asset-storage/infrastructure/providers/azure/types.ts
@@ -21,3 +21,10 @@ export interface BulkReadUrlsOptions extends Omit<FileOptions, "fileName"> {
   resourceNames?: string[];
   expiresInMinutes?: number;
 }
+
+/** Presigned upload URL plus headers and object key for client-side `fetch` PUT. */
+export interface UploadUrlDescriptor {
+  url: string;
+  headers: Record<string, string>;
+  key: string;
+}

--- a/features/asset-storage/infrastructure/providers/azure/types.ts
+++ b/features/asset-storage/infrastructure/providers/azure/types.ts
@@ -1,7 +1,10 @@
+import type { FileMetadata } from "../../../types";
+
 export interface FileOptions {
   fileName: string;
   containerName: string;
   folderPath?: string;
+  blobUploadFileMetadata?: FileMetadata;
 }
 
 export interface FolderOptions {

--- a/features/asset-storage/infrastructure/storage-gateway.ts
+++ b/features/asset-storage/infrastructure/storage-gateway.ts
@@ -10,6 +10,7 @@ import type {
   BulkReadUrlsOptions,
   FileOptions,
   FolderOptions,
+  UploadUrlDescriptor,
 } from "./providers/azure/types";
 
 /** Used when `instrumentation` has not run (e.g. Vitest). */
@@ -95,7 +96,7 @@ export async function bulkGenerateReadTokens(
 export async function generateUploadUrl(
   fileOptions: FileOptions,
   permissions: "wr" = "wr",
-): Promise<string> {
+): Promise<UploadUrlDescriptor> {
   return requireEnabledAzureProvider().generateUploadUrl(
     fileOptions,
     permissions,
@@ -131,4 +132,10 @@ export function resetBlobServiceClient(): void {
   }
 }
 
-export type { BulkReadUrlsOptions, FileOptions, BlobPropertiesResult };
+export type {
+  BlobPropertiesResult,
+  BulkReadUrlsOptions,
+  FileOptions,
+  FolderOptions,
+  UploadUrlDescriptor,
+};

--- a/features/asset-storage/server.ts
+++ b/features/asset-storage/server.ts
@@ -31,6 +31,7 @@ export {
   uploadToStorage,
   type BlobPropertiesResult,
   type FileOptions,
+  type UploadUrlDescriptor,
 } from "./infrastructure/storage-gateway";
 export * from "./types";
 export { AssetStorageProvider } from "./ui/asset-storage.provider";

--- a/features/asset-storage/use-cases/upload-user-files/use-storage-upload.hook.tsx
+++ b/features/asset-storage/use-cases/upload-user-files/use-storage-upload.hook.tsx
@@ -144,7 +144,7 @@ export function useStorageUpload({
       if (storageConfig?.isPrivate) {
         try {
           const tokenResponse = await fetch(
-            "/api/public/v0/storage/read-token",
+            "/api/public/v0/storage/read-urls",
             {
               method: "POST",
               headers: { "Content-Type": "application/json" },

--- a/features/asset-storage/use-cases/upload/upload-blob.ts
+++ b/features/asset-storage/use-cases/upload/upload-blob.ts
@@ -24,7 +24,8 @@ export async function uploadBlob(
       throw new Error(`Blob upload failed: ${detail}`);
     }
   } catch (err) {
-    throwUploadError(err, uploadUrl);
+    const fileUrl = uploadUrl.split("?").at(0) ?? uploadUrl;
+    throwUploadError(err, fileUrl);
   }
 
   return uploadUrl.split("?").at(0) ?? uploadUrl;

--- a/features/asset-storage/use-cases/upload/upload-blob.ts
+++ b/features/asset-storage/use-cases/upload/upload-blob.ts
@@ -1,32 +1,33 @@
-import { BlockBlobClient } from "@azure/storage-blob";
-import type { BlobUploadOptions } from "../../types";
 import { throwUploadError } from "./upload-errors";
 
-/** Uploads files to a SAS blob URL and returns the base URL (without query). */
+/**
+ * Uploads bytes to a presigned blob URL via `fetch` PUT (no Azure SDK on the client).
+ * @param uploadUrl - Full URL including SAS or presigned query string.
+ * @param data - Raw file bytes.
+ * @param headers - Merged provider base headers + {@link toAzureBlockBlobPutHeaders} (or S3 equivalent).
+ */
 export async function uploadBlob(
-  sasUrl: string,
+  uploadUrl: string,
   data: ArrayBuffer,
-  options: BlobUploadOptions,
+  headers: Record<string, string>,
 ): Promise<string> {
-  const client = new BlockBlobClient(sasUrl);
   try {
-    await client.uploadData(data, {
-      metadata: options.metadata,
-      blobHTTPHeaders: options.blobHTTPHeaders,
-      onProgress: (progress) => {
-        const progressPercentage = Math.round(
-          (progress.loadedBytes / data.byteLength) * 100,
-        );
-        console.debug(
-          `Upload of ${options.metadata.fileName} is ${progressPercentage}% complete`,
-        );
-      },
+    const response = await fetch(uploadUrl, {
+      method: "PUT",
+      body: data,
+      headers,
     });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      const detail = text || response.statusText || `HTTP ${response.status}`;
+      throw new Error(`Blob upload failed: ${detail}`);
+    }
   } catch (err) {
-    throwUploadError(err, sasUrl);
+    throwUploadError(err, uploadUrl);
   }
 
-  return sasUrl.split("?").at(0) ?? sasUrl;
+  return uploadUrl.split("?").at(0) ?? uploadUrl;
 }
 
 export type ResizeResult = {

--- a/features/asset-storage/use-cases/upload/upload-blob.ts
+++ b/features/asset-storage/use-cases/upload/upload-blob.ts
@@ -1,10 +1,10 @@
 import { throwUploadError } from "./upload-errors";
 
 /**
- * Uploads bytes to a presigned blob URL via `fetch` PUT (no Azure SDK on the client).
+ * Uploads bytes to a presigned blob URL via `fetch` PUT (no storage SDK on the client).
  * @param uploadUrl - Full URL including SAS or presigned query string.
  * @param data - Raw file bytes.
- * @param headers - Merged provider base headers + {@link toAzureBlockBlobPutHeaders} (or S3 equivalent).
+ * @param headers - Header map from {@link UploadUrlDescriptor.headers} (composed server-side).
  */
 export async function uploadBlob(
   uploadUrl: string,

--- a/features/asset-storage/use-cases/upload/upload-handler.factory.ts
+++ b/features/asset-storage/use-cases/upload/upload-handler.factory.ts
@@ -1,18 +1,32 @@
 import type { SurveyModel, UploadFilesEvent } from "survey-core";
 import type { UploadFileEvent } from "survey-creator-core";
 import { Result, type ResultType } from "@/lib/result";
-import type { ContentItemType, FileMetadata } from "../../types";
+import type { ContentItemType } from "../../types";
 import type { UploadUrlDescriptor } from "../../infrastructure/storage-gateway";
-import { buildUserFileMetadata } from "../../infrastructure/storage-utils";
 import {
   fetchUploadUrls,
+  prepareUploadBytes,
   processAndUploadFile,
   type ProcessAndUploadSuccess,
+  type PreparedUploadBytes,
   type UploadUrlsData,
 } from "./upload.utils";
 
 const USER_UPLOAD_URLS = "/api/public/v0/storage/upload-urls";
 const USER_RESIZE_URL = "/api/public/v0/storage/resize-image";
+
+function buildPerFileMaps(prepared: PreparedUploadBytes[]): {
+  fileTypes: Record<string, string>;
+  fileStates: Record<string, PreparedUploadBytes["fileState"]>;
+} {
+  const fileTypes: Record<string, string> = {};
+  const fileStates: Record<string, PreparedUploadBytes["fileState"]> = {};
+  for (const p of prepared) {
+    fileTypes[p.file.name] = p.contentType;
+    fileStates[p.file.name] = p.fileState;
+  }
+  return { fileTypes, fileStates };
+}
 
 export interface UserUploadConfig {
   formId: string;
@@ -46,11 +60,22 @@ export function createUserUpload(config: UserUploadConfig) {
     }
 
     const currentSubmissionId = getSubmissionId?.();
+    const resizeUrl = isResizeEnabled ? USER_RESIZE_URL : undefined;
+
+    const prepared = await Promise.all(
+      options.files.map((file) => prepareUploadBytes(file, resizeUrl)),
+    );
+
+    const { fileTypes, fileStates } = buildPerFileMaps(prepared);
+
     const sasResult = await fetchUploadUrls(USER_UPLOAD_URLS, {
       fileNames: options.files.map((f) => f.name),
       submissionId: currentSubmissionId,
       formId,
       formLocale: surveyModel?.locale ?? "",
+      fileTypes,
+      fileStates,
+      questionName: options.question?.name ?? "",
     });
 
     if (Result.isError(sasResult)) {
@@ -68,8 +93,11 @@ export function createUserUpload(config: UserUploadConfig) {
     }
 
     const uploadResults = await Promise.all(
-      options.files.map(
-        async (file): Promise<ResultType<ProcessAndUploadSuccess>> => {
+      prepared.map(
+        async ({
+          file,
+          buffer,
+        }): Promise<ResultType<ProcessAndUploadSuccess>> => {
           const entry = sasData.uploads[file.name];
           if (!entry) {
             return Result.error(`No URL for ${file.name}`);
@@ -80,23 +108,7 @@ export function createUserUpload(config: UserUploadConfig) {
 
           const descriptor: UploadUrlDescriptor = entry;
 
-          const metadata: FileMetadata = buildUserFileMetadata({
-            kind: "user",
-            uploadedBy: sasData.userId ?? "anonymous",
-            formId,
-            submissionId: sasData.submissionId ?? currentSubmissionId ?? "",
-            questionName: options.question?.name ?? "",
-            formLang: surveyModel?.locale ?? "",
-            displayName: file.name,
-            contentType: file.type,
-          });
-
-          return processAndUploadFile(
-            file,
-            descriptor,
-            metadata,
-            isResizeEnabled ? USER_RESIZE_URL : undefined,
-          );
+          return processAndUploadFile(file, descriptor, buffer);
         },
       ),
     );
@@ -143,11 +155,21 @@ export function createContentUpload(config: ContentUploadConfig) {
     const files = options.files ?? [];
     if (files.length === 0) return;
 
+    const resizeUrl = isResizeEnabled ? CONTENT_RESIZE_URL : undefined;
+
+    const prepared = await Promise.all(
+      files.map((file) => prepareUploadBytes(file, resizeUrl)),
+    );
+
+    const { fileTypes, fileStates } = buildPerFileMaps(prepared);
+
     const sasResult = await fetchUploadUrls(CONTENT_UPLOAD_URLS, {
       itemId,
       itemType,
       fileNames: files.map((f) => f.name),
       questionName,
+      fileTypes,
+      fileStates,
     });
 
     if (Result.isError(sasResult)) {
@@ -158,41 +180,24 @@ export function createContentUpload(config: ContentUploadConfig) {
     const uploadUrlsData: UploadUrlsData = sasResult.value;
 
     const uploadResults = await Promise.all(
-      files.map(async (file): Promise<ResultType<ProcessAndUploadSuccess>> => {
-        const entry = uploadUrlsData.uploads[file.name];
-        if (!entry) {
-          return Result.error(`No upload URL for ${file.name}`);
-        }
-        if ("error" in entry) {
-          return Result.error(entry.error);
-        }
-
-        const descriptor: UploadUrlDescriptor = entry;
-
-        const meta = uploadUrlsData.uploadMetadata ?? {
-          userId: "",
-          itemId,
-          contentItemType: itemType,
-          questionName,
-        };
-
-        const metadata: FileMetadata = {
-          kind: "content",
-          uploadedBy: meta.userId,
-          itemId: meta.itemId,
-          contentItemType: meta.contentItemType as ContentItemType,
-          displayName: file.name,
-          contentType: file.type,
-          questionName: meta.questionName,
-        };
-
-        return processAndUploadFile(
+      prepared.map(
+        async ({
           file,
-          descriptor,
-          metadata,
-          isResizeEnabled ? CONTENT_RESIZE_URL : undefined,
-        );
-      }),
+          buffer,
+        }): Promise<ResultType<ProcessAndUploadSuccess>> => {
+          const entry = uploadUrlsData.uploads[file.name];
+          if (!entry) {
+            return Result.error(`No upload URL for ${file.name}`);
+          }
+          if ("error" in entry) {
+            return Result.error(entry.error);
+          }
+
+          const descriptor: UploadUrlDescriptor = entry;
+
+          return processAndUploadFile(file, descriptor, buffer);
+        },
+      ),
     );
 
     const firstError = uploadResults.find(Result.isError);

--- a/features/asset-storage/use-cases/upload/upload-handler.factory.ts
+++ b/features/asset-storage/use-cases/upload/upload-handler.factory.ts
@@ -2,6 +2,7 @@ import type { SurveyModel, UploadFilesEvent } from "survey-core";
 import type { UploadFileEvent } from "survey-creator-core";
 import { Result, type ResultType } from "@/lib/result";
 import type { ContentItemType, FileMetadata } from "../../types";
+import type { UploadUrlDescriptor } from "../../infrastructure/storage-gateway";
 import { buildUserFileMetadata } from "../../infrastructure/storage-utils";
 import {
   fetchUploadUrls,
@@ -10,7 +11,7 @@ import {
   type UploadUrlsData,
 } from "./upload.utils";
 
-const USER_SAS_URL = "/api/public/v0/storage/sas-token";
+const USER_UPLOAD_URLS = "/api/public/v0/storage/upload-urls";
 const USER_RESIZE_URL = "/api/public/v0/storage/resize-image";
 
 export interface UserUploadConfig {
@@ -45,7 +46,7 @@ export function createUserUpload(config: UserUploadConfig) {
     }
 
     const currentSubmissionId = getSubmissionId?.();
-    const sasResult = await fetchUploadUrls(USER_SAS_URL, {
+    const sasResult = await fetchUploadUrls(USER_UPLOAD_URLS, {
       fileNames: options.files.map((f) => f.name),
       submissionId: currentSubmissionId,
       formId,
@@ -66,10 +67,15 @@ export function createUserUpload(config: UserUploadConfig) {
     const uploadResults = await Promise.all(
       options.files.map(
         async (file): Promise<ResultType<ProcessAndUploadSuccess>> => {
-          const token = sasData.sasTokens[file.name];
-          if (!token?.success || !token?.url) {
-            return Result.error(token?.message ?? `No URL for ${file.name}`);
+          const entry = sasData.uploads[file.name];
+          if (!entry) {
+            return Result.error(`No URL for ${file.name}`);
           }
+          if ("error" in entry) {
+            return Result.error(entry.error);
+          }
+
+          const descriptor: UploadUrlDescriptor = entry;
 
           const metadata: FileMetadata = buildUserFileMetadata({
             kind: "user",
@@ -84,7 +90,7 @@ export function createUserUpload(config: UserUploadConfig) {
 
           return processAndUploadFile(
             file,
-            token.url,
+            descriptor,
             metadata,
             isResizeEnabled ? USER_RESIZE_URL : undefined,
           );
@@ -109,7 +115,7 @@ export function createUserUpload(config: UserUploadConfig) {
 
 // ─── Content (creator) upload ─────────────────────────────────────────────
 
-const CONTENT_SAS_URL = "/api/hub/v0/storage/content/sas-token";
+const CONTENT_UPLOAD_URLS = "/api/hub/v0/storage/content/upload-urls";
 const CONTENT_RESIZE_URL = "/api/hub/v0/storage/resize-image";
 
 export interface ContentUploadConfig {
@@ -134,7 +140,7 @@ export function createContentUpload(config: ContentUploadConfig) {
     const files = options.files ?? [];
     if (files.length === 0) return;
 
-    const sasResult = await fetchUploadUrls(CONTENT_SAS_URL, {
+    const sasResult = await fetchUploadUrls(CONTENT_UPLOAD_URLS, {
       itemId,
       itemType,
       fileNames: files.map((f) => f.name),
@@ -150,10 +156,15 @@ export function createContentUpload(config: ContentUploadConfig) {
 
     const uploadResults = await Promise.all(
       files.map(async (file): Promise<ResultType<ProcessAndUploadSuccess>> => {
-        const token = uploadUrlsData.sasTokens[file.name];
-        if (!token?.success || !token?.url) {
-          return Result.error(token?.message ?? "No upload URL");
+        const entry = uploadUrlsData.uploads[file.name];
+        if (!entry) {
+          return Result.error("No upload URL");
         }
+        if ("error" in entry) {
+          return Result.error(entry.error);
+        }
+
+        const descriptor: UploadUrlDescriptor = entry;
 
         const meta = uploadUrlsData.uploadMetadata ?? {
           userId: "",
@@ -174,7 +185,7 @@ export function createContentUpload(config: ContentUploadConfig) {
 
         return processAndUploadFile(
           file,
-          token.url,
+          descriptor,
           metadata,
           isResizeEnabled ? CONTENT_RESIZE_URL : undefined,
         );

--- a/features/asset-storage/use-cases/upload/upload-handler.factory.ts
+++ b/features/asset-storage/use-cases/upload/upload-handler.factory.ts
@@ -60,7 +60,10 @@ export function createUserUpload(config: UserUploadConfig) {
 
     const sasData: UploadUrlsData = sasResult.value;
 
-    if (sasData.submissionId && sasData.submissionId !== (currentSubmissionId ?? "")) {
+    if (
+      sasData.submissionId &&
+      sasData.submissionId !== (currentSubmissionId ?? "")
+    ) {
       onSubmissionIdChange?.(sasData.submissionId);
     }
 
@@ -158,7 +161,7 @@ export function createContentUpload(config: ContentUploadConfig) {
       files.map(async (file): Promise<ResultType<ProcessAndUploadSuccess>> => {
         const entry = uploadUrlsData.uploads[file.name];
         if (!entry) {
-          return Result.error("No upload URL");
+          return Result.error(`No upload URL for ${file.name}`);
         }
         if ("error" in entry) {
           return Result.error(entry.error);

--- a/features/asset-storage/use-cases/upload/upload.utils.ts
+++ b/features/asset-storage/use-cases/upload/upload.utils.ts
@@ -1,14 +1,17 @@
 import { Result } from "@/lib/result";
-import type { FileMetadata } from "../../types";
-import {
-  toBlobUploadOptions,
-  toAzureBlockBlobPutHeaders,
-} from "@endatix/storage-azure";
+import type { ProcessedState } from "../../types";
 import type { UploadUrlDescriptor } from "../../infrastructure/storage-gateway";
 import { uploadBlob, resizeImageOrFallback } from "./upload-blob";
 import { processUploadError } from "./upload-errors";
 
 const LARGE_FILE_THRESHOLD = 20 * 1024 * 1024; // 20MB
+
+async function readFileAsArrayBuffer(file: File): Promise<ArrayBuffer> {
+  if (typeof file.arrayBuffer === "function") {
+    return file.arrayBuffer();
+  }
+  return new Response(file).arrayBuffer();
+}
 
 /** Per-file result from upload-urls / content/upload-urls (PR2 contract). */
 export type UploadUrlEntry = UploadUrlDescriptor | { error: string };
@@ -30,11 +33,43 @@ export interface UploadUrlsData {
 
 export type ProcessAndUploadSuccess = { url: string; file: File };
 
-function mergePutHeaders(
-  base: Record<string, string>,
-  overlay: Record<string, string>,
-): Record<string, string> {
-  return { ...base, ...overlay };
+export type PreparedUploadBytes = {
+  file: File;
+  buffer: ArrayBuffer;
+  contentType: string;
+  fileState: ProcessedState;
+};
+
+/**
+ * Reads the file (or resizes images under the threshold) so MIME and bytes match
+ * what the server will embed in {@link UploadUrlDescriptor.headers}.
+ */
+export async function prepareUploadBytes(
+  file: File,
+  resizeUrl: string | undefined,
+): Promise<PreparedUploadBytes> {
+  const shouldResize =
+    resizeUrl !== undefined &&
+    file.type.startsWith("image/") &&
+    file.size < LARGE_FILE_THRESHOLD;
+
+  if (shouldResize) {
+    const out = await resizeImageOrFallback(file, resizeUrl);
+    return {
+      file,
+      buffer: out.buffer,
+      contentType: out.contentType,
+      fileState: out.fileState,
+    };
+  }
+
+  const buffer = await readFileAsArrayBuffer(file);
+  return {
+    file,
+    buffer,
+    contentType: file.type || "application/octet-stream",
+    fileState: "original",
+  };
 }
 
 /**
@@ -75,52 +110,15 @@ export async function fetchUploadUrls(
 }
 
 /**
- * Resizes image if applicable, then uploads via `fetch` PUT to the presigned URL.
- *
- * @param file - The file to upload.
- * @param descriptor - URL, base headers, and object key from the upload-urls route.
- * @param meta - The metadata for the file.
- * @param resizeUrl - The URL to resize the file.
- * @returns A Result containing the URL of the uploaded file or an error message.
+ * PUTs prepared bytes using only server-supplied {@link UploadUrlDescriptor.headers}
  */
 export async function processAndUploadFile(
   file: File,
   descriptor: UploadUrlDescriptor,
-  meta: FileMetadata,
-  resizeUrl?: string,
+  buffer: ArrayBuffer,
 ): Promise<Result<ProcessAndUploadSuccess>> {
   try {
-    const shouldResize =
-      resizeUrl !== undefined &&
-      file.type.startsWith("image/") &&
-      file.size < LARGE_FILE_THRESHOLD;
-
-    let buffer: ArrayBuffer;
-    let contentType: string;
-    let fileState: "original" | "optimized";
-
-    if (shouldResize) {
-      const out = await resizeImageOrFallback(file, resizeUrl);
-      buffer = out.buffer;
-      contentType = out.contentType;
-      fileState = out.fileState;
-    } else {
-      buffer = await file.arrayBuffer();
-      contentType = file.type || "application/octet-stream";
-      fileState = "original";
-    }
-
-    const uploadMeta: FileMetadata = {
-      ...meta,
-      contentType,
-      fileState,
-    };
-    const blobOptions = toBlobUploadOptions(uploadMeta);
-    const putHeaders = mergePutHeaders(
-      descriptor.headers,
-      toAzureBlockBlobPutHeaders(blobOptions),
-    );
-    const url = await uploadBlob(descriptor.url, buffer, putHeaders);
+    const url = await uploadBlob(descriptor.url, buffer, descriptor.headers);
     return Result.success({ url, file });
   } catch (err) {
     return Result.error(processUploadError(err));

--- a/features/asset-storage/use-cases/upload/upload.utils.ts
+++ b/features/asset-storage/use-cases/upload/upload.utils.ts
@@ -1,19 +1,23 @@
 import { Result } from "@/lib/result";
 import type { FileMetadata } from "../../types";
-import { toBlobUploadOptions } from "@endatix/storage-azure";
+import {
+  toBlobUploadOptions,
+  toAzureBlockBlobPutHeaders,
+} from "@endatix/storage-azure";
+import type { UploadUrlDescriptor } from "../../infrastructure/storage-gateway";
 import { uploadBlob, resizeImageOrFallback } from "./upload-blob";
 import { processUploadError } from "./upload-errors";
 
 const LARGE_FILE_THRESHOLD = 20 * 1024 * 1024; // 20MB
 
+/** Per-file result from upload-urls / content/upload-urls (PR2 contract). */
+export type UploadUrlEntry = UploadUrlDescriptor | { error: string };
+
 /**
  * The data returned from the upload URLs endpoint.
  */
 export interface UploadUrlsData {
-  sasTokens: Record<
-    string,
-    { success: boolean; url?: string; message?: string }
-  >;
+  uploads: Record<string, UploadUrlEntry>;
   submissionId?: string;
   userId?: string;
   uploadMetadata?: {
@@ -25,6 +29,13 @@ export interface UploadUrlsData {
 }
 
 export type ProcessAndUploadSuccess = { url: string; file: File };
+
+function mergePutHeaders(
+  base: Record<string, string>,
+  overlay: Record<string, string>,
+): Record<string, string> {
+  return { ...base, ...overlay };
+}
 
 /**
  * Fetches upload URLs from the given endpoint.
@@ -64,17 +75,17 @@ export async function fetchUploadUrls(
 }
 
 /**
- * Resizes image if applicable, then uploads to the SAS URL.
+ * Resizes image if applicable, then uploads via `fetch` PUT to the presigned URL.
  *
  * @param file - The file to upload.
- * @param sasUrl - The URL to upload the file to.
+ * @param descriptor - URL, base headers, and object key from the upload-urls route.
  * @param meta - The metadata for the file.
  * @param resizeUrl - The URL to resize the file.
  * @returns A Result containing the URL of the uploaded file or an error message.
  */
 export async function processAndUploadFile(
   file: File,
-  sasUrl: string,
+  descriptor: UploadUrlDescriptor,
   meta: FileMetadata,
   resizeUrl?: string,
 ): Promise<Result<ProcessAndUploadSuccess>> {
@@ -104,8 +115,12 @@ export async function processAndUploadFile(
       contentType,
       fileState,
     };
-    const options = toBlobUploadOptions(uploadMeta);
-    const url = await uploadBlob(sasUrl, buffer, options);
+    const blobOptions = toBlobUploadOptions(uploadMeta);
+    const putHeaders = mergePutHeaders(
+      descriptor.headers,
+      toAzureBlockBlobPutHeaders(blobOptions),
+    );
+    const url = await uploadBlob(descriptor.url, buffer, putHeaders);
     return Result.success({ url, file });
   } catch (err) {
     return Result.error(processUploadError(err));


### PR DESCRIPTION
# refactor: Rewrite hub storage api routes to support multi provider setup

## Description

Get ready the endpoints to RustFS and additinal storage providers by moving away from Azure semantics

- rename app/api/hub/v0/storage/content/{sas-token => upload-urls}/route.ts
- rename app/api/public/v0/storage/{read-token => read-urls}/route.ts
- rename app/api/public/v0/storage/{sas-token => upload-urls}/route.ts

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/629

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [x] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured file upload and download endpoints to use modernized API contracts and improved response formatting.
  * Enhanced error handling with per-file error reporting for uploads.
  * Updated storage gateway to return structured upload URL metadata including headers and object keys.

* **Tests**
  * Updated comprehensive test suites to align with new API contracts and endpoint changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/endatix/endatix-hub/pull/630)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->