### PR TITLE
feat: Add email settings and templates cards and test email form

### DIFF
--- a/app/(main)/admin/email/page.tsx
+++ b/app/(main)/admin/email/page.tsx
@@ -1,0 +1,44 @@
+import { requireAdmin } from "@/components/admin-ui/admin-protection";
+import { auth } from "@/auth";
+import { ApiResult, EndatixApi } from "@/lib/endatix-api";
+import { Mail } from "lucide-react";
+import { EmailSettingsCard } from "@/features/email/ui/email-settings-card";
+import { EmailTemplatesCard } from "@/features/email/ui/email-templates-card";
+import { TestEmailForm } from "@/features/email/ui/test-email-form";
+import type { EmailProviderInfo, EmailTemplateSummary } from "@/lib/endatix-api/email/types";
+
+export default async function EmailSettingsPage() {
+  await requireAdmin();
+
+  const session = await auth();
+  const api = new EndatixApi(session?.accessToken);
+
+  const [providerResult, templatesResult] = await Promise.all([
+    api.email.getProviderSettings(),
+    api.email.getTemplates(),
+  ]);
+
+  const provider: EmailProviderInfo = ApiResult.isSuccess(providerResult)
+    ? providerResult.data
+    : { providerName: "Unknown", isConfigured: false };
+
+  const templates: EmailTemplateSummary[] = ApiResult.isSuccess(templatesResult)
+    ? templatesResult.data
+    : [];
+
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <div className="mb-6 flex items-center gap-2">
+        <Mail className="h-6 w-6" />
+        <h1 className="text-2xl font-bold">Email Settings</h1>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <EmailSettingsCard provider={provider} />
+        <EmailTemplatesCard templates={templates} />
+      </div>
+
+      <TestEmailForm templates={templates} />
+    </div>
+  );
+}

--- a/components/admin-ui/admin-menu-cards.tsx
+++ b/components/admin-ui/admin-menu-cards.tsx
@@ -88,6 +88,23 @@ export function AdminMenuCards({ showStorage }: Readonly<AdminMenuCardsProps>) {
           <div className="text-muted-foreground"></div>
         </CardFooter>
       </Card>
+      <Card
+        className="@container/card cursor-pointer"
+        onClick={() => router.push("/admin/email")}
+      >
+        <CardHeader>
+          <CardDescription>Manage Email Settings</CardDescription>
+          <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
+            Email
+          </CardTitle>
+        </CardHeader>
+        <CardFooter className="flex-col items-start gap-1.5 text-sm">
+          <div className="line-clamp-1 flex gap-2 font-medium">
+            View email provider and send test emails.
+          </div>
+          <div className="text-muted-foreground"></div>
+        </CardFooter>
+      </Card>
     </div>
   );
 }

--- a/features/email/application/send-test-email.action.ts
+++ b/features/email/application/send-test-email.action.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { auth } from "@/auth";
+import { authorization } from "@/features/auth";
+import { ApiResult, EndatixApi } from "@/lib/endatix-api";
+
+export async function sendTestEmailAction(
+  _prevState: ApiResult<string> | null,
+  formData: FormData,
+): Promise<ApiResult<string>> {
+  const session = await auth();
+  const { requirePlatformAdmin } = await authorization(session);
+  await requirePlatformAdmin();
+
+  const toEmail = formData.get("toEmail") as string;
+  const rawTemplateId = formData.get("templateId") as string | null;
+  const templateId =
+    !rawTemplateId || rawTemplateId === "__none__" ? undefined : rawTemplateId;
+
+  const endatixApi = new EndatixApi(session?.accessToken);
+  const result = await endatixApi.email.sendTestEmail({
+    toEmail,
+    templateId,
+  });
+
+  return result;
+}

