### PR TITLE
fix: Introduce dedicated content-object-path assertion

### DIFF
--- a/app/(main)/@header/forms/page.tsx
+++ b/app/(main)/@header/forms/page.tsx
@@ -2,8 +2,10 @@ import { auth } from "@/auth";
 import MainHeader from "@/components/layout-ui/header/main-header";
 import FormsBreadcrumbNav from "@/components/layout-ui/navigation/forms-breadcrumb-nav";
 import { Skeleton } from "@/components/ui/skeleton";
-import { buildFormsBreadcrumbModel } from "@/features/folders/view-forms-header";
-import { getFormsHeaderDataCached } from "@/features/folders/view-forms-header";
+import {
+  getFormsHeaderDataCached,
+  buildFormsBreadcrumbModel,
+} from "@/features/folders/view-forms-header";
 import { AssetStorageProvider } from "@/features/asset-storage/server";
 import CreateFormSheet from "@/features/forms/ui/create-form-sheet";
 import { FormAssistantProvider } from "@/features/forms/use-cases/design-form/form-assistant.context";

--- a/app/(main)/@header/forms/page.tsx
+++ b/app/(main)/@header/forms/page.tsx
@@ -4,6 +4,7 @@ import FormsBreadcrumbNav from "@/components/layout-ui/navigation/forms-breadcru
 import { Skeleton } from "@/components/ui/skeleton";
 import { buildFormsBreadcrumbModel } from "@/features/folders/view-forms-header";
 import { getFormsHeaderDataCached } from "@/features/folders/view-forms-header";
+import { AssetStorageProvider } from "@/features/asset-storage/server";
 import CreateFormSheet from "@/features/forms/ui/create-form-sheet";
 import { FormAssistantProvider } from "@/features/forms/use-cases/design-form/form-assistant.context";
 import { aiFeaturesFlag } from "@/lib/feature-flags/flags";
