### PR TITLE
feat: Support for deploying the Endatix Hub under a subfolder / reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ ENDATIX_BASE_URL=https://localhost:5001
 # Defaults to "/api", so the final URL will be `${ENDATIX_BASE_URL}/api`
 ENDATIX_API_PREFIX=/api
 
+# [OPTIONAL] The base path where the Endatix Hub is hosted, e.g. /app. Defaults to "", e.g. root path.
+NEXT_PUBLIC_BASE_PATH=
+
 # [OPTIONAL] The hostnames of the remote (external) images that will be used to serve & optimize images. Provide multiple hostnames separated by commas.
 REMOTE_IMAGE_HOSTNAMES=images.unsplash.com,images.pexels.com
 

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -26,6 +26,7 @@ async function getProxy(): Promise<ProxyHandler> {
 describe("proxy", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   describe("auth routes", () => {
@@ -171,6 +172,24 @@ describe("proxy", () => {
       const location = response.headers.get("Location");
       expect(location).toContain(encodeURIComponent("/forms?tab=submissions"));
     });
+
+    it("should include the configured base path in the signin redirect", async () => {
+      vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/app");
+      const { auth } = await import("@/auth");
+      vi.mocked(auth).mockResolvedValue(null as unknown as NextProxy);
+
+      const proxy = await getProxy();
+      const request = createRequest("/forms");
+      const response = await proxy(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get("Location")).toBe(
+        `${BASE_URL}/app${SIGNIN_PATH}?${RETURN_URL_PARAM}=${encodeURIComponent(
+          "/forms",
+        )}`,
+      );
+    });
+
   });
 
   describe("non-auth, non-hub paths", () => {
@@ -188,7 +207,7 @@ describe("proxy", () => {
 
     it("should allow request when path is not auth and not hub", async () => {
       const { auth } = await import("@/auth");
-      vi.mocked(auth).mockResolvedValue(null);
+      vi.mocked(auth).mockResolvedValue(null as unknown as NextProxy);
 
       const proxy = await getProxy();
       const request = createRequest("/some-other-path");

--- a/app/(auth)/account-verification/page.tsx
+++ b/app/(auth)/account-verification/page.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/loaders/spinner";
 import { sendVerificationAction } from "@/features/auth/use-cases/send-verification/send-verification.action";
+import { getPublicAssetPath } from "@/lib/hosting";
 
 export default function AccountVerificationPage() {
   const searchParams = useSearchParams();
@@ -55,9 +56,9 @@ export default function AccountVerificationPage() {
   if (!email) {
     return (
       <>
-        <div className="flex justify-center mb-2">
+        <div className="mb-2 flex justify-center">
           <Image
-            src="/assets/icons/endatix.svg"
+            src={getPublicAssetPath("/assets/icons/endatix.svg")}
             alt="Endatix logo"
             width={180}
             height={60}
@@ -83,9 +84,9 @@ export default function AccountVerificationPage() {
 
   return (
     <>
-      <div className="flex justify-center mb-2">
+      <div className="mb-2 flex justify-center">
         <Image
-          src="/assets/icons/endatix.svg"
+          src={getPublicAssetPath("/assets/icons/endatix.svg")}
           alt="Endatix logo"
           width={180}
           height={60}

--- a/app/(auth)/auth-error/page.tsx
+++ b/app/(auth)/auth-error/page.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import AuthErrorDetails from "@/features/auth/ui/auth-error";
 import { AuthErrorType, ErrorDetails } from "@/features/auth";
 import { auth } from "@/auth";
+import { getPublicAssetPath } from "@/lib/hosting";
 
 export const metadata: Metadata = {
   title: "Authentication failed | Endatix Hub",
@@ -24,7 +25,7 @@ export const metadata: Metadata = {
       "Authentication failed the Endatix Hub form management portal.",
     images: [
       {
-        url: "/assets/endatix-og-image.jpg",
+        url: getPublicAssetPath("/assets/endatix-og-image.jpg"),
       },
     ],
   },
@@ -91,8 +92,8 @@ export default async function AuthErrorPage({
     : "Authentication failed";
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen">
-      <div className="flex items-center justify-center gap-3 mb-2">
+    <div className="flex h-screen flex-col items-center justify-center">
+      <div className="mb-2 flex items-center justify-center gap-3">
         <XCircle className="h-6 w-6 text-red-500" />
         <h1 className="text-2xl font-semibold tracking-tight">
           {authErrorTitle}

--- a/app/(auth)/create-account/page.tsx
+++ b/app/(auth)/create-account/page.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
+import { getPublicAssetPath } from "@/lib/hosting";
 
 export const metadata: Metadata = {
   title: "Create account | Endatix Hub",
@@ -31,7 +32,7 @@ export const metadata: Metadata = {
       "Create a new account in the Endatix Hub form management portal.",
     images: [
       {
-        url: "/assets/endatix-og-image.jpg",
+        url: getPublicAssetPath("/assets/endatix-og-image.jpg"),
       },
     ],
   },
@@ -93,10 +94,10 @@ const LoggedInSuccessMessage = ({
 }: LoggedInMessageProps) => {
   if (isLoggedIn)
     return (
-      <Card className="bg-background gap-2">
+      <Card className="gap-2 bg-background">
         <CardHeader className="pb-3">
           <CardTitle>Welcome!</CardTitle>
-          <CardDescription className="max-w-lg text-balance leading-relaxed">
+          <CardDescription className="max-w-lg leading-relaxed text-balance">
             You are now logged in as {username}
           </CardDescription>
         </CardHeader>

--- a/app/(auth)/forgot-password/forgot-password-form.tsx
+++ b/app/(auth)/forgot-password/forgot-password-form.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/loaders/spinner";
 import Link from "next/link";
 import { ErrorMessage } from "@/components/forms/error-message";
+import { getPublicAssetPath } from "@/lib/hosting";
 import { CircleCheckBig } from "lucide-react";
 
 export default function ForgotPasswordForm() {
@@ -27,7 +28,7 @@ export default function ForgotPasswordForm() {
       <div className="grid gap-2 text-center">
         <div className="mb-2 flex justify-center">
           <Image
-            src="/assets/icons/endatix.svg"
+            src={getPublicAssetPath("/assets/icons/endatix.svg")}
             alt="Endatix logo"
             width={180}
             height={60}

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -2,6 +2,7 @@ import "@/app/globals.css";
 import { auth } from "@/auth";
 import { AppProvider } from "@/components/providers";
 import { geistMono, geistSans } from "@/lib/fonts/geist-local";
+import { getPublicAssetPath } from "@/lib/hosting";
 import Image from "next/image";
 import { Metadata } from "next";
 
@@ -34,7 +35,11 @@ export default async function AuthLayout({ children }: AuthLayoutProps) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <link rel="icon" href="/assets/icons/icon.svg" type="image/svg+xml" />
+        <link
+          rel="icon"
+          href={getPublicAssetPath("/assets/icons/icon.svg")}
+          type="image/svg+xml"
+        />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <AppProvider session={session}>
@@ -45,7 +50,7 @@ export default async function AuthLayout({ children }: AuthLayoutProps) {
               </div>
               <div className="hidden items-center justify-center lg:flex">
                 <Image
-                  src="/assets/lines-and-stuff.svg"
+                  src={getPublicAssetPath("/assets/lines-and-stuff.svg")}
                   alt="Lines and dots pattern"
                   width="600"
                   height="600"

--- a/app/(auth)/reset-password/reset-password-form.tsx
+++ b/app/(auth)/reset-password/reset-password-form.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { ErrorMessage } from "@/components/forms/error-message";
 import { CalendarX2 } from "lucide-react";
 import { ERROR_CODE } from "@/lib/endatix-api";
+import { getPublicAssetPath } from "@/lib/hosting";
 import FormSuccessMessage from "@/components/forms/form-success-message";
 
 interface ResetPasswordFormProps {
@@ -67,7 +68,7 @@ export default function ResetPasswordForm({
       <div className="grid gap-2 text-center">
         <div className="mb-2 flex justify-center">
           <Image
-            src="/assets/icons/endatix.svg"
+            src={getPublicAssetPath("/assets/icons/endatix.svg")}
             alt="Endatix logo"
             width={180}
             height={60}
@@ -136,7 +137,7 @@ export const InvalidResetLinkMessage = () => {
     <div className="grid gap-2 text-center">
       <div className="mb-2 flex justify-center">
         <Image
-          src="/assets/icons/endatix.svg"
+          src={getPublicAssetPath("/assets/icons/endatix.svg")}
           alt="Endatix logo"
           width={180}
           height={60}

--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -17,6 +17,7 @@ import {
   RETURN_URL_PARAM,
 } from "@/features/auth/infrastructure";
 import SigninForm from "@/features/auth/use-cases/signin/ui/signin-form";
+import { getPublicAssetPath } from "@/lib/hosting";
 
 export const metadata: Metadata = {
   title: "Sign in | Endatix Hub",
@@ -31,7 +32,7 @@ export const metadata: Metadata = {
     description: "Sign in the Endatix Hub form management portal.",
     images: [
       {
-        url: "/assets/endatix-og-image.jpg",
+        url: getPublicAssetPath("/assets/endatix-og-image.jpg"),
       },
     ],
   },
@@ -101,7 +102,7 @@ const SignedInSuccessMessage = ({
         <Card className="bg-background">
           <CardHeader className="pb-3">
             <CardTitle>Welcome!</CardTitle>
-            <CardDescription className="max-w-lg text-balance leading-relaxed">
+            <CardDescription className="max-w-lg leading-relaxed text-balance">
               You are now signed in as {username}
             </CardDescription>
           </CardHeader>
@@ -117,7 +118,7 @@ const SignedInSuccessMessage = ({
             </Link>
           </CardFooter>
         </Card>
-        <p className="max-w-lg text-balance leading-relaxed text-sm text-muted-foreground px-6">
+        <p className="max-w-lg px-6 text-sm leading-relaxed text-balance text-muted-foreground">
           Or{" "}
           <Link href="/signout" className="text-blue-500">
             sign out

--- a/app/(auth)/signout/page.tsx
+++ b/app/(auth)/signout/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import SignoutButton from "@/features/auth/use-cases/signout/ui/signout-button";
 import GoBackButton from "@/components/layout-ui/navigation/go-back-button";
+import { getPublicAssetPath } from "@/lib/hosting";
 
 export const metadata: Metadata = {
   title: "Sign out | Endatix Hub",
@@ -15,7 +16,7 @@ export const metadata: Metadata = {
     description: "Sign out from the Endatix Hub form management portal.",
     images: [
       {
-        url: "/assets/endatix-og-image.jpg",
+        url: getPublicAssetPath("/assets/endatix-og-image.jpg"),
       },
     ],
   },
@@ -27,12 +28,12 @@ export const metadata: Metadata = {
 
 export default function SignOutPage() {
   return (
-    <div className="flex flex-col items-center justify-center h-screen">
-      <h1 className="mt-2 text-2xl font-bold ">Sign out of Endatix Hub?</h1>
+    <div className="flex h-screen flex-col items-center justify-center">
+      <h1 className="mt-2 text-2xl font-bold">Sign out of Endatix Hub?</h1>
       <p className="mt-2 text-sm text-muted-foreground">
         You can always sign in back in at any time.
       </p>
-      <div className="flex gap-2 items-center justify-center gap-2 whitespace-nowrap px-4 py-2 mt-8">
+      <div className="mt-8 flex items-center justify-center gap-2 px-4 py-2 whitespace-nowrap">
         <SignoutButton />
         <GoBackButton variant="outline" text="Cancel" />
       </div>

--- a/app/(auth)/verify-email/page.tsx
+++ b/app/(auth)/verify-email/page.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { verifyEmailAction } from "@/features/auth/use-cases/verify-email/verify-email.action";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/loaders/spinner";
+import { getPublicAssetPath } from "@/lib/hosting";
 import { CheckCircle, XCircle, AlertCircle } from "lucide-react";
 import Link from "next/link";
 
@@ -62,7 +63,7 @@ export default function VerifyEmailPage() {
         return (
           <>
             <div className="grid gap-2 text-center">
-              <div className="flex items-center justify-center gap-3 mb-2">
+              <div className="mb-2 flex items-center justify-center gap-3">
                 <Spinner className="h-6 w-6" />
                 <h1 className="text-2xl font-semibold tracking-tight">
                   Verifying Your Email
@@ -79,7 +80,7 @@ export default function VerifyEmailPage() {
         return (
           <>
             <div className="grid gap-2 text-center">
-              <div className="flex items-center justify-center gap-3 mb-2">
+              <div className="mb-2 flex items-center justify-center gap-3">
                 <CheckCircle className="h-6 w-6 text-green-500" />
                 <h1 className="text-2xl font-semibold tracking-tight">
                   Email verified successfully!
@@ -102,7 +103,7 @@ export default function VerifyEmailPage() {
         return (
           <>
             <div className="grid gap-2 text-center">
-              <div className="flex items-center justify-center gap-3 mb-2">
+              <div className="mb-2 flex items-center justify-center gap-3">
                 <XCircle className="h-6 w-6 text-red-500" />
                 <h1 className="text-2xl font-semibold tracking-tight">
                   Verification failed
@@ -126,7 +127,7 @@ export default function VerifyEmailPage() {
         return (
           <>
             <div className="grid gap-2 text-center">
-              <div className="flex items-center justify-center gap-3 mb-2">
+              <div className="mb-2 flex items-center justify-center gap-3">
                 <AlertCircle className="h-6 w-6 text-yellow-500" />
                 <h1 className="text-2xl font-semibold tracking-tight">
                   Invalid Verification Link
@@ -154,9 +155,9 @@ export default function VerifyEmailPage() {
 
   return (
     <>
-      <div className="flex justify-center mb-2">
+      <div className="mb-2 flex justify-center">
         <Image
-          src="/assets/icons/endatix.svg"
+          src={getPublicAssetPath("/assets/icons/endatix.svg")}
           alt="Endatix logo"
           width={180}
           height={60}

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -2,6 +2,7 @@ import "@/app/globals.css";
 import { auth } from "@/auth";
 import { AppProvider } from "@/components/providers";
 import { geistMono, geistSans } from "@/lib/fonts/geist-local";
+import { getPublicAssetPath } from "@/lib/hosting";
 import { getOsClass } from "@/lib/utils/next-utils";
 import { Metadata } from "next";
 import { cookies, headers } from "next/headers";
@@ -42,7 +43,11 @@ export default async function RootLayout({
   return (
     <html lang="en" className={osClass} suppressHydrationWarning>
       <head>
-        <link rel="icon" href="/assets/icons/icon.svg" type="image/svg+xml" />
+        <link
+          rel="icon"
+          href={getPublicAssetPath("/assets/icons/icon.svg")}
+          type="image/svg+xml"
+        />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <AppProvider session={session} sidebarDefaultOpen={defaultSidebarOpen}>

--- a/app/(public)/edit/layout.tsx
+++ b/app/(public)/edit/layout.tsx
@@ -1,6 +1,7 @@
 import "@/app/globals.css";
 import { auth } from "@/auth";
 import { AppProvider } from "@/components/providers";
+import { getPublicAssetPath } from "@/lib/hosting";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -26,7 +27,11 @@ export default async function EditLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <link rel="icon" href="/assets/icons/icon.svg" type="image/svg+xml" />
+        <link
+          rel="icon"
+          href={getPublicAssetPath("/assets/icons/icon.svg")}
+          type="image/svg+xml"
+        />
       </head>
       <body>
         <AppProvider session={session}>{children}</AppProvider>

--- a/app/(public)/embed/[formId]/layout.tsx
+++ b/app/(public)/embed/[formId]/layout.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/auth";
 import { AppProvider } from "@/components/providers";
 import { AppOptions } from "@/components/providers/app-provider";
+import { getPublicAssetPath } from "@/lib/hosting";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -21,7 +22,11 @@ export default async function EmbedLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <link rel="icon" href="/assets/icons/icon.svg" type="image/svg+xml" />
+        <link
+          rel="icon"
+          href={getPublicAssetPath("/assets/icons/icon.svg")}
+          type="image/svg+xml"
+        />
       </head>
       <body>
         <AppProvider options={AppOptions.PublicPages} session={session}>

--- a/app/(public)/maintenance/layout.tsx
+++ b/app/(public)/maintenance/layout.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
 export default async function PublicLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: Readonly<React.ReactNode>;
 }) {
   const requestHeaders = await headers();
   const osClass = getOsClass(requestHeaders);

--- a/app/(public)/maintenance/layout.tsx
+++ b/app/(public)/maintenance/layout.tsx
@@ -19,11 +19,13 @@ export const metadata: Metadata = {
   description: "Customizable form management platform",
 };
 
+interface MaintenanceLayoutProps {
+  children: React.ReactNode;
+}
+
 export default async function PublicLayout({
   children,
-}: {
-  children: Readonly<React.ReactNode>;
-}) {
+}: Readonly<MaintenanceLayoutProps>) {
   const requestHeaders = await headers();
   const osClass = getOsClass(requestHeaders);
 

--- a/app/(public)/maintenance/layout.tsx
+++ b/app/(public)/maintenance/layout.tsx
@@ -1,6 +1,7 @@
 import "@/app/globals.css";
 import { AppProvider } from "@/components/providers";
 import { geistMono, geistSans } from "@/lib/fonts/geist-local";
+import { getPublicAssetPath } from "@/lib/hosting";
 import { getOsClass } from "@/lib/utils/next-utils";
 import { Metadata } from "next";
 import { headers } from "next/headers";
@@ -33,7 +34,11 @@ export default async function PublicLayout({
       suppressHydrationWarning
     >
       <head>
-        <link rel="icon" href="/assets/icons/icon.svg" type="image/svg+xml" />
+        <link
+          rel="icon"
+          href={getPublicAssetPath("/assets/icons/icon.svg")}
+          type="image/svg+xml"
+        />
       </head>
       <body>
         <AppProvider options={appOptions}>{children}</AppProvider>

--- a/app/(public)/share/[formId]/layout.tsx
+++ b/app/(public)/share/[formId]/layout.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/auth";
 import { AppProvider } from "@/components/providers";
 import { AppOptions } from "@/components/providers/app-provider";
+import { getPublicAssetPath } from "@/lib/hosting";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -28,7 +29,11 @@ export default async function ShareLayout({
       <head>
         <link rel="preconnect" href="https://www.google.com" />
         <link rel="preconnect" href="https://www.gstatic.com" crossOrigin="" />
-        <link rel="icon" href="/assets/icons/icon.svg" type="image/svg+xml" />
+        <link
+          rel="icon"
+          href={getPublicAssetPath("/assets/icons/icon.svg")}
+          type="image/svg+xml"
+        />
       </head>
       <body>
         <AppProvider options={AppOptions.PublicPages} session={session}>

--- a/app/(public)/view/layout.tsx
+++ b/app/(public)/view/layout.tsx
@@ -2,6 +2,7 @@ import "@/app/globals.css";
 import { auth } from "@/auth";
 import { AppProvider } from "@/components/providers";
 import { AppOptions } from "@/components/providers/app-provider";
+import { getPublicAssetPath } from "@/lib/hosting";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -27,10 +28,16 @@ export default async function ViewLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <link rel="icon" href="/assets/icons/icon.svg" type="image/svg+xml" />
+        <link
+          rel="icon"
+          href={getPublicAssetPath("/assets/icons/icon.svg")}
+          type="image/svg+xml"
+        />
       </head>
       <body>
-        <AppProvider options={AppOptions.PublicPages} session={session}>{children}</AppProvider>
+        <AppProvider options={AppOptions.PublicPages} session={session}>
+          {children}
+        </AppProvider>
       </body>
     </html>
   );

--- a/app/global-not-found.tsx
+++ b/app/global-not-found.tsx
@@ -1,5 +1,6 @@
 import { NotFoundComponent } from "@/components/error-handling/not-found";
 import "@/components/error-handling/not-found/not-found-styles-standalone.css";
+import { getPublicAssetPath } from "@/lib/hosting";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -21,7 +22,11 @@ export default function GlobalNotFound() {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <link rel="icon" href="/assets/icons/icon.svg" type="image/svg+xml" />
+        <link
+          rel="icon"
+          href={getPublicAssetPath("/assets/icons/icon.svg")}
+          type="image/svg+xml"
+        />
       </head>
       <body>
         <div className="not-found-container">

--- a/app/unauthorized/layout.tsx
+++ b/app/unauthorized/layout.tsx
@@ -2,6 +2,7 @@ import "@/app/globals.css";
 import { auth } from "@/auth";
 import { AppProvider } from "@/components/providers";
 import { geistMono, geistSans } from "@/lib/fonts/geist-local";
+import { getPublicAssetPath } from "@/lib/hosting";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -35,7 +36,11 @@ export default async function UnauthorizedLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <link rel="icon" href="/assets/icons/icon.svg" type="image/svg+xml" />
+        <link
+          rel="icon"
+          href={getPublicAssetPath("/assets/icons/icon.svg")}
+          type="image/svg+xml"
+        />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <AppProvider session={session}>

--- a/app/unauthorized/page.tsx
+++ b/app/unauthorized/page.tsx
@@ -3,6 +3,7 @@ import { UnauthorizedComponent } from "@/components/error-handling/unauthorized"
 import { Button } from "@/components/ui/button";
 import { SIGNIN_PATH, SIGNOUT_PATH } from "@/features/auth";
 import { Metadata } from "next";
+import { getPublicAssetPath } from "@/lib/hosting";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
@@ -19,7 +20,7 @@ export const metadata: Metadata = {
     description: "You don't have permission to access this page.",
     images: [
       {
-        url: "/assets/endatix-og-image.jpg",
+        url: getPublicAssetPath("/assets/endatix-og-image.jpg"),
       },
     ],
   },

--- a/components/providers/app-provider.tsx
+++ b/components/providers/app-provider.tsx
@@ -8,8 +8,9 @@ import type { ThemeProviderProps } from "next-themes";
 import { Toaster } from "sonner";
 import { SidebarProvider } from "../ui/sidebar";
 import { Session } from "next-auth";
+import { withBasePath } from "@/lib/hosting/base-path";
 
-const authBasePath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/auth`;
+const authBasePath = withBasePath("/api/auth");
 
 // Options for enabling specific features
 interface AppProviderOptions {

--- a/components/providers/app-provider.tsx
+++ b/components/providers/app-provider.tsx
@@ -9,6 +9,8 @@ import { Toaster } from "sonner";
 import { SidebarProvider } from "../ui/sidebar";
 import { Session } from "next-auth";
 
+const authBasePath = `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/auth`;
+
 // Options for enabling specific features
 interface AppProviderOptions {
   enableTheme?: boolean;
@@ -23,7 +25,11 @@ type ThemeOptions = Partial<Omit<ThemeProviderProps, "children">>;
 
 // Predefined options
 export const AppOptions = {
-  PublicPages: { enableTheme: false, enableAnalytics: true, enableSidebar: false } as AppProviderOptions,
+  PublicPages: {
+    enableTheme: false,
+    enableAnalytics: true,
+    enableSidebar: false,
+  } as AppProviderOptions,
 };
 
 // Main props interface
@@ -68,12 +74,20 @@ export function AppProvider({
 
   // Add NextAuth session provider if enabled
   if (enableSession) {
-    content = <SessionProvider session={session}>{content}</SessionProvider>;
+    content = (
+      <SessionProvider session={session} basePath={authBasePath}>
+        {content}
+      </SessionProvider>
+    );
   }
 
   // Add sidebar provider if enabled
   if (enableSidebar) {
-    content = <SidebarProvider defaultOpen={sidebarDefaultOpen}>{content}</SidebarProvider>;
+    content = (
+      <SidebarProvider defaultOpen={sidebarDefaultOpen}>
+        {content}
+      </SidebarProvider>
+    );
   }
 
   // Add analytics provider if enabled

--- a/components/providers/theme-provider.tsx
+++ b/components/providers/theme-provider.tsx
@@ -83,6 +83,10 @@ function ThemeHotkey() {
         return;
       }
 
+      if (!event.key){
+        return;
+      }
+
       if (event.metaKey || event.ctrlKey || event.altKey) {
         return;
       }

--- a/features/auth/__tests__/utils.test.ts
+++ b/features/auth/__tests__/utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { toAuthRedirectUrl } from "../utils";
+
+describe("toAuthRedirectUrl", () => {
+  it("prefixes safe return URLs with the configured base path", () => {
+    expect(toAuthRedirectUrl("/forms", "/app")).toBe("/app/forms");
+  });
+
+  it("does not prefix return URLs that already include the base path", () => {
+    expect(toAuthRedirectUrl("/app/forms", "/app")).toBe("/app/forms");
+  });
+
+  it("falls back to the default return URL for unsafe return URLs", () => {
+    expect(toAuthRedirectUrl("https://evil.example/forms", "/app")).toBe(
+      "/app/forms",
+    );
+  });
+
+  it("preserves query strings in safe return URLs", () => {
+    expect(toAuthRedirectUrl("/forms?tab=recent", "/app")).toBe(
+      "/app/forms?tab=recent",
+    );
+  });
+});

--- a/features/auth/use-cases/create-account/ui/create-account-form.tsx
+++ b/features/auth/use-cases/create-account/ui/create-account-form.tsx
@@ -23,7 +23,7 @@ interface CreateAccountActionState {
 
 const CreateAccountForm = () => {
   const router = useRouter();
-  const [state, formAction, isPending] = useActionState<
+  const [state, formAction, _] = useActionState<
     CreateAccountActionState,
     FormData
   >(

--- a/features/auth/use-cases/create-account/ui/create-account-form.tsx
+++ b/features/auth/use-cases/create-account/ui/create-account-form.tsx
@@ -9,6 +9,7 @@ import { ErrorMessage } from "@/components/forms/error-message";
 import { createAccountAction } from "../create-account.action";
 import { useActionState } from "react";
 import { useRouter } from "next/navigation";
+import { getPublicAssetPath } from "@/lib/hosting";
 
 interface CreateAccountActionState {
   success: boolean;
@@ -22,29 +23,34 @@ interface CreateAccountActionState {
 
 const CreateAccountForm = () => {
   const router = useRouter();
-  const [state, formAction, isPending] = useActionState<CreateAccountActionState, FormData>(
+  const [state, formAction, isPending] = useActionState<
+    CreateAccountActionState,
+    FormData
+  >(
     async (_, formData) => {
       const result = await createAccountAction(null, formData);
       if (result.success) {
         const email = formData.get("email");
         if (email) {
-          router.push(`/account-verification?email=${encodeURIComponent(email.toString())}`);
+          router.push(
+            `/account-verification?email=${encodeURIComponent(email.toString())}`,
+          );
         }
       }
       return result;
     },
-    { success: false }
+    { success: false },
   );
 
   return (
     <form action={formAction}>
       <div className="grid gap-2 text-center">
-        <div className="flex justify-center mb-2">
-          <Image 
-            src="/assets/icons/endatix.svg" 
-            alt="Endatix logo" 
-            width={180} 
-            height={60} 
+        <div className="mb-2 flex justify-center">
+          <Image
+            src={getPublicAssetPath("/assets/icons/endatix.svg")}
+            alt="Endatix logo"
+            width={180}
+            height={60}
             priority
           />
         </div>
@@ -70,11 +76,11 @@ const CreateAccountForm = () => {
         </div>
         <div className="grid gap-2">
           <Label htmlFor="password">Password</Label>
-          <Input 
-            id="password" 
-            type="password" 
-            name="password" 
-            required 
+          <Input
+            id="password"
+            type="password"
+            name="password"
+            required
             tabIndex={2}
             defaultValue={state?.formData?.get("password")?.toString()}
           />
@@ -82,9 +88,7 @@ const CreateAccountForm = () => {
             <ErrorMessage message={state.errors.password.toString()} />
           )}
         </div>
-        {state?.errorMessage && (
-          <ErrorMessage message={state.errorMessage} />
-        )}
+        {state?.errorMessage && <ErrorMessage message={state.errorMessage} />}
         {/* <Button type="submit" className="w-full" disabled={isPending}>
           {isPending ? <Spinner className="mr-2" /> : null}
           Create account with email

--- a/features/auth/use-cases/signin/sign-in-with-endatix.action.ts
+++ b/features/auth/use-cases/signin/sign-in-with-endatix.action.ts
@@ -14,6 +14,7 @@ import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { redirect } from "next/navigation";
 import { AUTH_ERROR_PATH } from "../../infrastructure/auth-constants";
 import { ServerActionState } from "@/lib/utils/zod-error-utils";
+import { toAuthRedirectUrl } from "@/features/auth/utils";
 
 export type SignInFormState = ServerActionState<{
   email?: string;
@@ -42,7 +43,7 @@ export async function signInWithEndatixAction(
     await signIn(ENDATIX_AUTH_PROVIDER_ID, {
       email: validatedData.data.email,
       password: validatedData.data.password,
-      redirectTo: validatedData.data.returnUrl,
+      redirectTo: toAuthRedirectUrl(validatedData.data.returnUrl),
     });
   } catch (error: unknown) {
     // handle redirect error, which is handled by Next.js to complete the redirect

--- a/features/auth/use-cases/signin/ui/endatix-sign-in-form.tsx
+++ b/features/auth/use-cases/signin/ui/endatix-sign-in-form.tsx
@@ -12,6 +12,7 @@ import {
   signInWithEndatixAction,
 } from "../sign-in-with-endatix.action";
 import { Spinner } from "@/components/loaders/spinner";
+import { getPublicAssetPath } from "@/lib/hosting";
 import Link from "next/link";
 
 import { ServerActionState } from "@/lib/utils/zod-error-utils";
@@ -40,7 +41,7 @@ const EndatixSignInForm: FC<EndatixSignInFormProps> = ({
       <div className="grid gap-2 text-center">
         <div className="mb-2 flex justify-center">
           <Image
-            src="/assets/icons/endatix.svg"
+            src={getPublicAssetPath("/assets/icons/endatix.svg")}
             alt="Endatix logo"
             width={180}
             height={60}

--- a/features/auth/use-cases/signin/ui/external-sign-in-button.tsx
+++ b/features/auth/use-cases/signin/ui/external-sign-in-button.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { AuthPresentation } from "@/features/auth/infrastructure";
+import { toAuthRedirectUrl } from "@/features/auth/utils";
 import { signIn } from "next-auth/react";
 import { FC } from "react";
 
@@ -17,6 +18,8 @@ const ExternalSignInOptions: FC<ExternalSignInOptionsProps> = ({
   if (externalAuthProviders.length === 0) {
     return null;
   }
+
+  const redirectTo = toAuthRedirectUrl(returnUrl);
 
   return (
     <div className="grid gap-4">
@@ -34,7 +37,7 @@ const ExternalSignInOptions: FC<ExternalSignInOptionsProps> = ({
         <Button
           key={provider.id}
           type="button"
-          onClick={() => signIn(provider.id, { redirectTo: returnUrl })}
+          onClick={() => signIn(provider.id, { redirectTo })}
         >
           {provider.signInLabel}
         </Button>

--- a/features/auth/utils.ts
+++ b/features/auth/utils.ts
@@ -1,0 +1,31 @@
+import { DEFAULT_RETURN_URL } from "./infrastructure/auth-constants";
+import { DEFAULT_BASE_PATH, withBasePath } from "@/lib/hosting/base-path";
+
+/**
+ * Normalizes the return URL to a safe relative URL.
+ * @param returnUrl - The return URL to normalize.
+ * @returns The normalized return URL.
+ */
+function normalizeReturnUrl(returnUrl: string | undefined): string {
+  const trimmed = returnUrl?.trim() || DEFAULT_RETURN_URL;
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
+    return DEFAULT_RETURN_URL;
+  }
+
+  return trimmed;
+}
+
+/**
+ * Builds a safe redirect URL for authentication.
+ * @param returnUrl - The return URL to build the redirect URL from.
+ * @param basePath - The base path to build the redirect URL from.
+ * @returns The safe redirect URL.
+ */
+export function toAuthRedirectUrl(
+  returnUrl: string | undefined,
+  basePath = DEFAULT_BASE_PATH,
+): string {
+  const safeReturnUrl = normalizeReturnUrl(returnUrl);
+  
+  return withBasePath(safeReturnUrl, basePath);
+}

--- a/features/forms/ui/share-dialog.tsx
+++ b/features/forms/ui/share-dialog.tsx
@@ -7,12 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
@@ -26,16 +21,18 @@ interface ShareDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
 const getShareUrl = (formId: string): string => {
   if (typeof window !== "undefined") {
-    return `${window.location.origin}/share/${formId}`;
+    return `${window.location.origin}${basePath}/share/${formId}`;
   }
-  return `/share/${formId}`;
+  return `${basePath}/share/${formId}`;
 };
 
 const getEmbedCode = (formId: string): string => {
   if (typeof window !== "undefined") {
-    return `<script src="${window.location.origin}/embed/v1/embed.js" data-form-id="${formId}"></script>`;
+    return `<script src="${window.location.origin}${basePath}/embed/v1/embed.js" data-form-id="${formId}"></script>`;
   }
   return ``;
 };
@@ -58,25 +55,30 @@ export function ShareDialog({ formId, open, onOpenChange }: ShareDialogProps) {
         <DialogHeader>
           <DialogTitle>Share Form</DialogTitle>
           <DialogDescription>
-            Share the form with others via a direct link or embedded on a web page.
+            Share the form with others via a direct link or embedded on a web
+            page.
           </DialogDescription>
         </DialogHeader>
-        <Tabs defaultValue="share-link" className="w-full" onValueChange={handleTabChange}>
+        <Tabs
+          defaultValue="share-link"
+          className="w-full"
+          onValueChange={handleTabChange}
+        >
           <TabsList className="grid w-full grid-cols-2">
             <TabsTrigger value="share-link">
-              <Link2 className="w-4 h-4 mr-2" />
+              <Link2 className="mr-2 h-4 w-4" />
               Share link
             </TabsTrigger>
             <TabsTrigger value="embed-code">
-              <Code className="w-4 h-4 mr-2" />
+              <Code className="mr-2 h-4 w-4" />
               Embed code
             </TabsTrigger>
           </TabsList>
 
-          <TabsContent value="share-link" className="space-y-4 min-h-[280px]">
+          <TabsContent value="share-link" className="min-h-[280px] space-y-4">
             <div className="space-y-2">
               <p className="text-sm text-muted-foreground">
-                Send this link to users for submitting  the form.
+                Send this link to users for submitting the form.
               </p>
               <div className="relative">
                 <Input
@@ -90,7 +92,7 @@ export function ShareDialog({ formId, open, onOpenChange }: ShareDialogProps) {
             </div>
           </TabsContent>
 
-          <TabsContent value="embed-code" className="space-y-4 min-h-[280px]">
+          <TabsContent value="embed-code" className="min-h-[280px] space-y-4">
             <div className="space-y-2">
               <p className="text-sm text-muted-foreground">
                 Copy and paste this code into a web page to embed the form.
@@ -99,7 +101,7 @@ export function ShareDialog({ formId, open, onOpenChange }: ShareDialogProps) {
                 <Textarea
                   readOnly
                   value={embedCode}
-                  className="font-mono text-xs pr-10"
+                  className="pr-10 font-mono text-xs"
                   rows={12}
                 />
                 <CopyToClipboard

--- a/features/forms/ui/share-dialog.tsx
+++ b/features/forms/ui/share-dialog.tsx
@@ -34,7 +34,7 @@ const getShareUrl = (formId: string): string => {
 };
 
 const getEmbedCode = (formId: string): string => {
-  if (typeof globalThis.window !== "undefined") {
+  if (globalThis.window !== undefined) {
     return `<script src="${globalThis.window.location.origin}${embedScriptPath}" data-form-id="${formId}"></script>`;
   }
   return ``;

--- a/features/forms/ui/share-dialog.tsx
+++ b/features/forms/ui/share-dialog.tsx
@@ -31,8 +31,8 @@ const getShareUrl = (formId: string): string => {
 };
 
 const getEmbedCode = (formId: string): string => {
-  if (typeof window !== "undefined") {
-    return `<script src="${window.location.origin}${basePath}/embed/v1/embed.js" data-form-id="${formId}"></script>`;
+  if (typeof globalThis.window !== "undefined") {
+    return `<script src="${globalThis.window.location.origin}${basePath}/embed/v1/embed.js" data-form-id="${formId}"></script>`;
   }
   return ``;
 };

--- a/features/forms/ui/share-dialog.tsx
+++ b/features/forms/ui/share-dialog.tsx
@@ -14,6 +14,7 @@ import { Label } from "@/components/ui/label";
 import { Link2, Code } from "lucide-react";
 import { toast } from "@/components/ui/toast";
 import CopyToClipboard from "@/components/copy-to-clipboard";
+import { withBasePath } from "@/lib/hosting";
 
 interface ShareDialogProps {
   formId: string;
@@ -21,18 +22,20 @@ interface ShareDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+const sharePath = (formId: string): string => withBasePath(`/share/${formId}`);
+const embedScriptPath = withBasePath("/embed/v1/embed.js");
 
 const getShareUrl = (formId: string): string => {
-  if (typeof window !== "undefined") {
-    return `${window.location.origin}${basePath}/share/${formId}`;
+  const path = sharePath(formId);
+  if (globalThis.window !== undefined) {
+    return `${globalThis.window.location.origin}${path}`;
   }
-  return `${basePath}/share/${formId}`;
+  return path;
 };
 
 const getEmbedCode = (formId: string): string => {
   if (typeof globalThis.window !== "undefined") {
-    return `<script src="${globalThis.window.location.origin}${basePath}/embed/v1/embed.js" data-form-id="${formId}"></script>`;
+    return `<script src="${globalThis.window.location.origin}${embedScriptPath}" data-form-id="${formId}"></script>`;
   }
   return ``;
 };

--- a/lib/hosting/__tests__/base-path.test.ts
+++ b/lib/hosting/__tests__/base-path.test.ts
@@ -12,6 +12,8 @@ describe("normalizeBasePath", () => {
   it("adds a leading slash and removes a trailing slash", () => {
     expect(normalizeBasePath("app")).toBe("/app");
     expect(normalizeBasePath("/app/")).toBe("/app");
+    expect(normalizeBasePath("/app//")).toBe("/app");
+    expect(normalizeBasePath("/app///")).toBe("/app");
   });
 });
 

--- a/lib/hosting/__tests__/base-path.test.ts
+++ b/lib/hosting/__tests__/base-path.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeBasePath, withBasePath } from "../base-path";
+
+describe("normalizeBasePath", () => {
+  it("normalizes empty and root base paths to an empty string", () => {
+    expect(normalizeBasePath("")).toBe("");
+    expect(normalizeBasePath("/")).toBe("");
+    expect(normalizeBasePath("   ")).toBe("");
+  });
+
+  it("adds a leading slash and removes a trailing slash", () => {
+    expect(normalizeBasePath("app")).toBe("/app");
+    expect(normalizeBasePath("/app/")).toBe("/app");
+  });
+});
+
+describe("withBasePath", () => {
+  it("prefixes paths with the configured base path", () => {
+    expect(withBasePath("/forms", "/app")).toBe("/app/forms");
+  });
+
+  it("does not duplicate the configured base path", () => {
+    expect(withBasePath("/app/forms", "/app")).toBe("/app/forms");
+    expect(withBasePath("/app?tab=recent", "/app")).toBe("/app?tab=recent");
+  });
+
+  it("normalizes paths without a leading slash", () => {
+    expect(withBasePath("assets/icons/icon.svg", "/app")).toBe(
+      "/app/assets/icons/icon.svg",
+    );
+  });
+
+  it("preserves query strings and hashes for callers that allow them", () => {
+    expect(withBasePath("/forms?tab=recent", "/app")).toBe(
+      "/app/forms?tab=recent",
+    );
+    expect(withBasePath("/forms#recent", "/app")).toBe("/app/forms#recent");
+  });
+
+  it("returns an empty string for blank paths", () => {
+    expect(withBasePath("   ", "/app")).toBe("");
+  });
+});

--- a/lib/hosting/__tests__/public-assets.test.ts
+++ b/lib/hosting/__tests__/public-assets.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getPublicAssetPath } from "../public-assets";
+import {
+  getPublicAssetPath,
+  InvalidPublicAssetPathError,
+} from "../public-assets";
 
 describe("getPublicAssetPath", () => {
   it("prefixes absolute public asset paths with the configured base path", () => {
@@ -26,22 +29,34 @@ describe("getPublicAssetPath", () => {
   });
 
   it("rejects external URLs", () => {
-    expect(() =>
-      getPublicAssetPath("https://example.com/assets/icon.svg", "/app"),
-    ).toThrow("Absolute URIs are not allowed for internal public assets.");
+    const action = () =>
+      getPublicAssetPath("https://example.com/assets/icon.svg", "/app");
+
+    expect(action).toThrow(InvalidPublicAssetPathError);
+    expect(action).toThrow(
+      "Absolute URIs are not allowed for internal public assets.",
+    );
   });
 
   it("rejects protocol-relative URLs", () => {
-    expect(() => getPublicAssetPath("//example.com/icon.svg", "/app")).toThrow(
-      "Protocol-relative URLs are not allowed.",
-    );
+    const action = () => getPublicAssetPath("//example.com/icon.svg", "/app");
+
+    expect(action).toThrow(InvalidPublicAssetPathError);
+    expect(action).toThrow("Protocol-relative URLs are not allowed.");
   });
 
   it("rejects query strings and hashes to keep the helper path-only", () => {
-    expect(() => getPublicAssetPath("/assets/icon.svg?v=1", "/app")).toThrow(
+    const queryAction = () =>
+      getPublicAssetPath("/assets/icon.svg?v=1", "/app");
+    const hashAction = () =>
+      getPublicAssetPath("/assets/icon.svg#logo", "/app");
+
+    expect(queryAction).toThrow(InvalidPublicAssetPathError);
+    expect(queryAction).toThrow(
       "Public asset paths must not include query strings or hashes.",
     );
-    expect(() => getPublicAssetPath("/assets/icon.svg#logo", "/app")).toThrow(
+    expect(hashAction).toThrow(InvalidPublicAssetPathError);
+    expect(hashAction).toThrow(
       "Public asset paths must not include query strings or hashes.",
     );
   });

--- a/lib/hosting/__tests__/public-assets.test.ts
+++ b/lib/hosting/__tests__/public-assets.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { getPublicAssetPath } from "../public-assets";
+
+describe("getPublicAssetPath", () => {
+  it("prefixes absolute public asset paths with the configured base path", () => {
+    expect(getPublicAssetPath("/assets/icons/icon.svg", "/app")).toBe(
+      "/app/assets/icons/icon.svg",
+    );
+  });
+
+  it("does not duplicate the base path when it is already present", () => {
+    expect(getPublicAssetPath("/app/assets/icons/icon.svg", "/app")).toBe(
+      "/app/assets/icons/icon.svg",
+    );
+  });
+
+  it("normalizes relative public asset paths", () => {
+    expect(getPublicAssetPath("assets/icons/icon.svg", "/app")).toBe(
+      "/app/assets/icons/icon.svg",
+    );
+  });
+
+  it("returns an empty path for blank input", () => {
+    expect(getPublicAssetPath("   ", "/app")).toBe("");
+  });
+
+  it("rejects external URLs", () => {
+    expect(() =>
+      getPublicAssetPath("https://example.com/assets/icon.svg", "/app"),
+    ).toThrow("Absolute URIs are not allowed for internal public assets.");
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(() => getPublicAssetPath("//example.com/icon.svg", "/app")).toThrow(
+      "Protocol-relative URLs are not allowed.",
+    );
+  });
+
+  it("rejects query strings and hashes to keep the helper path-only", () => {
+    expect(() => getPublicAssetPath("/assets/icon.svg?v=1", "/app")).toThrow(
+      "Public asset paths must not include query strings or hashes.",
+    );
+    expect(() => getPublicAssetPath("/assets/icon.svg#logo", "/app")).toThrow(
+      "Public asset paths must not include query strings or hashes.",
+    );
+  });
+});

--- a/lib/hosting/base-path.ts
+++ b/lib/hosting/base-path.ts
@@ -13,7 +13,12 @@ export function normalizeBasePath(
   }
 
   const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  return withLeadingSlash.replace(/\/+$/, "");
+  let endIndex = withLeadingSlash.length;
+  while (endIndex > 0 && withLeadingSlash[endIndex - 1] === "/") {
+    endIndex -= 1;
+  }
+
+  return withLeadingSlash.slice(0, endIndex);
 }
 
 export function withBasePath(

--- a/lib/hosting/base-path.ts
+++ b/lib/hosting/base-path.ts
@@ -13,9 +13,7 @@ export function normalizeBasePath(
   }
 
   const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  return withLeadingSlash.endsWith("/")
-    ? withLeadingSlash.slice(0, -1)
-    : withLeadingSlash;
+  return withLeadingSlash.replace(/\/+$/, "");
 }
 
 export function withBasePath(

--- a/lib/hosting/base-path.ts
+++ b/lib/hosting/base-path.ts
@@ -1,0 +1,48 @@
+export const DEFAULT_BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
+export function normalizeBasePath(
+  basePath: string = DEFAULT_BASE_PATH,
+): string {
+  if (typeof basePath !== "string") {
+    return "";
+  }
+
+  const trimmed = basePath.trim();
+  if (trimmed.length === 0 || trimmed === "/") {
+    return "";
+  }
+
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.endsWith("/")
+    ? withLeadingSlash.slice(0, -1)
+    : withLeadingSlash;
+}
+
+export function withBasePath(
+  path: string,
+  basePath: string = DEFAULT_BASE_PATH,
+): string {
+  if (typeof path !== "string") {
+    return "";
+  }
+
+  const trimmed = path.trim();
+  if (trimmed.length === 0) {
+    return "";
+  }
+
+  const normalizedPath = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  const normalizedBasePath = normalizeBasePath(basePath);
+
+  if (
+    normalizedBasePath.length === 0 ||
+    normalizedPath === normalizedBasePath ||
+    normalizedPath.startsWith(`${normalizedBasePath}/`) ||
+    normalizedPath.startsWith(`${normalizedBasePath}?`) ||
+    normalizedPath.startsWith(`${normalizedBasePath}#`)
+  ) {
+    return normalizedPath;
+  }
+
+  return `${normalizedBasePath}${normalizedPath}`;
+}

--- a/lib/hosting/index.ts
+++ b/lib/hosting/index.ts
@@ -1,0 +1,2 @@
+export { getPublicAssetPath } from "./public-assets";
+export { withBasePath } from "./base-path";

--- a/lib/hosting/index.ts
+++ b/lib/hosting/index.ts
@@ -1,2 +1,5 @@
-export { getPublicAssetPath } from "./public-assets";
+export {
+  getPublicAssetPath,
+  InvalidPublicAssetPathError,
+} from "./public-assets";
 export { withBasePath } from "./base-path";

--- a/lib/hosting/index.ts
+++ b/lib/hosting/index.ts
@@ -2,4 +2,4 @@ export {
   getPublicAssetPath,
   InvalidPublicAssetPathError,
 } from "./public-assets";
-export { withBasePath } from "./base-path";
+export { normalizeBasePath, withBasePath } from "./base-path";

--- a/lib/hosting/public-assets.ts
+++ b/lib/hosting/public-assets.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_BASE_PATH, withBasePath } from "./base-path";
 
-const internalAssetBaseUrl = "http://internal-endatix.local";
+const internalAssetBaseUrl = "https://internal-endatix.local";
 
 /**
  * Resolves the public asset path relative to the internal asset base URL.

--- a/lib/hosting/public-assets.ts
+++ b/lib/hosting/public-assets.ts
@@ -3,8 +3,8 @@ import { DEFAULT_BASE_PATH, withBasePath } from "./base-path";
 const internalAssetBaseUrl = "https://internal-endatix.local";
 
 export class InvalidPublicAssetPathError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "InvalidPublicAssetPathError";
   }
 }
@@ -41,7 +41,9 @@ export function getPublicAssetPath(
   try {
     parsedUrl = new URL(trimmedAssetPath, internalAssetBaseUrl);
   } catch (err) {
-    throw new InvalidPublicAssetPathError("Invalid URL format.");
+    throw new InvalidPublicAssetPathError("Invalid URL format.", {
+      cause: err,
+    });
   }
 
   if (parsedUrl.origin !== internalAssetBaseUrl) {

--- a/lib/hosting/public-assets.ts
+++ b/lib/hosting/public-assets.ts
@@ -2,6 +2,13 @@ import { DEFAULT_BASE_PATH, withBasePath } from "./base-path";
 
 const internalAssetBaseUrl = "https://internal-endatix.local";
 
+export class InvalidPublicAssetPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidPublicAssetPathError";
+  }
+}
+
 /**
  * Resolves the public asset path relative to the internal asset base URL.
  * @param assetPath - The asset path to resolve.
@@ -25,24 +32,26 @@ export function getPublicAssetPath(
     trimmedAssetPath.startsWith("//") ||
     trimmedAssetPath.startsWith("\\\\")
   ) {
-    throw new Error("Protocol-relative URLs are not allowed.");
+    throw new InvalidPublicAssetPathError(
+      "Protocol-relative URLs are not allowed.",
+    );
   }
 
   let parsedUrl: URL;
   try {
     parsedUrl = new URL(trimmedAssetPath, internalAssetBaseUrl);
   } catch (err) {
-    throw new Error("Invalid URL format.");
+    throw new InvalidPublicAssetPathError("Invalid URL format.");
   }
 
   if (parsedUrl.origin !== internalAssetBaseUrl) {
-    throw new Error(
+    throw new InvalidPublicAssetPathError(
       "Absolute URIs are not allowed for internal public assets.",
     );
   }
 
   if (parsedUrl.search.length > 0 || parsedUrl.hash.length > 0) {
-    throw new Error(
+    throw new InvalidPublicAssetPathError(
       "Public asset paths must not include query strings or hashes.",
     );
   }

--- a/lib/hosting/public-assets.ts
+++ b/lib/hosting/public-assets.ts
@@ -1,0 +1,82 @@
+const configuredBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+const internalAssetBaseUrl = "http://internal-endatix.local";
+
+/**
+ * Normalizes the base path to a string that can be used to resolve the public asset path.
+ * @param basePath - The base path to normalize.
+ * @returns The normalized base path.
+ */
+function normalizeBasePath(basePath: string): string {
+  if (typeof basePath !== "string") {
+    return "";
+  }
+
+  const trimmed = basePath.trim();
+  if (trimmed.length === 0 || trimmed === "/") {
+    return "";
+  }
+
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.endsWith("/")
+    ? withLeadingSlash.slice(0, -1)
+    : withLeadingSlash;
+}
+
+/**
+ * Resolves the public asset path relative to the internal asset base URL.
+ * @param assetPath - The asset path to resolve.
+ * @param basePath - The base path to resolve the asset path relative to.
+ * @returns The resolved public asset path.
+ */
+export function getPublicAssetPath(
+  assetPath: string,
+  basePath: string = configuredBasePath,
+): string {
+  if (typeof assetPath !== "string") {
+    return "";
+  }
+
+  const trimmedAssetPath = assetPath.trim();
+  if (trimmedAssetPath.length === 0) {
+    return "";
+  }
+
+  if (
+    trimmedAssetPath.startsWith("//") ||
+    trimmedAssetPath.startsWith("\\\\")
+  ) {
+    throw new Error("Protocol-relative URLs are not allowed.");
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(trimmedAssetPath, internalAssetBaseUrl);
+  } catch (err) {
+    throw new Error("Invalid URL format.");
+  }
+
+  if (parsedUrl.origin !== internalAssetBaseUrl) {
+    throw new Error(
+      "Absolute URIs are not allowed for internal public assets.",
+    );
+  }
+
+  if (parsedUrl.search.length > 0 || parsedUrl.hash.length > 0) {
+    throw new Error(
+      "Public asset paths must not include query strings or hashes.",
+    );
+  }
+
+  const normalizedAssetPath = parsedUrl.pathname;
+  const normalizedBasePath = normalizeBasePath(basePath);
+
+  if (
+    normalizedBasePath.length === 0 ||
+    normalizedAssetPath === normalizedBasePath ||
+    normalizedAssetPath.startsWith(`${normalizedBasePath}/`)
+  ) {
+    return normalizedAssetPath;
+  }
+
+  return `${normalizedBasePath}${normalizedAssetPath}`;
+}

--- a/lib/hosting/public-assets.ts
+++ b/lib/hosting/public-assets.ts
@@ -1,26 +1,6 @@
-const configuredBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+import { DEFAULT_BASE_PATH, withBasePath } from "./base-path";
+
 const internalAssetBaseUrl = "http://internal-endatix.local";
-
-/**
- * Normalizes the base path to a string that can be used to resolve the public asset path.
- * @param basePath - The base path to normalize.
- * @returns The normalized base path.
- */
-function normalizeBasePath(basePath: string): string {
-  if (typeof basePath !== "string") {
-    return "";
-  }
-
-  const trimmed = basePath.trim();
-  if (trimmed.length === 0 || trimmed === "/") {
-    return "";
-  }
-
-  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-  return withLeadingSlash.endsWith("/")
-    ? withLeadingSlash.slice(0, -1)
-    : withLeadingSlash;
-}
 
 /**
  * Resolves the public asset path relative to the internal asset base URL.
@@ -30,7 +10,7 @@ function normalizeBasePath(basePath: string): string {
  */
 export function getPublicAssetPath(
   assetPath: string,
-  basePath: string = configuredBasePath,
+  basePath: string = DEFAULT_BASE_PATH,
 ): string {
   if (typeof assetPath !== "string") {
     return "";
@@ -67,16 +47,5 @@ export function getPublicAssetPath(
     );
   }
 
-  const normalizedAssetPath = parsedUrl.pathname;
-  const normalizedBasePath = normalizeBasePath(basePath);
-
-  if (
-    normalizedBasePath.length === 0 ||
-    normalizedAssetPath === normalizedBasePath ||
-    normalizedAssetPath.startsWith(`${normalizedBasePath}/`)
-  ) {
-    return normalizedAssetPath;
-  }
-
-  return `${normalizedBasePath}${normalizedAssetPath}`;
+  return withBasePath(parsedUrl.pathname, basePath);
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -55,6 +55,11 @@ const nextConfig: NextConfig = {
   },
   redirects: async () => [
     {
+      source: "/",
+      destination: "/signin",
+      permanent: false,
+    },
+    {
       source: "/login",
       destination: "/signin",
       permanent: true,

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { normalizeBasePath } from "./lib/hosting/base-path";
 import { getRewriteRuleFor } from "./lib/hosting/next-config-helper";
 import { Rewrite } from "next/dist/lib/load-custom-routes";
 import { withEndatix } from "@/features/config";
@@ -6,7 +7,7 @@ import { withEndatix } from "@/features/config";
 const nextConfig: NextConfig = {
   /* config options here */
   output: "standalone", // Used to decrease the size of the application, check https://nextjs.org/docs/pages/api-reference/next-config-js/output
-  basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
+  basePath: normalizeBasePath(),
   typedRoutes: true,
   reactStrictMode: true,
   reactCompiler: true,

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,7 @@ import { withEndatix } from "@/features/config";
 const nextConfig: NextConfig = {
   /* config options here */
   output: "standalone", // Used to decrease the size of the application, check https://nextjs.org/docs/pages/api-reference/next-config-js/output
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
   typedRoutes: true,
   reactStrictMode: true,
   reactCompiler: true,

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,7 @@ import { auth } from "@/auth";
 import { isMaintenanceMode } from "@/lib/maintenance/maintenance-config";
 import { rewriteToMaintenance } from "@/lib/maintenance/maintenance-response";
 import { toSafeRelativeUrl } from "@/lib/utils/url-utils";
+import { withBasePath } from "@/lib/hosting/base-path";
 import { NextRequest, NextResponse } from "next/server";
 import {
   AUTH_ROUTES,
@@ -80,8 +81,13 @@ function redirectToLogin(req: NextRequest): NextResponse<unknown> {
     req.nextUrl.origin,
     DEFAULT_RETURN_URL,
   );
+  const signinPath = withBasePath(
+    SIGNIN_PATH,
+    process.env.NEXT_PUBLIC_BASE_PATH,
+  );
+
   const loginUrl = new URL(
-    `${SIGNIN_PATH}?${RETURN_URL_PARAM}=${encodeURIComponent(returnUrl)}`,
+    `${signinPath}?${RETURN_URL_PARAM}=${encodeURIComponent(returnUrl)}`,
     req.nextUrl.origin,
   );
   return NextResponse.redirect(loginUrl);

--- a/src/embed/embed.ts
+++ b/src/embed/embed.ts
@@ -218,11 +218,7 @@ function handleResizeMessage(
   data: Record<string, unknown>,
 ): void {
   const height = data.height;
-  if (
-    typeof height !== "number" ||
-    !Number.isFinite(height) ||
-    height < 0
-  ) {
+  if (typeof height !== "number" || !Number.isFinite(height) || height < 0) {
     return;
   }
 
@@ -394,8 +390,14 @@ const endatixEmbed: EndatixEmbedApi = {
       );
     }
 
+    let basePath = "";
+    const index = resolvedUrl.pathname.indexOf("/embed/v1/embed.js");
+    if (index !== -1) {
+      basePath = resolvedUrl.pathname.slice(0, index);
+    }
+
     const iframeUrl = new URL(
-      `${embedProtocol}//${resolvedUrl.host}/embed/${validatedFormId}`,
+      `${embedProtocol}//${resolvedUrl.host}${basePath}/embed/${validatedFormId}`,
     );
 
     if (options.token) {


### PR DESCRIPTION
# feat: Support for deploying the Endatix Hub under a subfolder / reverse proxy

## Description
This PR adds few key components:
- Application now supports deployment at a custom base path via the `NEXT_PUBLIC_BASE_PATH` environment variable, enabling hosting under non-root paths.
- Static asset path respects reverse-proxy or base path configuration
- Authentication redirects now respect the reverse-proxy or base path configuration
- Share and embed functionality properly includes the base path in generated URLs.

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/648

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)


## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Application now supports deployment at a custom base path via the `NEXT_PUBLIC_BASE_PATH` environment variable, enabling hosting under non-root paths.

* **Improvements**
  * Asset references and authentication redirects now respect the configured base path.
  * Share and embed functionality properly includes the base path in generated URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/endatix/endatix-hub/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->