--- a/features/email/ui/email-settings-card.tsx
+++ b/features/email/ui/email-settings-card.tsx
@@ -1,0 +1,45 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Mail, CheckCircle2, AlertCircle } from "lucide-react";
+import type { EmailProviderInfo } from "@/lib/endatix-api/email/types";
+
+type EmailSettingsCardProps = {
+  provider: EmailProviderInfo;
+};
+
+export function EmailSettingsCard({
+  provider,
+}: Readonly<EmailSettingsCardProps>) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Mail className="h-5 w-5" />
+          Email Provider
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-3 rounded-lg border bg-muted/30 p-4 text-sm">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-muted-foreground">Provider</span>
+            <span className="font-medium">{provider.providerName}</span>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-muted-foreground">Status</span>
+            {provider.isConfigured ? (
+              <Badge variant="secondary" className="gap-1">
+                <CheckCircle2 className="h-3 w-3" />
+                Configured
+              </Badge>
+            ) : (
+              <Badge variant="outline" className="gap-1 text-muted-foreground">
+                <AlertCircle className="h-3 w-3" />
+                Not Configured
+              </Badge>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/email/ui/email-templates-card.tsx
+++ b/features/email/ui/email-templates-card.tsx
@@ -1,0 +1,51 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { FileText } from "lucide-react";
+import type { EmailTemplateSummary } from "@/lib/endatix-api/email/types";
+
+type EmailTemplatesCardProps = {
+  templates: EmailTemplateSummary[];
+};
+
+export function EmailTemplatesCard({
+  templates,
+}: Readonly<EmailTemplatesCardProps>) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FileText className="h-5 w-5" />
+          Available Email Templates ({templates.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {templates.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No email templates registered.
+          </p>
+        ) : (
+          <div className="grid gap-3">
+            {templates.map((template) => (
+              <div
+                key={template.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-lg border bg-card p-3"
+              >
+                <div className="flex flex-col gap-1">
+                  <span className="font-mono text-sm font-medium">
+                    {template.name}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {template.subject}
+                  </span>
+                </div>
+                <Badge variant="outline" className="text-xs">
+                  {template.fromAddress}
+                </Badge>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/features/email/ui/test-email-form.tsx
+++ b/features/email/ui/test-email-form.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useActionState, useEffect, useRef } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/loaders/spinner";
+import { toast } from "@/components/ui/toast";
+import { ApiResult } from "@/lib/endatix-api";
+import { sendTestEmailAction } from "@/features/email/application/send-test-email.action";
+import { Send, Mail } from "lucide-react";
+import type { EmailTemplateSummary } from "@/lib/endatix-api/email/types";
+
+type TestEmailFormProps = {
+  templates: EmailTemplateSummary[];
+};
+
+export function TestEmailForm({ templates }: Readonly<TestEmailFormProps>) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [state, formAction, isPending] = useActionState(
+    sendTestEmailAction,
+    null,
+  );
+
+  useEffect(() => {
+    if (!state) return;
+
+    if (ApiResult.isSuccess(state)) {
+      toast.success("Test email sent successfully.");
+      formRef.current?.reset();
+    } else {
+      toast.error(state.error?.message || "Failed to send test email.");
+    }
+  }, [state]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Send className="h-5 w-5" />
+          Send Test Email
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form ref={formRef} action={formAction} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <label htmlFor="toEmail" className="text-sm font-medium">
+              Recipient Email
+            </label>
+            <Input
+              id="toEmail"
+              name="toEmail"
+              type="email"
+              placeholder="admin@example.com"
+              required
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label htmlFor="templateId" className="text-sm font-medium">
+              Template (optional)
+            </label>
+            <Select name="templateId" disabled={isPending}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Plain text test email" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">None (plain text)</SelectItem>
+                {templates.map((template) => (
+                  <SelectItem key={template.id} value={template.name}>
+                    <span className="flex items-center gap-2">
+                      {template.name}
+                      <Badge variant="outline" className="text-xs">
+                        {template.fromAddress}
+                      </Badge>
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Button type="submit" disabled={isPending} className="self-start">
+            {isPending ? (
+              <>
+                <Spinner className="mr-2 h-4 w-4" />
+                Sending...
+              </>
+            ) : (
+              <>
+                <Mail data-icon="inline-start" />
+                Send Test Email
+              </>
+            )}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/endatix-api/email/email.ts
+++ b/lib/endatix-api/email/email.ts
@@ -1,0 +1,22 @@
+import { EndatixApi } from "../endatix-api";
+import type {
+  EmailProviderInfo,
+  EmailTemplateSummary,
+  SendTestEmailRequest,
+} from "./types";
+
+export default class Email {
+  constructor(private readonly endatix: EndatixApi) {}
+
+  async getProviderSettings() {
+    return this.endatix.get<EmailProviderInfo>("/admin/email/settings");
+  }
+
+  async getTemplates() {
+    return this.endatix.get<EmailTemplateSummary[]>("/admin/email/templates");
+  }
+
+  async sendTestEmail(request: SendTestEmailRequest) {
+    return this.endatix.post<string>("/admin/email/test", request);
+  }
+}

--- a/lib/endatix-api/email/types.ts
+++ b/lib/endatix-api/email/types.ts
@@ -1,0 +1,16 @@
+export type EmailProviderInfo = {
+  providerName: string;
+  isConfigured: boolean;
+};
+
+export type EmailTemplateSummary = {
+  id: number;
+  name: string;
+  subject: string;
+  fromAddress: string;
+};
+
+export type SendTestEmailRequest = {
+  toEmail: string;
+  templateId?: string;
+};

--- a/lib/endatix-api/endatix-api.ts
+++ b/lib/endatix-api/endatix-api.ts
@@ -17,6 +17,7 @@ import Users from "./users/users";
 import Stats from "./stats/stats";
 import { Folders } from "./folders/folders";
 import { FormTemplates } from "./form-templates/form-templates";
+import Email from "./email/email";
 
 /**
  * Gets the validated and cached API URL
@@ -67,6 +68,7 @@ export class EndatixApi {
   private _stats?: Stats;
   private _folders?: Folders;
   private _formTemplates?: FormTemplates;
+  private _email?: Email;
 
   constructor(
     sessionOrToken?: SessionData | string,
@@ -213,6 +215,11 @@ export class EndatixApi {
   get formTemplates(): FormTemplates {
     this._formTemplates ??= new FormTemplates(this);
     return this._formTemplates;
+  }
+
+  get email(): Email {
+    this._email ??= new Email(this);
+    return this._email;
   }
 
   /**

--- a/lib/endatix-api/types.ts
+++ b/lib/endatix-api/types.ts
@@ -123,3 +123,10 @@ export type { DefinitionField } from "./definitions/types";
 
 // users/types
 export type { UserListItem } from "./users/types";
+
+// email/types
+export type {
+  EmailProviderInfo,
+  EmailTemplateSummary,
+  SendTestEmailRequest,
+} from "./email/types";


### PR DESCRIPTION
# feat: Add email settings and templates cards and test email form

## Description
Adds ability to view if email provider is configured and to send test email
- Uses admin screen as most suitable for the current UI architecture
- Shows currently enabled email provider
- Shows if email provider is confgured
- Lists templates from DB
- Sends test email - plain text or via email template
- For platform admins only

## Related Issues
- closes https://github.com/endatix/endatix/issues/763

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="1052" height="811" alt="image" src="https://github.com/user-attachments/assets/d3496699-703d-461c-86c6-9d0505a6040b" />