@@ -62,12 +63,14 @@ async function FormsHeaderActions({
   const headerData = await headerDataPromise;
 
   return (
-    <FormAssistantProvider
-      isAssistantEnabled={aiFeatureFlag}
-      requireFolderForNewForms={headerData.requireFolderForNewForms}
-      assignableFolders={headerData.assignableFolders}
-    >
-      <CreateFormSheet />
-    </FormAssistantProvider>
+    <AssetStorageProvider>
+      <FormAssistantProvider
+        isAssistantEnabled={aiFeatureFlag}
+        requireFolderForNewForms={headerData.requireFolderForNewForms}
+        assignableFolders={headerData.assignableFolders}
+      >
+        <CreateFormSheet />
+      </FormAssistantProvider>
+    </AssetStorageProvider>
   );
 }

--- a/features/asset-storage/__tests__/use-cases/upload-content-files/use-content-upload.hook.test.tsx
+++ b/features/asset-storage/__tests__/use-cases/upload-content-files/use-content-upload.hook.test.tsx
@@ -37,7 +37,11 @@ const createMockFile = (name = "test.jpg"): File => {
   return file;
 };
 
-const mockFetchSuccess = (questionName: string) => {
+const mockFetchSuccess = (
+  questionName: string,
+  itemType: "form" | "template" = "form",
+) => {
+  const contentPrefix = itemType === "form" ? "f" : "t";
   global.fetch = vi
     .fn()
     .mockResolvedValueOnce({
@@ -46,15 +50,15 @@ const mockFetchSuccess = (questionName: string) => {
         Promise.resolve({
           uploads: {
             "test.jpg": {
-              url: `https://account.blob.core.windows.net/content/f/test-item/unique.jpg?sas=token`,
+              url: `https://account.blob.core.windows.net/content/${contentPrefix}/test-item/unique.jpg?sas=token`,
               headers: { "x-ms-blob-type": "BlockBlob" },
-              key: "f/test-item/unique.jpg",
+              key: `${contentPrefix}/test-item/unique.jpg`,
             },
           },
           uploadMetadata: {
             userId: "user-1",
             itemId: "test-item",
-            contentItemType: "form",
+            contentItemType: itemType,
             questionName,
           },
         }),
@@ -174,6 +178,52 @@ describe("useContentUpload", () => {
     expect(options.callback).toHaveBeenCalledWith(
       "success",
       "https://account.blob.core.windows.net/content/f/test-item/unique.jpg",
+    );
+  });
+
+  it("should request template content upload urls for template editor uploads", async () => {
+    const creator = createMockCreatorModel();
+    const { result } = renderHook(
+      () => useContentUpload({ itemId: "test-item", itemType: "template" }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.registerUploadHandlers(creator);
+    });
+
+    const options: UploadFileEvent = {
+      files: [createMockFile()],
+      callback: vi.fn(),
+      element: { name: "templateLogo" } as any,
+      elementType: "question",
+      propertyName: "templateLogo",
+      question: {} as any,
+    };
+
+    mockFetchSuccess("templateLogo", "template");
+
+    await act(async () => {
+      await creator._handlers.onUploadFile(creator, options);
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/hub/v0/storage/content/upload-urls",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          itemId: "test-item",
+          itemType: "template",
+          fileNames: ["test.jpg"],
+          questionName: "templateLogo",
+          fileTypes: { "test.jpg": "image/jpeg" },
+          fileStates: { "test.jpg": "original" },
+        }),
+      }),
+    );
+    expect(options.callback).toHaveBeenCalledWith(
+      "success",
+      "https://account.blob.core.windows.net/content/t/test-item/unique.jpg",
     );
   });
 

--- a/features/asset-storage/infrastructure/__tests__/storage-utils.test.ts
+++ b/features/asset-storage/infrastructure/__tests__/storage-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { Result } from "@/lib/result";
 import {
   USER_FILES_PREFIX,
+  buildContentFolderPath,
   buildUserFileFolderPath,
   buildUserFilePath,
   buildUserFileMetadata,
@@ -179,5 +180,25 @@ describe("buildUserFileMetadata", () => {
 describe("USER_FILES_PREFIX", () => {
   it("is s/", () => {
     expect(USER_FILES_PREFIX).toBe("s/");
+  });
+});
+
+describe("buildContentFolderPath", () => {
+  it("returns f/{formId} for form content", () => {
+    const result = buildContentFolderPath("form", "form-1");
+
+    expect(Result.isSuccess(result)).toBe(true);
+    if (Result.isSuccess(result)) {
+      expect(result.value).toBe("f/form-1");
+    }
+  });
+
+  it("returns t/{templateId} for template content", () => {
+    const result = buildContentFolderPath("template", "template-1");
+
+    expect(Result.isSuccess(result)).toBe(true);
+    if (Result.isSuccess(result)) {
+      expect(result.value).toBe("t/template-1");
+    }
   });
 });

--- a/features/form-access/assert-path/__tests__/assert-designer-object-access.test.ts
+++ b/features/form-access/assert-path/__tests__/assert-designer-object-access.test.ts
@@ -31,6 +31,51 @@ describe("assertDesignerObjectAccess", () => {
     expect(error).toBeNull();
   });
 
+  it("allows scoped template content under templateId", () => {
+    const error = assertDesignerObjectAccess(
+      {
+        containerName: "content",
+        blobName: "t/template-1/logo.svg",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      { templateId: "template-1" },
+      storageConfig,
+    );
+    expect(error).toBeNull();
+  });
+
+  it("allows copied template content while editing a form", () => {
+    const error = assertDesignerObjectAccess(
+      {
+        containerName: "content",
+        blobName: "t/template-1/logo.svg",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      { formId: "42" },
+      storageConfig,
+    );
+    expect(error).toBeNull();
+  });
+
+  it("denies content outside form and template namespaces", () => {
+    const error = assertDesignerObjectAccess(
+      {
+        containerName: "content",
+        blobName: "x/42/logo.svg",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: false,
+      },
+      { formId: "42" },
+      storageConfig,
+    );
+    expect(error).toContain("content namespace");
+  });
+
   it("denies user-files without submissionId", () => {
     const error = assertDesignerObjectAccess(
       {

--- a/features/form-access/assert-path/__tests__/assert-hub-object-access.test.ts
+++ b/features/form-access/assert-path/__tests__/assert-hub-object-access.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { clientStorageConfig } from "@/features/asset-storage/__tests__/test-storage-config";
+import { assertHubObjectAccess } from "../assert-hub-object-access";
+
+const storageConfig = clientStorageConfig({ isPrivate: true });
+
+describe("assertHubObjectAccess", () => {
+  it("allows scoped form content under formId", () => {
+    const error = assertHubObjectAccess(
+      {
+        containerName: "content",
+        blobName: "f/form-1/logo.png",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      { formId: "form-1" },
+      storageConfig,
+    );
+    expect(error).toBeNull();
+  });
+
+  it("allows scoped template content under templateId", () => {
+    const error = assertHubObjectAccess(
+      {
+        containerName: "content",
+        blobName: "t/template-1/logo.svg",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      { templateId: "template-1" },
+      storageConfig,
+    );
+    expect(error).toBeNull();
+  });
+
+  it("allows copied template content while editing a form", () => {
+    const error = assertHubObjectAccess(
+      {
+        containerName: "content",
+        blobName: "t/template-1/logo.svg",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      { formId: "form-1" },
+      storageConfig,
+    );
+    expect(error).toBeNull();
+  });
+
+  it("allows elevated content under valid content namespaces", () => {
+    const formContentError = assertHubObjectAccess(
+      {
+        containerName: "content",
+        blobName: "f/shared/logo.png",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      {},
+      storageConfig,
+    );
+    const templateContentError = assertHubObjectAccess(
+      {
+        containerName: "content",
+        blobName: "t/shared/logo.png",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      {},
+      storageConfig,
+    );
+
+    expect(formContentError).toBeNull();
+    expect(templateContentError).toBeNull();
+  });
+
+  it("denies content outside form and template namespaces", () => {
+    const error = assertHubObjectAccess(
+      {
+        containerName: "content",
+        blobName: "logo.png",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      { formId: "form-1" },
+      storageConfig,
+    );
+    expect(error).toContain("content namespace");
+  });
+
+  it("denies user-files without submissionId", () => {
+    const error = assertHubObjectAccess(
+      {
+        containerName: "user-files",
+        blobName: "s/form-1/submission-1/file.pdf",
+        hostName: "storage.example.com",
+        containerType: "USER_FILES",
+        isPrivate: true,
+      },
+      { formId: "form-1" },
+      storageConfig,
+    );
+    expect(error).toContain("Submission context");
+  });
+
+  it("allows user-files when form and submission match", () => {
+    const error = assertHubObjectAccess(
+      {
+        containerName: "user-files",
+        blobName: "s/form-1/submission-1/file.pdf",
+        hostName: "storage.example.com",
+        containerType: "USER_FILES",
+        isPrivate: true,
+      },
+      { formId: "form-1", submissionId: "submission-1" },
+      storageConfig,
+    );
+    expect(error).toBeNull();
+  });
+});

--- a/features/form-access/assert-path/__tests__/assert-public-object-access.test.ts
+++ b/features/form-access/assert-path/__tests__/assert-public-object-access.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { clientStorageConfig } from "@/features/asset-storage/__tests__/test-storage-config";
+import type { FormStorageAccess } from "../../types";
+import { assertPublicObjectAccess } from "../assert-public-object-access";
+
+const storageConfig = clientStorageConfig({ isPrivate: true });
+
+const access: FormStorageAccess = {
+  formId: "form-1",
+  submissionId: "submission-1",
+  isPublicForm: true,
+  canViewFiles: true,
+  canUploadFiles: true,
+  canDeleteFiles: true,
+};
+
+describe("assertPublicObjectAccess", () => {
+  it("allows form content namespace", () => {
+    const error = assertPublicObjectAccess(
+      {
+        containerName: "content",
+        blobName: "f/form-1/logo.png",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      access,
+      storageConfig,
+    );
+    expect(error).toBeNull();
+  });
+
+  it("allows template content namespace for forms created from templates", () => {
+    const error = assertPublicObjectAccess(
+      {
+        containerName: "content",
+        blobName: "t/template-1/logo.svg",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      access,
+      storageConfig,
+    );
+    expect(error).toBeNull();
+  });
+
+  it("denies content outside form and template namespaces", () => {
+    const error = assertPublicObjectAccess(
+      {
+        containerName: "content",
+        blobName: "x/form-1/logo.svg",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      access,
+      storageConfig,
+    );
+    expect(error).toContain("content namespace");
+  });
+});

--- a/features/form-access/assert-path/__tests__/assert-respondent-object-access.test.ts
+++ b/features/form-access/assert-path/__tests__/assert-respondent-object-access.test.ts
@@ -100,6 +100,21 @@ describe("assertStorageObjectAccess", () => {
     expect(error).toContain("content namespace");
   });
 
+  it("rejects content under an unknown namespace", () => {
+    const error = assertStorageObjectAccess(
+      {
+        containerName: "content",
+        blobName: "x/100/logo.png",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      access,
+      storageConfig,
+    );
+    expect(error).toContain("content namespace");
+  });
+
   it("rejects user-files for another form", () => {
     const error = assertStorageObjectAccess(
       {

--- a/features/form-access/assert-path/__tests__/assert-storage-object-path.test.ts
+++ b/features/form-access/assert-path/__tests__/assert-storage-object-path.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { clientStorageConfig } from "@/features/asset-storage/__tests__/test-storage-config";
+import { assertStorageObjectPathAccess } from "../assert-storage-object-path";
+
+const storageConfig = clientStorageConfig({ isPrivate: true });
+
+describe("assertStorageObjectPathAccess", () => {
+  it("allows form and template content paths", () => {
+    const formError = assertStorageObjectPathAccess(
+      {
+        containerName: "content",
+        blobName: "f/form-1/logo.png",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      storageConfig,
+      { formId: "form-1", contentNamespaceName: "form" },
+    );
+    const templateError = assertStorageObjectPathAccess(
+      {
+        containerName: "content",
+        blobName: "t/template-1/logo.svg",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      storageConfig,
+      { formId: "form-1", contentNamespaceName: "form" },
+    );
+
+    expect(formError).toBeNull();
+    expect(templateError).toBeNull();
+  });
+
+  it("rejects content outside the supported namespaces with policy-specific wording", () => {
+    const error = assertStorageObjectPathAccess(
+      {
+        containerName: "content",
+        blobName: "x/form-1/logo.png",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      storageConfig,
+      { formId: "form-1", contentNamespaceName: "hub" },
+    );
+
+    expect(error).toBe("Content object is not in hub content namespace");
+  });
+
+  it("rejects unknown containers", () => {
+    const error = assertStorageObjectPathAccess(
+      {
+        containerName: "unknown",
+        blobName: "f/form-1/logo.png",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      storageConfig,
+      { formId: "form-1", contentNamespaceName: "form" },
+    );
+
+    expect(error).toBe("Unknown storage container");
+  });
+
+  it("requires form context for user files", () => {
+    const error = assertStorageObjectPathAccess(
+      {
+        containerName: "user-files",
+        blobName: "s/form-1/submission-1/file.pdf",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      storageConfig,
+      { contentNamespaceName: "designer" },
+    );
+
+    expect(error).toBe("Form context is required for user file access");
+  });
+
+  it("requires submission context for user files", () => {
+    const error = assertStorageObjectPathAccess(
+      {
+        containerName: "user-files",
+        blobName: "s/form-1/submission-1/file.pdf",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      storageConfig,
+      { formId: "form-1", contentNamespaceName: "form" },
+    );
+
+    expect(error).toBe("Submission context is required for user file access");
+  });
+
+  it("rejects user files outside the requested form or submission", () => {
+    const formError = assertStorageObjectPathAccess(
+      {
+        containerName: "user-files",
+        blobName: "s/form-2/submission-1/file.pdf",
+        hostName: "storage.example.com",
+        containerType: "CONTENT",
+        isPrivate: true,
+      },
+      storageConfig,
+      {
+        formId: "form-1",
+        submissionId: "submission-1",
+        contentNamespaceName: "form",
+      },
+    );
+    const submissionError = assertStorageObjectPathAccess(
+      {
+        containerName: "user-files",
+        blobName: "s/form-1/submission-2/file.pdf",
+        hostName: "storage.example.com",
+        containerType: "USER_FILES",
+        isPrivate: true,
+      },
+      storageConfig,
+      {
+        formId: "form-1",
+        submissionId: "submission-1",
+        contentNamespaceName: "form",
+      },
+    );
+
+    expect(formError).toBe("File is not scoped to this form");
+    expect(submissionError).toBe("File is not scoped to this submission");
+  });
+});

--- a/features/form-access/assert-path/__tests__/content-object-path.test.ts
+++ b/features/form-access/assert-path/__tests__/content-object-path.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  isContentObjectPath,
-  isFormContentObjectPath,
-  isTemplateContentObjectPath,
-} from "../content-object-path";
+import { isContentObjectPath } from "../content-object-path";
 
 describe("content object paths", () => {
   it("allows form and template content namespaces", () => {
@@ -15,23 +11,5 @@ describe("content object paths", () => {
     expect(isContentObjectPath("logo.png")).toBe(false);
     expect(isContentObjectPath("x/form-1/logo.png")).toBe(false);
     expect(isContentObjectPath("forms/form-1/logo.png")).toBe(false);
-  });
-
-  it("matches form content by form id", () => {
-    expect(isFormContentObjectPath("f/form-1/logo.png", "form-1")).toBe(true);
-    expect(isFormContentObjectPath("f/form-2/logo.png", "form-1")).toBe(false);
-    expect(isFormContentObjectPath("t/form-1/logo.png", "form-1")).toBe(false);
-  });
-
-  it("matches template content by template id", () => {
-    expect(
-      isTemplateContentObjectPath("t/template-1/logo.svg", "template-1"),
-    ).toBe(true);
-    expect(
-      isTemplateContentObjectPath("t/template-2/logo.svg", "template-1"),
-    ).toBe(false);
-    expect(
-      isTemplateContentObjectPath("f/template-1/logo.svg", "template-1"),
-    ).toBe(false);
   });
 });

--- a/features/form-access/assert-path/__tests__/content-object-path.test.ts
+++ b/features/form-access/assert-path/__tests__/content-object-path.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  isContentObjectPath,
+  isFormContentObjectPath,
+  isTemplateContentObjectPath,
+} from "../content-object-path";
+
+describe("content object paths", () => {
+  it("allows form and template content namespaces", () => {
+    expect(isContentObjectPath("f/form-1/logo.png")).toBe(true);
+    expect(isContentObjectPath("t/template-1/logo.svg")).toBe(true);
+  });
+
+  it("rejects non-content namespaces", () => {
+    expect(isContentObjectPath("logo.png")).toBe(false);
+    expect(isContentObjectPath("x/form-1/logo.png")).toBe(false);
+    expect(isContentObjectPath("forms/form-1/logo.png")).toBe(false);
+  });
+
+  it("matches form content by form id", () => {
+    expect(isFormContentObjectPath("f/form-1/logo.png", "form-1")).toBe(true);
+    expect(isFormContentObjectPath("f/form-2/logo.png", "form-1")).toBe(false);
+    expect(isFormContentObjectPath("t/form-1/logo.png", "form-1")).toBe(false);
+  });
+
+  it("matches template content by template id", () => {
+    expect(
+      isTemplateContentObjectPath("t/template-1/logo.svg", "template-1"),
+    ).toBe(true);
+    expect(
+      isTemplateContentObjectPath("t/template-2/logo.svg", "template-1"),
+    ).toBe(false);
+    expect(
+      isTemplateContentObjectPath("f/template-1/logo.svg", "template-1"),
+    ).toBe(false);
+  });
+});

--- a/features/form-access/assert-path/assert-designer-object-access.ts
+++ b/features/form-access/assert-path/assert-designer-object-access.ts
@@ -2,10 +2,13 @@ import type { ClientStorageConfig } from "@/features/asset-storage/infrastructur
 import type { ParsedStorageObjectUrl } from "@/features/asset-storage/utils";
 import { assertUserFileBlobPath } from "./assert-user-file-blob-path";
 import { DesignerScope } from "@/lib/designer-runtime";
+import {
+  isContentObjectPath,
+  isFormContentObjectPath,
+  isTemplateContentObjectPath,
+} from "./content-object-path";
 
-const CONTENT_FORM_PREFIX = "f/";
-
-/** Hub designer read-urls: content allows scoped or elevated `f/*` keys; user-files require form + submission. */
+/** Hub designer read-urls: content allows scoped or elevated `f/*`/`t/*` keys; user-files require form + submission. */
 export function assertDesignerObjectAccess(
   parsed: ParsedStorageObjectUrl,
   scope: DesignerScope,
@@ -18,25 +21,22 @@ export function assertDesignerObjectAccess(
   const blobName = parsed.blobName;
 
   if (container === contentContainer) {
-    if (!blobName.startsWith(CONTENT_FORM_PREFIX)) {
+    if (!isContentObjectPath(blobName)) {
       return "Content object is not in designer content namespace";
     }
 
-    if (
-      scope.formId &&
-      blobName.startsWith(`${CONTENT_FORM_PREFIX}${scope.formId}/`)
-    ) {
+    if (scope.formId && isFormContentObjectPath(blobName, scope.formId)) {
       return null;
     }
 
     if (
       scope.templateId &&
-      blobName.startsWith(`${CONTENT_FORM_PREFIX}${scope.templateId}/`)
+      isTemplateContentObjectPath(blobName, scope.templateId)
     ) {
       return null;
     }
 
-    // Hub editors may presign any content/f/* asset until per-image DB permissions exist.
+    // Hub editors may presign any content asset until per-image DB permissions exist.
     return null;
   }
 

--- a/features/form-access/assert-path/assert-designer-object-access.ts
+++ b/features/form-access/assert-path/assert-designer-object-access.ts
@@ -1,12 +1,7 @@
 import type { ClientStorageConfig } from "@/features/asset-storage/infrastructure/providers/shared/client-storage-config";
 import type { ParsedStorageObjectUrl } from "@/features/asset-storage/utils";
-import { assertUserFileBlobPath } from "./assert-user-file-blob-path";
 import { DesignerScope } from "@/lib/designer-runtime";
-import {
-  isContentObjectPath,
-  isFormContentObjectPath,
-  isTemplateContentObjectPath,
-} from "./content-object-path";
+import { assertStorageObjectPathAccess } from "./assert-storage-object-path";
 
 /** Hub designer read-urls: content allows scoped or elevated `f/*`/`t/*` keys; user-files require form + submission. */
 export function assertDesignerObjectAccess(
@@ -14,43 +9,9 @@ export function assertDesignerObjectAccess(
   scope: DesignerScope,
   storageConfig: ClientStorageConfig,
 ): string | null {
-  const userFilesContainer =
-    storageConfig.containerNames.USER_FILES.toLowerCase();
-  const contentContainer = storageConfig.containerNames.CONTENT.toLowerCase();
-  const container = parsed.containerName.toLowerCase();
-  const blobName = parsed.blobName;
-
-  if (container === contentContainer) {
-    if (!isContentObjectPath(blobName)) {
-      return "Content object is not in designer content namespace";
-    }
-
-    if (scope.formId && isFormContentObjectPath(blobName, scope.formId)) {
-      return null;
-    }
-
-    if (
-      scope.templateId &&
-      isTemplateContentObjectPath(blobName, scope.templateId)
-    ) {
-      return null;
-    }
-
-    // Hub editors may presign any content asset until per-image DB permissions exist.
-    return null;
-  }
-
-  if (container !== userFilesContainer) {
-    return "Unknown storage container";
-  }
-
-  if (!scope.formId) {
-    return "Form context is required for user file access";
-  }
-
-  return assertUserFileBlobPath(
-    blobName,
-    { formId: scope.formId, submissionId: scope.submissionId },
-    { requireSubmission: true },
-  );
+  return assertStorageObjectPathAccess(parsed, storageConfig, {
+    formId: scope.formId,
+    submissionId: scope.submissionId,
+    contentNamespaceName: "designer",
+  });
 }

--- a/features/form-access/assert-path/assert-hub-object-access.ts
+++ b/features/form-access/assert-path/assert-hub-object-access.ts
@@ -1,12 +1,7 @@
 import type { ClientStorageConfig } from "@/features/asset-storage/infrastructure/providers/shared/client-storage-config";
 import type { ParsedStorageObjectUrl } from "@/features/asset-storage/utils";
 import type { HubStorageScope } from "../types";
-import { assertUserFileBlobPath } from "./assert-user-file-blob-path";
-import {
-  isContentObjectPath,
-  isFormContentObjectPath,
-  isTemplateContentObjectPath,
-} from "./content-object-path";
+import { assertStorageObjectPathAccess } from "./assert-storage-object-path";
 
 /** Hub read-urls: content allows scoped or elevated `f/*`/`t/*` keys; user-files require form + submission. */
 export function assertHubObjectAccess(
@@ -14,43 +9,9 @@ export function assertHubObjectAccess(
   scope: HubStorageScope,
   storageConfig: ClientStorageConfig,
 ): string | null {
-  const userFilesContainer =
-    storageConfig.containerNames.USER_FILES.toLowerCase();
-  const contentContainer = storageConfig.containerNames.CONTENT.toLowerCase();
-  const container = parsed.containerName.toLowerCase();
-  const blobName = parsed.blobName;
-
-  if (container === contentContainer) {
-    if (!isContentObjectPath(blobName)) {
-      return "Content object is not in hub content namespace";
-    }
-
-    if (scope.formId && isFormContentObjectPath(blobName, scope.formId)) {
-      return null;
-    }
-
-    if (
-      scope.templateId &&
-      isTemplateContentObjectPath(blobName, scope.templateId)
-    ) {
-      return null;
-    }
-
-    // Hub editors may presign any content asset until per-image DB permissions exist.
-    return null;
-  }
-
-  if (container !== userFilesContainer) {
-    return "Unknown storage container";
-  }
-
-  if (!scope.formId) {
-    return "Form context is required for user file access";
-  }
-
-  return assertUserFileBlobPath(
-    blobName,
-    { formId: scope.formId, submissionId: scope.submissionId },
-    { requireSubmission: true },
-  );
+  return assertStorageObjectPathAccess(parsed, storageConfig, {
+    formId: scope.formId,
+    submissionId: scope.submissionId,
+    contentNamespaceName: "hub",
+  });
 }

--- a/features/form-access/assert-path/assert-hub-object-access.ts
+++ b/features/form-access/assert-path/assert-hub-object-access.ts
@@ -2,10 +2,13 @@ import type { ClientStorageConfig } from "@/features/asset-storage/infrastructur
 import type { ParsedStorageObjectUrl } from "@/features/asset-storage/utils";
 import type { HubStorageScope } from "../types";
 import { assertUserFileBlobPath } from "./assert-user-file-blob-path";
+import {
+  isContentObjectPath,
+  isFormContentObjectPath,
+  isTemplateContentObjectPath,
+} from "./content-object-path";
 
-const CONTENT_FORM_PREFIX = "f/";
-
-/** Hub read-urls: content allows scoped or elevated `f/*` keys; user-files require form + submission. */
+/** Hub read-urls: content allows scoped or elevated `f/*`/`t/*` keys; user-files require form + submission. */
 export function assertHubObjectAccess(
   parsed: ParsedStorageObjectUrl,
   scope: HubStorageScope,
@@ -18,25 +21,22 @@ export function assertHubObjectAccess(
   const blobName = parsed.blobName;
 
   if (container === contentContainer) {
-    if (!blobName.startsWith(CONTENT_FORM_PREFIX)) {
+    if (!isContentObjectPath(blobName)) {
       return "Content object is not in hub content namespace";
     }
 
-    if (
-      scope.formId &&
-      blobName.startsWith(`${CONTENT_FORM_PREFIX}${scope.formId}/`)
-    ) {
+    if (scope.formId && isFormContentObjectPath(blobName, scope.formId)) {
       return null;
     }
 
     if (
       scope.templateId &&
-      blobName.startsWith(`${CONTENT_FORM_PREFIX}${scope.templateId}/`)
+      isTemplateContentObjectPath(blobName, scope.templateId)
     ) {
       return null;
     }
 
-    // Hub editors may presign any content/f/* asset until per-image DB permissions exist.
+    // Hub editors may presign any content asset until per-image DB permissions exist.
     return null;
   }
 

--- a/features/form-access/assert-path/assert-public-object-access.ts
+++ b/features/form-access/assert-path/assert-public-object-access.ts
@@ -1,8 +1,7 @@
 import type { ClientStorageConfig } from "@/features/asset-storage/infrastructure/providers/shared/client-storage-config";
 import type { ParsedStorageObjectUrl } from "@/features/asset-storage/utils";
 import type { FormStorageAccess } from "../types";
-import { assertUserFileBlobPath } from "./assert-user-file-blob-path";
-import { isContentObjectPath } from "./content-object-path";
+import { assertStorageObjectPathAccess } from "./assert-storage-object-path";
 
 /** Returns an error message when the object key is not allowed for public-plane access, or null if allowed. */
 export function assertPublicObjectAccess(
@@ -10,26 +9,9 @@ export function assertPublicObjectAccess(
   access: FormStorageAccess,
   storageConfig: ClientStorageConfig,
 ): string | null {
-  const userFilesContainer =
-    storageConfig.containerNames.USER_FILES.toLowerCase();
-  const contentContainer = storageConfig.containerNames.CONTENT.toLowerCase();
-  const container = parsed.containerName.toLowerCase();
-  const blobName = parsed.blobName;
-
-  if (container === contentContainer) {
-    if (!isContentObjectPath(blobName)) {
-      return "Content object is not in form content namespace";
-    }
-    return null;
-  }
-
-  if (container !== userFilesContainer) {
-    return "Unknown storage container";
-  }
-
-  return assertUserFileBlobPath(
-    blobName,
-    { formId: access.formId, submissionId: access.submissionId },
-    { requireSubmission: true },
-  );
+  return assertStorageObjectPathAccess(parsed, storageConfig, {
+    formId: access.formId,
+    submissionId: access.submissionId,
+    contentNamespaceName: "form",
+  });
 }

--- a/features/form-access/assert-path/assert-public-object-access.ts
+++ b/features/form-access/assert-path/assert-public-object-access.ts
@@ -2,10 +2,7 @@ import type { ClientStorageConfig } from "@/features/asset-storage/infrastructur
 import type { ParsedStorageObjectUrl } from "@/features/asset-storage/utils";
 import type { FormStorageAccess } from "../types";
 import { assertUserFileBlobPath } from "./assert-user-file-blob-path";
-
-function isContentNamespace(blobName: string): boolean {
-  return blobName.startsWith("f/") || blobName.startsWith("t/");
-}
+import { isContentObjectPath } from "./content-object-path";
 
 /** Returns an error message when the object key is not allowed for public-plane access, or null if allowed. */
 export function assertPublicObjectAccess(
@@ -20,7 +17,7 @@ export function assertPublicObjectAccess(
   const blobName = parsed.blobName;
 
   if (container === contentContainer) {
-    if (!isContentNamespace(blobName)) {
+    if (!isContentObjectPath(blobName)) {
       return "Content object is not in form content namespace";
     }
     return null;

--- a/features/form-access/assert-path/assert-respondent-object-access.ts
+++ b/features/form-access/assert-path/assert-respondent-object-access.ts
@@ -1,8 +1,7 @@
 import type { ClientStorageConfig } from "@/features/asset-storage/infrastructure/providers/shared/client-storage-config";
 import type { ParsedStorageObjectUrl } from "@/features/asset-storage/utils";
 import type { FormStorageAccess } from "../types";
-import { assertUserFileBlobPath } from "./assert-user-file-blob-path";
-import { isContentObjectPath } from "./content-object-path";
+import { assertStorageObjectPathAccess } from "./assert-storage-object-path";
 
 /** Returns an error message when the object key is not allowed for respondent access, or null if allowed. */
 export function assertStorageObjectAccess(
@@ -10,26 +9,9 @@ export function assertStorageObjectAccess(
   access: FormStorageAccess,
   storageConfig: ClientStorageConfig,
 ): string | null {
-  const userFilesContainer =
-    storageConfig.containerNames.USER_FILES.toLowerCase();
-  const contentContainer = storageConfig.containerNames.CONTENT.toLowerCase();
-  const container = parsed.containerName.toLowerCase();
-  const blobName = parsed.blobName;
-
-  if (container === contentContainer) {
-    if (!isContentObjectPath(blobName)) {
-      return "Content object is not in form content namespace";
-    }
-    return null;
-  }
-
-  if (container !== userFilesContainer) {
-    return "Unknown storage container";
-  }
-
-  return assertUserFileBlobPath(
-    blobName,
-    { formId: access.formId, submissionId: access.submissionId },
-    { requireSubmission: true },
-  );
+  return assertStorageObjectPathAccess(parsed, storageConfig, {
+    formId: access.formId,
+    submissionId: access.submissionId,
+    contentNamespaceName: "form",
+  });
 }

--- a/features/form-access/assert-path/assert-respondent-object-access.ts
+++ b/features/form-access/assert-path/assert-respondent-object-access.ts
@@ -2,10 +2,7 @@ import type { ClientStorageConfig } from "@/features/asset-storage/infrastructur
 import type { ParsedStorageObjectUrl } from "@/features/asset-storage/utils";
 import type { FormStorageAccess } from "../types";
 import { assertUserFileBlobPath } from "./assert-user-file-blob-path";
-
-function isContentNamespace(blobName: string): boolean {
-  return blobName.startsWith("f/") || blobName.startsWith("t/");
-}
+import { isContentObjectPath } from "./content-object-path";
 
 /** Returns an error message when the object key is not allowed for respondent access, or null if allowed. */
 export function assertStorageObjectAccess(
@@ -20,7 +17,7 @@ export function assertStorageObjectAccess(
   const blobName = parsed.blobName;
 
   if (container === contentContainer) {
-    if (!isContentNamespace(blobName)) {
+    if (!isContentObjectPath(blobName)) {
       return "Content object is not in form content namespace";
     }
     return null;

--- a/features/form-access/assert-path/assert-storage-object-path.ts
+++ b/features/form-access/assert-path/assert-storage-object-path.ts
@@ -1,0 +1,53 @@
+import type { ClientStorageConfig } from "@/features/asset-storage/infrastructure/providers/shared/client-storage-config";
+import type { ParsedStorageObjectUrl } from "@/features/asset-storage/utils";
+import { assertUserFileBlobPath } from "./assert-user-file-blob-path";
+import { isContentObjectPath } from "./content-object-path";
+
+type ContentNamespaceName = "designer" | "form" | "hub";
+
+interface StorageObjectPathAccessOptions {
+  formId?: string;
+  submissionId?: string;
+  contentNamespaceName: ContentNamespaceName;
+}
+
+/**
+ * Asserts that a storage object path is scoped to a form and submission.
+ * @param parsed - The parsed storage object url
+ * @param storageConfig - The storage config
+ * @param options - The options
+ * @returns The error message or null if the path is valid
+ */
+function assertStorageObjectPathAccess(
+  parsed: ParsedStorageObjectUrl,
+  storageConfig: ClientStorageConfig,
+  options: StorageObjectPathAccessOptions,
+): string | null {
+  const userFilesContainer =
+    storageConfig.containerNames.USER_FILES.toLowerCase();
+  const contentContainer = storageConfig.containerNames.CONTENT.toLowerCase();
+  const container = parsed.containerName.toLowerCase();
+  const blobName = parsed.blobName;
+
+  if (container === contentContainer) {
+    return isContentObjectPath(blobName)
+      ? null
+      : `Content object is not in ${options.contentNamespaceName} content namespace`;
+  }
+
+  if (container !== userFilesContainer) {
+    return "Unknown storage container";
+  }
+
+  if (!options.formId) {
+    return "Form context is required for user file access";
+  }
+
+  return assertUserFileBlobPath(
+    blobName,
+    { formId: options.formId, submissionId: options.submissionId },
+    { requireSubmission: true },
+  );
+}
+
+export { assertStorageObjectPathAccess };

--- a/features/form-access/assert-path/content-object-path.ts
+++ b/features/form-access/assert-path/content-object-path.ts
@@ -9,21 +9,4 @@ function isContentObjectPath(blobName: string): boolean {
   );
 }
 
-/** Returns true if the blob name is a content object path. Form. */
-function isFormContentObjectPath(blobName: string, formId: string): boolean {
-  return blobName.startsWith(`${CONTENT_FORM_PREFIX}${formId}/`);
-}
-
-/** Returns true if the blob name is a content object path. Template. */
-function isTemplateContentObjectPath(
-  blobName: string,
-  templateId: string,
-): boolean {
-  return blobName.startsWith(`${CONTENT_TEMPLATE_PREFIX}${templateId}/`);
-}
-
-export {
-  isContentObjectPath,
-  isFormContentObjectPath,
-  isTemplateContentObjectPath,
-};
+export { isContentObjectPath };

--- a/features/form-access/assert-path/content-object-path.ts
+++ b/features/form-access/assert-path/content-object-path.ts
@@ -1,0 +1,29 @@
+const CONTENT_FORM_PREFIX = "f/";
+const CONTENT_TEMPLATE_PREFIX = "t/";
+
+/** Returns true if the blob name is a content object path. Form or template. */
+function isContentObjectPath(blobName: string): boolean {
+  return (
+    blobName.startsWith(CONTENT_FORM_PREFIX) ||
+    blobName.startsWith(CONTENT_TEMPLATE_PREFIX)
+  );
+}
+
+/** Returns true if the blob name is a content object path. Form. */
+function isFormContentObjectPath(blobName: string, formId: string): boolean {
+  return blobName.startsWith(`${CONTENT_FORM_PREFIX}${formId}/`);
+}
+
+/** Returns true if the blob name is a content object path. Template. */
+function isTemplateContentObjectPath(
+  blobName: string,
+  templateId: string,
+): boolean {
+  return blobName.startsWith(`${CONTENT_TEMPLATE_PREFIX}${templateId}/`);
+}
+
+export {
+  isContentObjectPath,
+  isFormContentObjectPath,
+  isTemplateContentObjectPath,
+};


### PR DESCRIPTION
# fix: Adding dedicate content-object-path assertion

## Description
- Introduce dedicated content path assertion for `/t` (template) and `/f` (forms)
- Adds tests
- Fix issue with missing `AssetStorageProvider` on the FormCreateSheet (now preview template works)

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/643

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added template upload support to the asset storage system.
  * Implemented dedicated storage namespace for template content.

* **Improvements**
  * Enhanced access controls for template content across designer, hub, public, and respondent roles.
  * Improved content path validation to ensure proper authorization for form and template assets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/endatix/endatix-hub/pull/644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->