### PR TITLE
fix(helm): Add Helm Chart

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -1,9 +1,38 @@
-name: Build & Test
+name: Build, Test & Release
+
+# Thin consumer of endatix/release-workflows (see its README):
+#   • PR to main → tests (below) + build validation in the shared pipeline
+#     (scripts/release-prepare.sh @ 0.0.0-ci — builds the image and packages
+#     the chart, publishes nothing)
+#   • push main  → tests, then canary vX.Y.Z-canary.N: semantic-release builds
+#     once at the real version and publishes the image + Helm chart to GHCR
+#     (canaries NEVER go to Docker Hub — it is public and immutable).
+#   • stable releases → MANUAL, human-reviewed: run "Start Stable Release"
+#     (release-start.yml) → edit the draft notes → click "Publish release" →
+#     release-artifacts.yml rebuilds at the tag and publishes to GHCR +
+#     Docker Hub.
+#
+# The canary publishes ONLY after build + tests pass (needs: below).
+# Repo-specific release logic lives in scripts/release-prepare.sh and
+# scripts/release-publish.sh (the consumer contract), plus the dormant `stable`
+# branch required by semantic-release's branch validation.
 
 on:
+  pull_request:
+    branches: [main, "hotfix/**"] # PRs into maintenance-line branches validate too
   push:
-    branches:
-      - "**"
+    branches: [main, "hotfix/**"] # hotfix/X.Y.x pushes publish vX.Y.Z-hotfix.N builds
+  workflow_dispatch:
+
+# Serialize runs per ref so two quick merges to main can't run overlapping
+# releases. Cancel in-flight runs only for pull requests to save CI minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Elevated permissions live on the pipeline job only — the test job is read-only.
+permissions:
+  contents: read
 
 jobs:
   node-build:
@@ -53,3 +82,24 @@ jobs:
           name: "Endatix Hub"
           json-summary-path: ".coverage/endatix-hub/coverage-summary.json"
           json-final-path: ".coverage/endatix-hub/coverage-final.json"
+
+  # Build validation on PRs; canary release on main — publishes only after the
+  # tests above pass. docker-image makes the shared workflow log into GHCR and
+  # export DOCKER_IMAGE to the release scripts; canaries stay on GHCR only.
+  # Promoted releases mirror to Docker Hub — both stable AND maintenance (an
+  # older line's hotfix still ships publicly); only stable moves the `latest`
+  # tag, so a maintenance release never drags it backwards (release-publish.sh).
+  # No secrets are passed: the shared workflow uses the implicit GITHUB_TOKEN
+  # and fetches everything else via Infisical (OIDC, hence id-token).
+  pipeline:
+    name: Pipeline
+    needs: [node-build]
+    permissions:
+      contents: read # release writes use the App token inside the shared workflow
+      packages: write # GHCR image push + Helm chart push
+      id-token: write # OIDC for Infisical inside the shared workflow
+    uses: endatix/release-workflows/.github/workflows/canary.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
+    with:
+      docker-image: ghcr.io/endatix/endatix-hub
+      # No dotnet-version/java-version: the image builds inside Docker and the
+      # chart only needs the runner's preinstalled helm.

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,26 @@
+name: Publish Stable Artifacts
+
+# Thin consumer of endatix/release-workflows: fires when a human publishes the
+# reviewed draft release (that's when GitHub creates the vX.Y.Z tag).
+# promotion: rebuild — the Helm chart bakes its version into the packaged
+# artifact and cannot be retagged, so both the image and the chart are rebuilt
+# at the tagged commit and pushed to GHCR + Docker Hub (release scripts).
+# fetch-secrets provides the Docker Hub credentials via Infisical.
+# Canary prereleases are filtered out — build-ci.yml already shipped theirs.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  promote:
+    if: ${{ !github.event.release.prerelease }}
+    permissions:
+      contents: read
+      packages: write # GHCR image push + Helm chart push
+      id-token: write # OIDC for Infisical (fetch-secrets)
+    uses: endatix/release-workflows/.github/workflows/release-artifacts.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
+    with:
+      docker-image: ghcr.io/endatix/endatix-hub
+      promotion: rebuild # the chart bakes in its version — the image is rebuilt at the tag too
+      fetch-secrets: true # ENDATIX_DOCKERHUB_* via Infisical (prod)

--- a/.github/workflows/release-hotfix.yml
+++ b/.github/workflows/release-hotfix.yml
@@ -1,0 +1,44 @@
+name: Start Hotfix Release
+
+# One-parameter, mistake-proof entry point for releasing from a hotfix line
+# (hotfix/X.Y.x): always a PATCH bump on that line — the version base is the
+# nearest stable ancestor of the branch, so v0.8.0 → v0.8.1 → v0.8.2 …
+# Creates a DRAFT release pinned to the branch head; review/edit the notes,
+# then click "Publish release". Releasing an older line automatically becomes
+# a maintenance release (no "Latest" badge, and docker `latest` does not move).
+# For promoting canaries from main, use "Start Stable Release" instead.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Hotfix line branch to release from (e.g. hotfix/0.8.x)"
+        required: true
+
+jobs:
+  # Reject anything that is not a hotfix line branch (hotfix/X.Y.x) BEFORE the
+  # release job runs — e.g. typing `main` here would otherwise draft a patch
+  # release cut from main, bypassing the canary-promotion flow.
+  validate:
+    name: Validate branch name
+    runs-on: ubuntu-latest
+    permissions: {} # needs no token scopes at all
+    steps:
+      - name: Check hotfix line branch name
+        env:
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          if [[ ! "$BRANCH" =~ ^hotfix/[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "::error::'${BRANCH}' is not a hotfix line branch — expected hotfix/X.Y.x (e.g. hotfix/0.8.x)"
+            exit 1
+          fi
+          echo "Branch name OK: ${BRANCH}"
+
+  draft:
+    needs: validate
+    permissions:
+      contents: write # create the draft release (no tag exists until a human publishes it)
+    uses: endatix/release-workflows/.github/workflows/release-start.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
+    with:
+      ref: ${{ inputs.branch }}
+      bump: patch

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -1,0 +1,29 @@
+name: Start Stable Release
+
+# Thin consumer of endatix/release-workflows: creates a DRAFT release with
+# aggregated notes pinned to a canary's commit. Review/edit the notes in the
+# GitHub UI, then click "Publish release" — that creates the tag and triggers
+# release-artifacts.yml to publish the stable image + Helm chart (GHCR +
+# Docker Hub).
+
+on:
+  workflow_dispatch:
+    inputs:
+      canary_tag:
+        description: "Canary tag to promote (leave empty for the newest canary)"
+        required: false
+        default: ""
+      bump:
+        description: "Version bump relative to the last stable release"
+        type: choice
+        options: [minor, patch, major]
+        default: minor
+
+jobs:
+  draft:
+    permissions:
+      contents: write # create the draft release (no tag exists until a human publishes it)
+    uses: endatix/release-workflows/.github/workflows/release-start.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
+    with:
+      canary-tag: ${{ inputs.canary_tag }}
+      bump: ${{ inputs.bump }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,13 @@ COPY . .
 RUN pnpm run build
 
 FROM base
-COPY --from=build /app/.next/standalone ./
-COPY --from=build /app/.next/static ./.next/static
-COPY --from=build /app/public ./public
+# Run as the non-root `node` user (uid 1000) the base image already provides,
+# so the Helm chart can enforce runAsNonRoot. --chown matters as much as USER:
+# COPY otherwise preserves the build host's directory permissions, and a
+# restrictive local umask yields an image that cannot read its own /app/public
+# and crashes on startup once it is no longer root.
+COPY --from=build --chown=node:node /app/.next/standalone ./
+COPY --from=build --chown=node:node /app/.next/static ./.next/static
+COPY --from=build --chown=node:node /app/public ./public
+USER node
 CMD ["node", "server.js"]

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: endatix-hub
+description: Endatix Hub — Next.js form management frontend
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/*
+Release-qualified resource name, shared by every resource in this chart so two
+releases can coexist in one namespace without colliding. Truncated to 63 chars
+for the DNS label limit; if the release name already contains the chart name
+(e.g. `helm install endatix-hub ./helm`) it is not repeated.
+*/}}
+{{- define "endatix-hub.fullname" -}}
+{{- if contains .Chart.Name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Selector labels. These must be release-specific: without the instance label the
+Service of one release would also match the pods of another. Used verbatim in
+the Deployment selector, the pod template, and the Service selector — a
+Deployment's selector is immutable, so all three must stay in sync.
+*/}}
+{{- define "endatix-hub.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,19 +1,31 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ include "endatix-hub.fullname" . }}
   labels:
-    app: {{ .Chart.Name }}
+    {{- include "endatix-hub.selectorLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Chart.Name }}
+      {{- include "endatix-hub.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ .Chart.Name }}
+        {{- include "endatix-hub.selectorLabels" . | nindent 8 }}
     spec:
+      # The Hub only talks to the Endatix API over HTTP — it never calls the
+      # Kubernetes API, so a mounted service-account token would just park a
+      # live credential in the pod for an attacker to find.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        # 1000 is the `node` user in the base image. The Dockerfile sets USER
+        # node; this asserts it at admission rather than trusting the build.
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -26,6 +38,12 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         ports:
         - containerPort: {{ .Values.service.port }}
         env:
@@ -85,3 +103,11 @@ spec:
             port: {{ .Values.service.port }}
           initialDelaySeconds: 30
           periodSeconds: 30
+        # The only writable path, required by readOnlyRootFilesystem above.
+        # Next.js and its dependencies spill to the OS temp dir at runtime.
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.port }}
+        env:
+        # Node / Next.js
+        - name: NODE_ENV
+          value: {{ .Values.nodeEnv | quote }}
+        - name: PORT
+          value: {{ .Values.service.port | quote }}
+
+        # Endatix API connection
+        - name: ENDATIX_BASE_URL
+          value: {{ .Values.api.baseUrl | quote }}
+        - name: ENDATIX_API_URL
+          value: {{ .Values.api.apiUrl | quote }}
+
+        # Auth
+        - name: SESSION_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.auth.secretName }}
+              key: session-secret
+        - name: AUTH_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.auth.secretName }}
+              key: auth-secret
+        - name: AUTH_TRUST_HOST
+          value: {{ .Values.auth.trustHost | quote }}
+        {{- if .Values.auth.url }}
+        - name: AUTH_URL
+          value: {{ .Values.auth.url | quote }}
+        {{- end }}
+
+        {{- if .Values.otel.enabled }}
+        # OpenTelemetry
+        - name: OTEL_SERVICE_NAME
+          value: {{ .Values.otel.serviceName | quote }}
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: {{ .Values.otel.endpoint | quote }}
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: {{ .Values.otel.protocol | quote }}
+        - name: NEXT_OTEL_VERBOSE
+          value: "0"
+        {{- end }}
+
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.service.port }}
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.service.port }}
+          initialDelaySeconds: 30
+          periodSeconds: 30

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,11 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ include "endatix-hub.fullname" . }}
+  labels:
+    {{- include "endatix-hub.selectorLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   selector:
-    app: {{ .Chart.Name }}
+    {{- include "endatix-hub.selectorLabels" . | nindent 4 }}
   ports:
   - port: 80
     targetPort: {{ .Values.service.port }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Chart.Name }}
+  ports:
+  - port: 80
+    targetPort: {{ .Values.service.port }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,46 @@
+replicaCount: 1
+
+image:
+  repository: endatix/endatix-hub
+  pullPolicy: Always
+  # tag defaults to chart appVersion
+
+imagePullSecrets: []
+
+service:
+  type: ClusterIP
+  port: 8000
+
+api:
+  # Used by the Hub server to make backend API calls — must include /api suffix
+  # e.g. http://endatix-api:8080/api  (internal K8s service URL)
+  apiUrl: "http://endatix-api:8080/api"
+  # Base URL of the Endatix API, used for constructing links in emails etc.
+  # e.g. https://api.example.com
+  baseUrl: "http://endatix-api:8080"
+
+auth:
+  # Name of an existing secret with keys: session-secret, auth-secret
+  # session-secret: openssl rand -hex 32
+  # auth-secret:    npx auth secret
+  secretName: endatix-hub-auth-secret
+  trustHost: "true"
+  # Public URL of this hub, required for auth callbacks (e.g. https://hub.example.com)
+  url: ""
+
+nodeEnv: production
+
+otel:
+  enabled: false
+  endpoint: ""
+  protocol: grpc
+  serviceName: endatix-hub
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 512Mi
+
+nodeSelector: {}

--- a/scripts/release-prepare.sh
+++ b/scripts/release-prepare.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Consumer contract for endatix/release-workflows (prepare half):
+# build the Endatix Hub container image AND the Helm chart, both stamped with
+# the given version. Called by the shared pipeline for PR validation (version
+# 0.0.0-ci), canary releases, and stable rebuilds.
+# Builds only — nothing is pushed here (PR validation has no registry login).
+#
+# Usage: scripts/release-prepare.sh <version>
+# Expects env vars (exported by the shared workflows):
+#   DOCKER_IMAGE  container image name, from the caller's docker-image input
+set -euo pipefail
+
+VERSION="${1:?usage: release-prepare.sh <version>}"
+: "${DOCKER_IMAGE:?DOCKER_IMAGE env var is required (is docker-image set on the caller workflow?)}"
+
+# Clean so the publish step only ever sees artifacts stamped with THIS version.
+rm -rf build/packages/helm
+
+# linux/amd64 only, deliberately. Unlike the .NET API this cannot be
+# cross-compiled: `pnpm install` resolves platform-specific binaries (sharp,
+# esbuild) and `next build` actually executes, so an arm64 image would mean
+# QEMU emulation on every PR and every canary. Revisit if arm64 nodes appear —
+# the publish step would then need a manifest list, as the API's does.
+echo "──── Building container image ${DOCKER_IMAGE}:${VERSION} ────"
+docker build --platform linux/amd64 -t "${DOCKER_IMAGE}:${VERSION}" .
+
+# Helm chart, released in lockstep with the image. Stamping BOTH version and
+# appVersion with the release version is what makes the chart self-consistent:
+# the deployment template falls back to .Chart.Version for the image tag, so a
+# chart at X.Y.Z always deploys the image built at X.Y.Z above. The 0.1.0 in
+# Chart.yaml is only a placeholder for local `helm template` runs.
+# lint first — on PRs this is the only thing that type-checks the templates.
+echo "──── Packaging Helm chart at version ${VERSION} ────"
+helm lint helm
+helm package helm \
+  --version "${VERSION}" \
+  --app-version "${VERSION}" \
+  --destination build/packages/helm

--- a/scripts/release-publish.sh
+++ b/scripts/release-publish.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Consumer contract for endatix/release-workflows (publish half):
+# push the artifacts produced by release-prepare.sh.
+#
+# Channels (RELEASE_CHANNEL, set by the shared workflows):
+#   canary       push to main             prerelease build
+#   hotfix       push to hotfix/X.Y.x     prerelease build on a maintenance line
+#   stable       promoted release, and the newest version overall
+#   maintenance  promoted release on an older line (a newer stable exists)
+#
+# Prereleases stay on GHCR — Docker Hub is public and immutable, so per-push
+# builds must never land there. BOTH promoted channels publish to Docker Hub;
+# only `stable` may move floating pointers (docker `latest`), so a hotfix for an
+# older line ships without dragging `latest` backwards.
+#
+#   channel                 GHCR      Docker Hub     latest
+#   canary / hotfix          yes          no           no
+#   maintenance              yes          yes          no
+#   stable                   yes          yes          yes
+#
+# The Helm chart ships to GHCR on every channel: OCI charts are addressed by
+# exact version with no floating pointer to protect, and the prerelease version
+# already keeps canaries out of `helm upgrade` unless --devel is passed.
+#
+# Usage: scripts/release-publish.sh <version>
+# Expects env vars (exported by the shared workflows):
+#   GH_PACKAGES_USER   actor for the GHCR/Helm registry login
+#   GH_PACKAGES_TOKEN  job token with packages:write
+#   DOCKER_IMAGE       GHCR image name, from the caller's docker-image input
+#                      (the shared workflows do the ghcr.io login)
+#   HELM_OCI_REPO      OCI chart repo (oci://ghcr.io/endatix/charts)
+#   ENDATIX_DOCKERHUB_USERNAME / ENDATIX_DOCKERHUB_TOKEN
+#                      Docker Hub credentials via Infisical (fetch-secrets:
+#                      true on the caller) — promoted releases only
+set -euo pipefail
+
+VERSION="${1:?usage: release-publish.sh <version>}"
+CHANNEL="${RELEASE_CHANNEL:-stable}"
+: "${GH_PACKAGES_USER:?GH_PACKAGES_USER env var is required}"
+: "${GH_PACKAGES_TOKEN:?GH_PACKAGES_TOKEN env var is required}"
+: "${DOCKER_IMAGE:?DOCKER_IMAGE env var is required (is docker-image set on the caller workflow?)}"
+: "${HELM_OCI_REPO:?HELM_OCI_REPO env var is required}"
+
+# Public mirror for promoted releases. Not an input on the shared workflows
+# (they model a single image) — mirroring is this repo's own publish concern.
+DOCKERHUB_IMAGE="docker.io/endatix/endatix-hub"
+
+# Fail loud on an unrecognised channel: silently publishing nothing is a far
+# worse outcome for a release than a red run.
+case "$CHANNEL" in
+  stable) PUBLISH_PUBLIC=true; MOVE_LATEST=true ;;
+  maintenance) PUBLISH_PUBLIC=true; MOVE_LATEST=false ;;
+  canary | hotfix) PUBLISH_PUBLIC=false; MOVE_LATEST=false ;;
+  *) echo "::error::Unknown RELEASE_CHANNEL '${CHANNEL}' — release-workflows contract changed?" >&2; exit 1 ;;
+esac
+
+echo "──── Publishing ${VERSION} (${CHANNEL} channel) ────"
+
+echo "──── Pushing container image to ${DOCKER_IMAGE} ────"
+docker push "${DOCKER_IMAGE}:${VERSION}"
+
+if [[ "$MOVE_LATEST" = true ]]; then
+  echo "──── Moving ${DOCKER_IMAGE}:latest to ${VERSION} ────"
+  docker buildx imagetools create -t "${DOCKER_IMAGE}:latest" "${DOCKER_IMAGE}:${VERSION}"
+fi
+
+if [[ "$PUBLISH_PUBLIC" = true ]]; then
+  : "${ENDATIX_DOCKERHUB_USERNAME:?ENDATIX_DOCKERHUB_USERNAME env var is required for promoted releases (Infisical prod — is fetch-secrets: true set?)}"
+  : "${ENDATIX_DOCKERHUB_TOKEN:?ENDATIX_DOCKERHUB_TOKEN env var is required for promoted releases (Infisical prod — is fetch-secrets: true set?)}"
+
+  # Mirror by copying the manifest — same digest as GHCR, no rebuild.
+  DOCKERHUB_TAGS=(-t "${DOCKERHUB_IMAGE}:${VERSION}")
+  if [[ "$MOVE_LATEST" = true ]]; then
+    DOCKERHUB_TAGS+=(-t "${DOCKERHUB_IMAGE}:latest")
+  fi
+
+  echo "──── Mirroring container image to ${DOCKERHUB_IMAGE} ────"
+  echo "$ENDATIX_DOCKERHUB_TOKEN" | docker login docker.io -u "$ENDATIX_DOCKERHUB_USERNAME" --password-stdin
+  docker buildx imagetools create "${DOCKERHUB_TAGS[@]}" "${DOCKER_IMAGE}:${VERSION}"
+fi
+
+# Helm chart. Helm keeps its own registry credentials (~/.config/helm), so the
+# workflow's docker login does not carry over — log in explicitly. The path is
+# pinned to the exact version so a stale tarball can never be pushed.
+echo "──── Pushing Helm chart to ${HELM_OCI_REPO} ────"
+echo "$GH_PACKAGES_TOKEN" | helm registry login ghcr.io -u "$GH_PACKAGES_USER" --password-stdin
+helm push "build/packages/helm/endatix-hub-${VERSION}.tgz" "$HELM_OCI_REPO"


### PR DESCRIPTION
# Add Helm chart and adopt the Endatix release model

Adds a Helm chart for Endatix Hub and wires the repo into 'endatix/release-workflows`, so the image and chart are built, versioned and published automatically — same model as `endatix/endatix`. Previously nothing was published.

## What ships

| Artifact | Canary (push `main`) | Stable / maintenance |
|---|---|---|
| Image | GHCR | GHCR + Docker Hub |
| Helm chart | GHCR (OCI) | GHCR (OCI) |
| `latest` | never moves | stable only |

Chart and image are lockstep: a chart at `X.Y.Z` deploys the image at `X.Y.Z`.

## Changes

- **`scripts/release-prepare.sh` / `release-publish.sh`** (new) — the consumer
  contract: build image + package chart, then push with the canary/stable split.
- **`release-start.yml`, `release-artifacts.yml`, `release-hotfix.yml`** (new) —
  thin callers of the shared workflows.
- **`build-ci.yml`** — triggers move from `push: "**"` to PRs + `main`/`hotfix/**`;
  adds concurrency, read-only default permissions, and a `pipeline` job gated on
  `needs: [node-build]`. Test job unchanged.
- **`Dockerfile`** — runs as non-root `node` (uid 1000) via `COPY --chown` +
  `USER node`, required for the chart's `runAsNonRoot`.
- **Helm chart** — `_helpers.tpl` adds a release-qualified name and
  release-specific selectors so two releases can coexist in one namespace;
  pod/container security context (non-root, seccomp `RuntimeDefault`, drop all
  caps, read-only rootfs + `/tmp` emptyDir).


## Note for reviewers

Feature-branch pushes no longer trigger CI on their own — builds run on PRs and
on `main`/`hotfix/**`. Update branch protection if it referenced the old
trigger. Image is amd64-only: `sharp`/`esbuild` and `next build` can't be
cross-compiled, so arm64 would mean QEMU on every PR.