### PR TITLE
feat(h717): Enable lazy loading of data list properties for the property grid

### DIFF
--- a/.agents/skills/add-survey-feature/SKILL.md
+++ b/.agents/skills/add-survey-feature/SKILL.md
@@ -219,7 +219,9 @@ lib/survey-features/data-lists/
 ├── use-cases/
 │   ├── search-data-list-choices.ts      # respondent + creator API search
 │   ├── resolve-data-list-display-values.ts
-│   └── load-choices-in-creator.ts       # merged static + data-list paging for Creator
+│   ├── load-choices-in-creator.ts       # low-level static + multi-list paging
+│   ├── load-multi-source-choices-in-creator.ts
+│   └── resolve-multi-source-display-values.ts
 └── infrastructure/
     ├── property-grid-lazy-choice-registry.ts
     ├── survey-bindings.ts

--- a/.agents/skills/add-survey-feature/SKILL.md
+++ b/.agents/skills/add-survey-feature/SKILL.md
@@ -210,6 +210,28 @@ Shared registries live in `lib/survey-features/infrastructure/` (e.g.
 `choices-lazy-load-guards.ts`). Register from your feature's `onInit`, not from
 `form-editor`.
 
+**data-lists layout (reference for cross-feature reuse):**
+
+```text
+lib/survey-features/data-lists/
+├── types.ts
+├── utils/                    # property-grid-source-choices, with-form-access-jwt-retry
+├── use-cases/
+│   ├── search-data-list-choices.ts      # respondent + creator API search
+│   ├── resolve-data-list-display-values.ts
+│   └── load-choices-in-creator.ts       # merged static + data-list paging for Creator
+└── infrastructure/
+    ├── property-grid-lazy-choice-registry.ts
+    ├── survey-bindings.ts
+    └── creator-bindings.ts
+```
+
+Cross-feature consumers should import **use-cases** and **utils** directly (not the
+data-lists `index.ts` barrel) to avoid pulling UI hooks into survey-feature tests.
+
+Reference: carry-forward `edxCarryForwardPriorityItems`, question-loops `priorityItems`
+(issue #717).
+
 ---
 
 ## 6. Tests

--- a/lib/survey-features/carry-forward/__tests__/registry.test.ts
+++ b/lib/survey-features/carry-forward/__tests__/registry.test.ts
@@ -403,6 +403,36 @@ describe("registerAdvancedCarryForwardGlobals", () => {
       );
       expect(choices).toHaveLength(4);
     });
+
+    it("returns empty choices when any source uses a data list (lazy load handles options)", async () => {
+      const survey = new SurveyModel({
+        elements: [
+          {
+            type: "tagbox",
+            name: "brands",
+            edxDataListId: "list-1",
+          },
+          {
+            type: "checkbox",
+            name: "target",
+            choices: ["X"],
+            edxCarryForwardSources: ["brands"],
+          },
+        ],
+      });
+
+      const target = survey.getQuestionByName("target");
+      const choices = await getPropertyChoices(
+        "checkbox",
+        CARRY_FORWARD_PRIORITY_ITEMS_PROPERTY,
+        {
+          survey,
+          edxCarryForwardSources: target.edxCarryForwardSources,
+        },
+      );
+
+      expect(choices).toEqual([]);
+    });
   });
 
   it("is idempotent", () => {

--- a/lib/survey-features/carry-forward/carry-forward-properties.ts
+++ b/lib/survey-features/carry-forward/carry-forward-properties.ts
@@ -1,8 +1,5 @@
 import type { IJsonPropertyInfo, SurveyModel } from "survey-core";
-import {
-  getAllSelectBasedQuestions,
-  getAllUniqueChoices,
-} from "@/lib/survey-features/question-loops/loop-utils";
+import { getAllSelectBasedQuestions } from "@/lib/survey-features/question-loops/loop-utils";
 import { DATA_LIST_PROPERTY_NAME } from "@/lib/survey-features/data-lists/constants";
 import { isChoiceSourceSectionAvailable } from "@/lib/survey-features/infrastructure/choice-source-mutual-exclusion";
 import {
@@ -19,7 +16,11 @@ import {
 } from "./carry-forward-mode-values";
 import type { CarryForwardVisibleQuestion } from "./types";
 import { getCarryForwardSourceQuestions } from "./utils/carry-forward-target-query";
-import { normalizeChoiceKey } from "@/lib/utils/survey";
+import {
+  formatSourceChoiceLabel,
+  getStaticChoicesFromSources,
+  hasDataListSource,
+} from "@/lib/survey-features/data-lists/utils/property-grid-source-choices";
 
 export function isCarryForwardChoicesSectionVisible(
   obj: CarryForwardVisibleQuestion,
@@ -133,16 +134,13 @@ const PRIORITY_ITEMS_PROPERTY: IJsonPropertyInfo = {
       edxCarryForwardSources,
     });
 
-    const uniqueChoices = getAllUniqueChoices(
-      sourceQuestions,
-      (question, choice) => `${question.name}: (${choice.value})`,
-    );
+    if (hasDataListSource(sourceQuestions)) {
+      choicesCallback([]);
+      return;
+    }
 
     choicesCallback(
-      uniqueChoices.map((choice) => ({
-        value: normalizeChoiceKey(choice.value),
-        text: String(choice.text ?? choice.value),
-      })),
+      getStaticChoicesFromSources(sourceQuestions, "", formatSourceChoiceLabel),
     );
   },
 };

--- a/lib/survey-features/carry-forward/infrastructure/carry-forward-priority-lazy-provider.ts
+++ b/lib/survey-features/carry-forward/infrastructure/carry-forward-priority-lazy-provider.ts
@@ -1,0 +1,62 @@
+import { registerPropertyGridLazyChoiceProvider } from "@/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry";
+import { loadMultiSourceChoicesInCreator } from "@/lib/survey-features/data-lists/use-cases/load-multi-source-choices-in-creator";
+import { resolveMultiSourceDisplayValues } from "@/lib/survey-features/data-lists/use-cases/resolve-multi-source-display-values";
+import type {
+  PropertyGridLazyChoiceContext,
+  PropertyGridLazyChoiceProvider,
+} from "@/lib/survey-features/data-lists/types";
+import {
+  getStaticChoicesFromSources,
+  hasDataListSource,
+} from "@/lib/survey-features/data-lists/utils/property-grid-source-choices";
+import { CARRY_FORWARD_PRIORITY_ITEMS_PROPERTY } from "../constants";
+import { getCarryForwardSourceQuestions } from "../utils/carry-forward-target-query";
+import type { AdvancedCarryForwardQuestion } from "../types";
+
+function getEditingTarget(
+  ctx: PropertyGridLazyChoiceContext,
+): Pick<AdvancedCarryForwardQuestion, "edxCarryForwardSources"> | null {
+  const editingObj = ctx.editingObj as AdvancedCarryForwardQuestion | null;
+  if (!editingObj?.edxCarryForwardSources?.length) {
+    return null;
+  }
+
+  return editingObj;
+}
+
+function getSources(ctx: PropertyGridLazyChoiceContext) {
+  const target = getEditingTarget(ctx);
+  if (!target) {
+    return [];
+  }
+
+  return getCarryForwardSourceQuestions(ctx.designerSurvey, target);
+}
+
+const carryForwardPriorityLazyProvider: PropertyGridLazyChoiceProvider = {
+  propertyName: CARRY_FORWARD_PRIORITY_ITEMS_PROPERTY,
+
+  shouldEnable(ctx) {
+    const sources = getSources(ctx);
+    return sources.length > 0 && hasDataListSource(sources);
+  },
+
+  getStaticChoices(ctx, filter) {
+    return getStaticChoicesFromSources(getSources(ctx), filter);
+  },
+
+  loadPage(ctx, params, deps) {
+    return loadMultiSourceChoicesInCreator(deps, getSources(ctx), params);
+  },
+
+  resolveDisplayValues(ctx, values, deps) {
+    return resolveMultiSourceDisplayValues(deps, getSources(ctx), values);
+  },
+};
+
+/**
+ * Registers the carry forward priority lazy provider.
+ */
+export function registerCarryForwardPriorityLazyProvider(): void {
+  registerPropertyGridLazyChoiceProvider(carryForwardPriorityLazyProvider);
+}

--- a/lib/survey-features/carry-forward/infrastructure/carry-forward.extension.ts
+++ b/lib/survey-features/carry-forward/infrastructure/carry-forward.extension.ts
@@ -1,5 +1,6 @@
 import type { ExtensionModule } from "@/lib/survey-extensions/types";
 import { bindAdvancedCarryForwardToCreator } from "./creator-bindings";
+import { registerCarryForwardPriorityLazyProvider } from "./carry-forward-priority-lazy-provider";
 import { registerAdvancedCarryForwardCreatorHelp } from "./creator-help";
 import { registerAdvancedCarryForwardGlobals } from "./registry";
 import { bindAdvancedCarryForwardToSurvey } from "./survey-bindings";
@@ -12,6 +13,7 @@ const carryForwardExtension: ExtensionModule = {
   onInit: () => {
     registerAdvancedCarryForwardGlobals();
     registerAdvancedCarryForwardCreatorHelp();
+    registerCarryForwardPriorityLazyProvider();
   },
   onCreatorReady: (creator) => {
     bindAdvancedCarryForwardToCreator(creator);

--- a/lib/survey-features/data-lists/constants.ts
+++ b/lib/survey-features/data-lists/constants.ts
@@ -2,6 +2,13 @@ export const DATA_LIST_PROPERTY_NAME = "edxDataListId";
 
 export const DEFAULT_CHOICES_LAZY_LOAD_PAGE_SIZE = 25;
 
+/** Property changes that affect aggregated property-grid lazy choice editors. */
+export const PROPERTY_GRID_LAZY_REFRESH_PROPERTY_NAMES = [
+  DATA_LIST_PROPERTY_NAME,
+  "loopSource",
+  "edxCarryForwardSources",
+] as const;
+
 /** API max length for data list item label and value. */
 export const DATA_LIST_ITEM_MAX_LENGTH = 255;
 

--- a/lib/survey-features/data-lists/index.ts
+++ b/lib/survey-features/data-lists/index.ts
@@ -16,6 +16,8 @@ export type {
 export { searchDataListChoices } from "./use-cases/search-data-list-choices";
 export { resolveDataListDisplayValues } from "./use-cases/resolve-data-list-display-values";
 export { loadChoicesInCreator } from "./use-cases/load-choices-in-creator";
+export { loadMultiSourceChoicesInCreator } from "./use-cases/load-multi-source-choices-in-creator";
+export { resolveMultiSourceDisplayValues } from "./use-cases/resolve-multi-source-display-values";
 export {
   type ConvertibleChoiceQuestionRef,
   findConvertibleChoiceQuestions,

--- a/lib/survey-features/data-lists/index.ts
+++ b/lib/survey-features/data-lists/index.ts
@@ -4,6 +4,18 @@ export {
   DATA_LIST_PROPERTY_NAME,
 } from "./constants";
 export * from "./utils";
+export type {
+  DataListChoiceItem,
+  DataListChoicePageParams,
+  DataListSourceRef,
+  PropertyGridChoice,
+  PropertyGridLazyChoiceContext,
+  PropertyGridLazyChoicePageParams,
+  PropertyGridLazyChoiceProvider,
+} from "./types";
+export { searchDataListChoices } from "./use-cases/search-data-list-choices";
+export { resolveDataListDisplayValues } from "./use-cases/resolve-data-list-display-values";
+export { loadChoicesInCreator } from "./use-cases/load-choices-in-creator";
 export {
   type ConvertibleChoiceQuestionRef,
   findConvertibleChoiceQuestions,
@@ -20,3 +32,4 @@ export {
 } from "./ui/use-convert-inline-choices-ui.hook";
 export { useDataLists, useDataListsLoader } from "./ui/use-data-lists.hook";
 export { dataListsExtension } from "./infrastructure/data-lists.extension";
+export { registerPropertyGridLazyChoiceProvider } from "./infrastructure/property-grid-lazy-choice-registry";

--- a/lib/survey-features/data-lists/infrastructure/__tests__/property-grid-lazy-choice-registry.test.ts
+++ b/lib/survey-features/data-lists/infrastructure/__tests__/property-grid-lazy-choice-registry.test.ts
@@ -4,7 +4,8 @@ import {
   clearPropertyGridLazyChoiceProvidersForTests,
   getPropertyGridLazyChoiceProvider,
   registerPropertyGridLazyChoiceProvider,
-  setupPropertyGridLazyChoices,
+  refreshPropertyGridLazyChoices,
+  refreshPropertyGridLazyChoicesForCreator,
 } from "../property-grid-lazy-choice-registry";
 
 describe("property-grid-lazy-choice-registry", () => {
@@ -46,7 +47,7 @@ describe("property-grid-lazy-choice-registry", () => {
     });
     propertyGridSurvey.editingObj = designerSurvey.getQuestionByName("target");
 
-    setupPropertyGridLazyChoices({
+    refreshPropertyGridLazyChoices({
       designerSurvey,
       propertyGridSurvey,
       editingObj: propertyGridSurvey.editingObj,
@@ -76,7 +77,7 @@ describe("property-grid-lazy-choice-registry", () => {
       ],
     });
 
-    setupPropertyGridLazyChoices({
+    refreshPropertyGridLazyChoices({
       designerSurvey: new SurveyModel({ elements: [] }),
       propertyGridSurvey,
       editingObj: {},
@@ -97,5 +98,67 @@ describe("property-grid-lazy-choice-registry", () => {
     });
 
     expect(getPropertyGridLazyChoiceProvider("priorityItems")).toBeDefined();
+  });
+
+  it("enables lazy load on refresh after dependencies become available", () => {
+    let hasDataListSource = false;
+
+    registerPropertyGridLazyChoiceProvider({
+      propertyName: "priorityItems",
+      shouldEnable: () => hasDataListSource,
+      getStaticChoices: () => [{ value: "A", text: "static: (A)" }],
+      loadPage: async () => ({ items: [], total: 0 }),
+      resolveDisplayValues: async (_ctx, values) => values,
+    });
+
+    const designerSurvey = new SurveyModel({ elements: [] });
+    const propertyGridSurvey = new Model({
+      elements: [{ type: "tagbox", name: "priorityItems" }],
+    });
+    const loopPanel = { loopSource: ["Cars"] };
+    const ctx = {
+      designerSurvey,
+      propertyGridSurvey,
+      editingObj: loopPanel,
+    };
+
+    refreshPropertyGridLazyChoices(ctx);
+
+    const editor = propertyGridSurvey.getQuestionByName("priorityItems");
+    expect(editor?.choicesLazyLoadEnabled).not.toBe(true);
+
+    hasDataListSource = true;
+    refreshPropertyGridLazyChoices(ctx);
+
+    expect(editor?.choicesLazyLoadEnabled).toBe(true);
+    expect(editor?.choices).toHaveLength(1);
+    expect(editor?.choices?.[0]?.value).toBe("A");
+    expect(editor?.choices?.[0]?.text).toBe("static: (A)");
+  });
+
+  it("refreshes from an open creator property grid", () => {
+    registerPropertyGridLazyChoiceProvider({
+      propertyName: "priorityItems",
+      shouldEnable: () => true,
+      loadPage: async () => ({ items: [], total: 0 }),
+      resolveDisplayValues: async (_ctx, values) => values,
+    });
+
+    const designerSurvey = new SurveyModel({ elements: [] });
+    const propertyGridSurvey = new Model({
+      elements: [{ type: "tagbox", name: "priorityItems" }],
+    });
+    const loopPanel = { loopSource: ["Cars"] };
+
+    refreshPropertyGridLazyChoicesForCreator({
+      survey: designerSurvey,
+      propertyGrid: propertyGridSurvey,
+      selectedElement: loopPanel,
+    } as never);
+
+    expect(
+      propertyGridSurvey.getQuestionByName("priorityItems")
+        ?.choicesLazyLoadEnabled,
+    ).toBe(true);
   });
 });

--- a/lib/survey-features/data-lists/infrastructure/__tests__/property-grid-lazy-choice-registry.test.ts
+++ b/lib/survey-features/data-lists/infrastructure/__tests__/property-grid-lazy-choice-registry.test.ts
@@ -64,6 +64,7 @@ describe("property-grid-lazy-choice-registry", () => {
     registerPropertyGridLazyChoiceProvider({
       propertyName: "edxCarryForwardPriorityItems",
       shouldEnable: () => false,
+      getStaticChoices: () => [{ value: "A", text: "static: (A)" }],
       loadPage: async () => ({ items: [], total: 0 }),
       resolveDisplayValues: async (_ctx, values) => values,
     });
@@ -87,6 +88,8 @@ describe("property-grid-lazy-choice-registry", () => {
       "edxCarryForwardPriorityItems",
     );
     expect(editor?.choicesLazyLoadEnabled).not.toBe(true);
+    expect(editor?.choices).toHaveLength(1);
+    expect(editor?.choices?.[0]?.value).toBe("A");
   });
 
   it("registers providers by property name", () => {
@@ -134,6 +137,48 @@ describe("property-grid-lazy-choice-registry", () => {
     expect(editor?.choices).toHaveLength(1);
     expect(editor?.choices?.[0]?.value).toBe("A");
     expect(editor?.choices?.[0]?.text).toBe("static: (A)");
+  });
+
+  it("restores static choices when lazy load is disabled after a source change", () => {
+    let hasDataListSource = true;
+
+    registerPropertyGridLazyChoiceProvider({
+      propertyName: "priorityItems",
+      shouldEnable: () => hasDataListSource,
+      getStaticChoices: () =>
+        hasDataListSource
+          ? []
+          : [
+              { value: "A", text: "static: (A)" },
+              { value: "B", text: "static: (B)" },
+            ],
+      loadPage: async () => ({ items: [], total: 0 }),
+      resolveDisplayValues: async (_ctx, values) => values,
+    });
+
+    const designerSurvey = new SurveyModel({ elements: [] });
+    const propertyGridSurvey = new Model({
+      elements: [{ type: "tagbox", name: "priorityItems" }],
+    });
+    const ctx = {
+      designerSurvey,
+      propertyGridSurvey,
+      editingObj: { loopSource: ["Cars"] },
+    };
+
+    refreshPropertyGridLazyChoices(ctx);
+
+    const editor = propertyGridSurvey.getQuestionByName("priorityItems");
+    expect(editor?.choicesLazyLoadEnabled).toBe(true);
+    expect(editor?.choices).toHaveLength(0);
+
+    hasDataListSource = false;
+    refreshPropertyGridLazyChoices(ctx);
+
+    expect(editor?.choicesLazyLoadEnabled).toBe(false);
+    expect(editor?.choices).toHaveLength(2);
+    expect(editor?.choices?.[0]?.value).toBe("A");
+    expect(editor?.choices?.[1]?.value).toBe("B");
   });
 
   it("refreshes from an open creator property grid", () => {

--- a/lib/survey-features/data-lists/infrastructure/__tests__/property-grid-lazy-choice-registry.test.ts
+++ b/lib/survey-features/data-lists/infrastructure/__tests__/property-grid-lazy-choice-registry.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Model, SurveyModel } from "survey-core";
+import {
+  clearPropertyGridLazyChoiceProvidersForTests,
+  getPropertyGridLazyChoiceProvider,
+  registerPropertyGridLazyChoiceProvider,
+  setupPropertyGridLazyChoices,
+} from "../property-grid-lazy-choice-registry";
+
+describe("property-grid-lazy-choice-registry", () => {
+  beforeEach(() => {
+    clearPropertyGridLazyChoiceProvidersForTests();
+  });
+
+  it("enables lazy load on a registered property editor tagbox", () => {
+    registerPropertyGridLazyChoiceProvider({
+      propertyName: "edxCarryForwardPriorityItems",
+      shouldEnable: () => true,
+      loadPage: async () => ({ items: [], total: 0 }),
+      resolveDisplayValues: async (_ctx, values) => values,
+    });
+
+    const designerSurvey = new SurveyModel({
+      elements: [
+        {
+          type: "tagbox",
+          name: "src",
+          edxDataListId: "list-1",
+        },
+        {
+          type: "checkbox",
+          name: "target",
+          edxCarryForwardEnabled: true,
+          edxCarryForwardSources: ["src"],
+        },
+      ],
+    });
+
+    const propertyGridSurvey = new Model({
+      elements: [
+        {
+          type: "tagbox",
+          name: "edxCarryForwardPriorityItems",
+        },
+      ],
+    });
+    propertyGridSurvey.editingObj = designerSurvey.getQuestionByName("target");
+
+    setupPropertyGridLazyChoices({
+      designerSurvey,
+      propertyGridSurvey,
+      editingObj: propertyGridSurvey.editingObj,
+    });
+
+    const editor = propertyGridSurvey.getQuestionByName(
+      "edxCarryForwardPriorityItems",
+    );
+    expect(editor?.choicesLazyLoadEnabled).toBe(true);
+    expect(editor?.choicesLazyLoadPageSize).toBe(25);
+  });
+
+  it("skips setup when provider shouldEnable returns false", () => {
+    registerPropertyGridLazyChoiceProvider({
+      propertyName: "edxCarryForwardPriorityItems",
+      shouldEnable: () => false,
+      loadPage: async () => ({ items: [], total: 0 }),
+      resolveDisplayValues: async (_ctx, values) => values,
+    });
+
+    const propertyGridSurvey = new Model({
+      elements: [
+        {
+          type: "tagbox",
+          name: "edxCarryForwardPriorityItems",
+        },
+      ],
+    });
+
+    setupPropertyGridLazyChoices({
+      designerSurvey: new SurveyModel({ elements: [] }),
+      propertyGridSurvey,
+      editingObj: {},
+    });
+
+    const editor = propertyGridSurvey.getQuestionByName(
+      "edxCarryForwardPriorityItems",
+    );
+    expect(editor?.choicesLazyLoadEnabled).not.toBe(true);
+  });
+
+  it("registers providers by property name", () => {
+    registerPropertyGridLazyChoiceProvider({
+      propertyName: "priorityItems",
+      shouldEnable: () => true,
+      loadPage: vi.fn(),
+      resolveDisplayValues: vi.fn(),
+    });
+
+    expect(getPropertyGridLazyChoiceProvider("priorityItems")).toBeDefined();
+  });
+});

--- a/lib/survey-features/data-lists/infrastructure/creator-bindings.ts
+++ b/lib/survey-features/data-lists/infrastructure/creator-bindings.ts
@@ -3,17 +3,27 @@ import {
   SurveyCreatorModel,
   SurveyInstanceCreatedEvent,
 } from "survey-creator-core";
-import { DATA_LIST_PROPERTY_NAME } from "../constants";
+import {
+  DATA_LIST_PROPERTY_NAME,
+  PROPERTY_GRID_LAZY_REFRESH_PROPERTY_NAMES,
+} from "../constants";
 import { parseDataListId } from "./data-list-survey-integration";
 import { bindDataListsToSurvey } from "./survey-bindings";
 import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
 import { bindConvertInlineChoicesTitleActions } from "./convert-inline-choices-title-actions";
-import { setupPropertyGridLazyChoices } from "./property-grid-lazy-choice-registry";
+import {
+  refreshPropertyGridLazyChoices,
+  refreshPropertyGridLazyChoicesForCreator,
+} from "./property-grid-lazy-choice-registry";
 import { registerDataListGlobals } from "./registry";
 
 export { setDataListPropertyChoices } from "./data-list-property-choices";
 
 const DATA_LIST_CREATOR_BOUND_KEY = "__endatixDataListsCreatorBound";
+
+const LAZY_REFRESH_PROPERTY_NAMES = new Set<string>(
+  PROPERTY_GRID_LAZY_REFRESH_PROPERTY_NAMES,
+);
 
 export function bindDataListsToCreator(
   creator: SurveyCreatorModel,
@@ -29,24 +39,24 @@ export function bindDataListsToCreator(
 
   const creatorSurveyDisposers = new Map<string, () => void>();
 
-  const onDataListChanged = (
+  const onPropertyChanged = (
     _: SurveyCreatorModel,
     options: AfterPropertyChangedEvent,
   ) => {
-    if (options.propertyName !== DATA_LIST_PROPERTY_NAME) {
-      return;
+    if (options.propertyName === DATA_LIST_PROPERTY_NAME) {
+      const question = options.element;
+      if (question) {
+        const dataListId = parseDataListId(options.value);
+        const creatorQuestion = question as unknown as Record<string, unknown>;
+        creatorQuestion.choicesLazyLoadEnabled = Boolean(dataListId);
+        if (dataListId) {
+          creatorQuestion.choices = [];
+        }
+      }
     }
 
-    const question = options.element;
-    if (!question) {
-      return;
-    }
-
-    const dataListId = parseDataListId(options.value);
-    const creatorQuestion = question as unknown as Record<string, unknown>;
-    creatorQuestion.choicesLazyLoadEnabled = Boolean(dataListId);
-    if (dataListId) {
-      creatorQuestion.choices = [];
+    if (LAZY_REFRESH_PROPERTY_NAMES.has(options.propertyName)) {
+      refreshPropertyGridLazyChoicesForCreator(creator);
     }
   };
 
@@ -78,7 +88,7 @@ export function bindDataListsToCreator(
       const designerSurvey = creator.survey;
       const editingObj = options.element ?? options.survey.editingObj;
       if (designerSurvey && editingObj != null) {
-        setupPropertyGridLazyChoices({
+        refreshPropertyGridLazyChoices({
           designerSurvey,
           propertyGridSurvey: options.survey,
           editingObj,
@@ -87,7 +97,7 @@ export function bindDataListsToCreator(
     }
   };
 
-  creator.onAfterPropertyChanged.add(onDataListChanged);
+  creator.onAfterPropertyChanged.add(onPropertyChanged);
   creator.onSurveyInstanceCreated.add(handleSurveyInstanceCreated);
 
   const disposeConvertTitleActions =
@@ -99,7 +109,7 @@ export function bindDataListsToCreator(
 
   return () => {
     disposeConvertTitleActions();
-    creator.onAfterPropertyChanged.remove(onDataListChanged);
+    creator.onAfterPropertyChanged.remove(onPropertyChanged);
     creator.onSurveyInstanceCreated.remove(handleSurveyInstanceCreated);
     creatorSurveyDisposers.forEach((dispose) => dispose?.());
     creatorSurveyDisposers.clear();

--- a/lib/survey-features/data-lists/infrastructure/creator-bindings.ts
+++ b/lib/survey-features/data-lists/infrastructure/creator-bindings.ts
@@ -8,6 +8,7 @@ import { parseDataListId } from "./data-list-survey-integration";
 import { bindDataListsToSurvey } from "./survey-bindings";
 import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
 import { bindConvertInlineChoicesTitleActions } from "./convert-inline-choices-title-actions";
+import { setupPropertyGridLazyChoices } from "./property-grid-lazy-choice-registry";
 import { registerDataListGlobals } from "./registry";
 
 export { setDataListPropertyChoices } from "./data-list-property-choices";
@@ -49,6 +50,20 @@ export function bindDataListsToCreator(
     }
   };
 
+  const bindSurveyForArea = (
+    area: string,
+    survey: Parameters<typeof bindDataListsToSurvey>[0],
+  ) => {
+    const previousDispose = creatorSurveyDisposers.get(area);
+    previousDispose?.();
+
+    const dispose = bindDataListsToSurvey(survey, {
+      deps,
+      getDesignerSurvey: () => creator.survey ?? null,
+    });
+    creatorSurveyDisposers.set(area, dispose);
+  };
+
   const handleSurveyInstanceCreated = (
     _: unknown,
     options: SurveyInstanceCreatedEvent,
@@ -57,25 +72,29 @@ export function bindDataListsToCreator(
       return;
     }
 
-    const previousDispose = creatorSurveyDisposers.get(options.area);
-    previousDispose?.();
+    bindSurveyForArea(options.area, options.survey);
 
-    const dispose = bindDataListsToSurvey(options.survey, deps);
-    creatorSurveyDisposers.set(options.area, dispose);
+    if (options.area === "property-grid") {
+      const designerSurvey = creator.survey;
+      const editingObj = options.element ?? options.survey.editingObj;
+      if (designerSurvey && editingObj != null) {
+        setupPropertyGridLazyChoices({
+          designerSurvey,
+          propertyGridSurvey: options.survey,
+          editingObj,
+        });
+      }
+    }
   };
 
   creator.onAfterPropertyChanged.add(onDataListChanged);
   creator.onSurveyInstanceCreated.add(handleSurveyInstanceCreated);
 
-  const disposeConvertTitleActions = bindConvertInlineChoicesTitleActions(creator);
+  const disposeConvertTitleActions =
+    bindConvertInlineChoicesTitleActions(creator);
 
   if (creator.survey) {
-    const initialSurveyArea = "__creator-initial-survey";
-    const previousDispose = creatorSurveyDisposers.get(initialSurveyArea);
-    previousDispose?.();
-
-    const dispose = bindDataListsToSurvey(creator.survey, deps);
-    creatorSurveyDisposers.set(initialSurveyArea, dispose);
+    bindSurveyForArea("__creator-initial-survey", creator.survey);
   }
 
   return () => {

--- a/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry.ts
+++ b/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry.ts
@@ -1,4 +1,5 @@
 import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
+import type { SurveyCreatorModel } from "survey-creator-core";
 import type { Question } from "survey-core";
 import { DEFAULT_CHOICES_LAZY_LOAD_PAGE_SIZE } from "../constants";
 import type {
@@ -37,14 +38,10 @@ export function clearPropertyGridLazyChoiceProvidersForTests(): void {
   providers.clear();
 }
 
-export function setupPropertyGridLazyChoices(
+export function refreshPropertyGridLazyChoices(
   ctx: PropertyGridLazyChoiceContext,
 ): void {
   for (const provider of providers.values()) {
-    if (!provider.shouldEnable(ctx)) {
-      continue;
-    }
-
     const editor = ctx.propertyGridSurvey.getQuestionByName(
       provider.propertyName,
     );
@@ -58,10 +55,34 @@ export function setupPropertyGridLazyChoices(
       choices?: unknown[];
     };
 
+    if (!provider.shouldEnable(ctx)) {
+      tagbox.choicesLazyLoadEnabled = false;
+      continue;
+    }
+
     tagbox.choicesLazyLoadEnabled = true;
     tagbox.choicesLazyLoadPageSize = DEFAULT_CHOICES_LAZY_LOAD_PAGE_SIZE;
     tagbox.choices = provider.getStaticChoices?.(ctx, "") ?? [];
   }
+}
+
+export function refreshPropertyGridLazyChoicesForCreator(
+  creator: SurveyCreatorModel,
+): void {
+  const designerSurvey = creator.survey;
+  const propertyGridSurvey = creator.propertyGrid;
+  const editingObj =
+    creator.selectedElement ?? propertyGridSurvey?.editingObj ?? null;
+
+  if (!designerSurvey || !propertyGridSurvey || editingObj == null) {
+    return;
+  }
+
+  refreshPropertyGridLazyChoices({
+    designerSurvey,
+    propertyGridSurvey,
+    editingObj,
+  });
 }
 
 export async function dispatchPropertyGridChoicesLazyLoad(

--- a/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry.ts
+++ b/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry.ts
@@ -1,0 +1,96 @@
+import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
+import type { Question } from "survey-core";
+import { DEFAULT_CHOICES_LAZY_LOAD_PAGE_SIZE } from "../constants";
+import type {
+  PropertyGridLazyChoiceContext,
+  PropertyGridLazyChoicePageParams,
+  PropertyGridLazyChoiceProvider,
+} from "../types";
+
+export type {
+  PropertyGridLazyChoiceContext,
+  PropertyGridLazyChoicePageParams,
+  PropertyGridLazyChoiceProvider,
+} from "../types";
+
+const providers = new Map<string, PropertyGridLazyChoiceProvider>();
+
+export function registerPropertyGridLazyChoiceProvider(
+  provider: PropertyGridLazyChoiceProvider,
+): void {
+  providers.set(provider.propertyName, provider);
+}
+
+export function unregisterPropertyGridLazyChoiceProvider(
+  propertyName: string,
+): void {
+  providers.delete(propertyName);
+}
+
+export function getPropertyGridLazyChoiceProvider(
+  propertyName: string,
+): PropertyGridLazyChoiceProvider | undefined {
+  return providers.get(propertyName);
+}
+
+export function clearPropertyGridLazyChoiceProvidersForTests(): void {
+  providers.clear();
+}
+
+export function setupPropertyGridLazyChoices(
+  ctx: PropertyGridLazyChoiceContext,
+): void {
+  for (const provider of providers.values()) {
+    if (!provider.shouldEnable(ctx)) {
+      continue;
+    }
+
+    const editor = ctx.propertyGridSurvey.getQuestionByName(
+      provider.propertyName,
+    );
+    if (!editor || editor.getType() !== "tagbox") {
+      continue;
+    }
+
+    const tagbox = editor as Question & {
+      choicesLazyLoadEnabled?: boolean;
+      choicesLazyLoadPageSize?: number;
+      choices?: unknown[];
+    };
+
+    tagbox.choicesLazyLoadEnabled = true;
+    tagbox.choicesLazyLoadPageSize = DEFAULT_CHOICES_LAZY_LOAD_PAGE_SIZE;
+    tagbox.choices = provider.getStaticChoices?.(ctx, "") ?? [];
+  }
+}
+
+export async function dispatchPropertyGridChoicesLazyLoad(
+  ctx: PropertyGridLazyChoiceContext,
+  propertyName: string,
+  params: PropertyGridLazyChoicePageParams,
+  deps: ExtensionRuntimeDeps,
+): Promise<{
+  items: Array<{ value: string; text: string }>;
+  total: number;
+} | null> {
+  const provider = providers.get(propertyName);
+  if (!provider || !provider.shouldEnable(ctx)) {
+    return null;
+  }
+
+  return provider.loadPage(ctx, params, deps);
+}
+
+export async function dispatchPropertyGridChoiceDisplayValues(
+  ctx: PropertyGridLazyChoiceContext,
+  propertyName: string,
+  values: string[],
+  deps: ExtensionRuntimeDeps,
+): Promise<string[] | null> {
+  const provider = providers.get(propertyName);
+  if (!provider || values.length === 0 || !provider.shouldEnable(ctx)) {
+    return null;
+  }
+
+  return provider.resolveDisplayValues(ctx, values, deps);
+}

--- a/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry.ts
+++ b/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry.ts
@@ -45,7 +45,7 @@ export function refreshPropertyGridLazyChoices(
     const editor = ctx.propertyGridSurvey.getQuestionByName(
       provider.propertyName,
     );
-    if (!editor || editor.getType() !== "tagbox") {
+    if (editor?.getType() !== "tagbox") {
       continue;
     }
 

--- a/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry.ts
+++ b/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry.ts
@@ -57,6 +57,7 @@ export function refreshPropertyGridLazyChoices(
 
     if (!provider.shouldEnable(ctx)) {
       tagbox.choicesLazyLoadEnabled = false;
+      tagbox.choices = provider.getStaticChoices?.(ctx, "") ?? [];
       continue;
     }
 

--- a/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry.ts
+++ b/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry.ts
@@ -95,7 +95,7 @@ export async function dispatchPropertyGridChoicesLazyLoad(
   total: number;
 } | null> {
   const provider = providers.get(propertyName);
-  if (!provider || !provider.shouldEnable(ctx)) {
+  if (!provider?.shouldEnable(ctx)) {
     return null;
   }
 
@@ -109,7 +109,7 @@ export async function dispatchPropertyGridChoiceDisplayValues(
   deps: ExtensionRuntimeDeps,
 ): Promise<string[] | null> {
   const provider = providers.get(propertyName);
-  if (!provider || values.length === 0 || !provider.shouldEnable(ctx)) {
+  if (!provider?.shouldEnable(ctx) || values.length === 0) {
     return null;
   }
 

--- a/lib/survey-features/data-lists/infrastructure/survey-bindings.ts
+++ b/lib/survey-features/data-lists/infrastructure/survey-bindings.ts
@@ -1,52 +1,65 @@
-import { createEndatixPublicApi } from "@/lib/endatix-api/public";
-import { ApiErrorType, ApiResult } from "@/lib/endatix-api/shared/api-result";
-import {
-  ensureRuntimeFormAccessJwt,
-  invalidateRuntimeFormAccessJwt,
-} from "@/lib/form-runtime/form-access-jwt-orchestrator";
-import type { FormRuntimeState } from "@/lib/form-runtime/form-runtime.context";
 import { resolveFormRuntimeState } from "@/lib/form-runtime/resolve-form-runtime-state";
 import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
 import {
   ChoicesLazyLoadEvent,
   GetChoiceDisplayValueEvent,
   Model,
+  SurveyModel,
 } from "survey-core";
 import {
   notifyChoicesLazyLoadCompleted,
   shouldSuppressChoicesLazyLoad,
 } from "@/lib/survey-features/infrastructure/choices-lazy-load-guards";
+import { searchDataListChoices } from "../use-cases/search-data-list-choices";
+import { resolveDataListDisplayValues } from "../use-cases/resolve-data-list-display-values";
 import { getDataListIdFromQuestion } from "./data-list-survey-integration";
+import {
+  dispatchPropertyGridChoiceDisplayValues,
+  dispatchPropertyGridChoicesLazyLoad,
+  type PropertyGridLazyChoiceContext,
+} from "./property-grid-lazy-choice-registry";
 import { registerDataListGlobals } from "./registry";
 
 const DATA_LIST_HANDLERS_ATTACHED_KEY = "__endatixDataListHandlersAttached";
 
-async function withJwtRetry<T>(
-  runtimeState: FormRuntimeState,
-  call: (jwt: string) => Promise<ApiResult<T>>,
-): Promise<ApiResult<T>> {
-  let jwt = await ensureRuntimeFormAccessJwt(runtimeState);
-  if (!jwt) {
-    return ApiResult.authError<T>("Could not obtain form access token.");
+export type BindDataListsToSurveyOptions = {
+  deps: ExtensionRuntimeDeps;
+  getDesignerSurvey?: () => SurveyModel | null;
+};
+
+function resolveBindOptions(
+  depsOrOptions: ExtensionRuntimeDeps | BindDataListsToSurveyOptions,
+): BindDataListsToSurveyOptions {
+  if ("deps" in depsOrOptions) {
+    return depsOrOptions;
   }
 
-  let response = await call(jwt);
-  if (!response.success && response.error.type === ApiErrorType.AuthError) {
-    invalidateRuntimeFormAccessJwt(runtimeState);
-    jwt = await ensureRuntimeFormAccessJwt(runtimeState);
-    if (!jwt) {
-      return response;
-    }
-    response = await call(jwt);
+  return { deps: depsOrOptions };
+}
+
+function buildPropertyGridContext(
+  model: Model,
+  getDesignerSurvey?: () => SurveyModel | null,
+): PropertyGridLazyChoiceContext | null {
+  const designerSurvey = getDesignerSurvey?.() ?? null;
+  if (!designerSurvey || model.editingObj == null) {
+    return null;
   }
-  return response;
+
+  return {
+    designerSurvey,
+    propertyGridSurvey: model,
+    editingObj: model.editingObj,
+  };
 }
 
 export function bindDataListsToSurvey(
   model: Model,
-  deps: ExtensionRuntimeDeps,
+  depsOrOptions: ExtensionRuntimeDeps | BindDataListsToSurveyOptions,
 ): () => void {
   registerDataListGlobals();
+
+  const { deps, getDesignerSurvey } = resolveBindOptions(depsOrOptions);
 
   const modelWithFlags = model as Model & Record<string, unknown>;
   if (modelWithFlags[DATA_LIST_HANDLERS_ATTACHED_KEY]) {
@@ -54,13 +67,36 @@ export function bindDataListsToSurvey(
   }
   modelWithFlags[DATA_LIST_HANDLERS_ATTACHED_KEY] = true;
 
-  const api = createEndatixPublicApi().dataLists;
-
   const onChoicesLazyLoad = async (_: Model, options: ChoicesLazyLoadEvent) => {
     const filter = options.filter ?? "";
     if (shouldSuppressChoicesLazyLoad(options.question, filter)) {
       options.setItems([], 0);
       return;
+    }
+
+    const propertyGridCtx = buildPropertyGridContext(model, getDesignerSurvey);
+    if (propertyGridCtx) {
+      const providerResult = await dispatchPropertyGridChoicesLazyLoad(
+        propertyGridCtx,
+        options.question.name,
+        {
+          filter: options.filter,
+          skip: options.skip,
+          take: options.take,
+        },
+        deps,
+      );
+
+      if (providerResult) {
+        options.setItems(providerResult.items, providerResult.total);
+        notifyChoicesLazyLoadCompleted(
+          options.question,
+          filter,
+          providerResult.items.length,
+          true,
+        );
+        return;
+      }
     }
 
     const runtime = resolveFormRuntimeState(deps.getRuntimeState());
@@ -70,16 +106,11 @@ export function bindDataListsToSurvey(
       return;
     }
 
-    const response = await withJwtRetry(runtime, (jwt) =>
-      api.search({
-        formId: runtime.formId,
-        dataListId,
-        formAccessJwt: jwt,
-        query: options.filter,
-        skip: options.skip,
-        take: options.take,
-      }),
-    );
+    const response = await searchDataListChoices(deps, dataListId, {
+      filter: options.filter,
+      skip: options.skip,
+      take: options.take,
+    });
 
     if (!response.success) {
       console.error("Failed to lazy-load data list choices.", response.error);
@@ -88,15 +119,11 @@ export function bindDataListsToSurvey(
       return;
     }
 
-    const items = response.data.items.map((item) => ({
-      value: item.value,
-      text: item.label,
-    }));
-    options.setItems(items, response.data.totalRecords);
+    options.setItems(response.data.items, response.data.total);
     notifyChoicesLazyLoadCompleted(
       options.question,
       filter,
-      items.length,
+      response.data.items.length,
       true,
     );
   };
@@ -105,19 +132,31 @@ export function bindDataListsToSurvey(
     _: Model,
     options: GetChoiceDisplayValueEvent,
   ) => {
+    const propertyGridCtx = buildPropertyGridContext(model, getDesignerSurvey);
+    if (propertyGridCtx) {
+      const labels = await dispatchPropertyGridChoiceDisplayValues(
+        propertyGridCtx,
+        options.question.name,
+        options.values.map(String),
+        deps,
+      );
+
+      if (labels) {
+        options.setItems(labels);
+        return;
+      }
+    }
+
     const runtime = resolveFormRuntimeState(deps.getRuntimeState());
     const dataListId = getDataListIdFromQuestion(options.question);
     if (!runtime || !dataListId || options.values.length === 0) {
       return;
     }
 
-    const response = await withJwtRetry(runtime, (jwt) =>
-      api.getDisplayValues({
-        formId: runtime.formId,
-        dataListId,
-        formAccessJwt: jwt,
-        values: options.values.map(String),
-      }),
+    const response = await resolveDataListDisplayValues(
+      deps,
+      dataListId,
+      options.values.map(String),
     );
 
     if (!response.success) {
@@ -130,12 +169,9 @@ export function bindDataListsToSurvey(
       return;
     }
 
-    const valueMap = new Map(
-      response.data.map((item) => [item.value, item.label] as const),
-    );
     options.setItems(
       options.values.map(
-        (value) => valueMap.get(String(value)) ?? String(value),
+        (value) => response.data.get(String(value)) ?? String(value),
       ),
     );
   };

--- a/lib/survey-features/data-lists/types.ts
+++ b/lib/survey-features/data-lists/types.ts
@@ -1,0 +1,48 @@
+import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
+import type { Model, SurveyModel } from "survey-core";
+
+export type DataListChoiceItem = { value: string; text: string };
+
+export type DataListChoicePageParams = {
+  filter?: string;
+  skip: number;
+  take: number;
+};
+
+export type PropertyGridChoice = { value: string; text: string };
+
+export type DataListSourceRef = {
+  sourceName: string;
+  dataListId: string;
+};
+
+export type PropertyGridLazyChoiceContext = {
+  designerSurvey: SurveyModel;
+  propertyGridSurvey: Model;
+  editingObj: unknown;
+};
+
+export type PropertyGridLazyChoicePageParams = {
+  filter?: string;
+  skip: number;
+  take: number;
+};
+
+export type PropertyGridLazyChoiceProvider = {
+  propertyName: string;
+  shouldEnable: (ctx: PropertyGridLazyChoiceContext) => boolean;
+  getStaticChoices?: (
+    ctx: PropertyGridLazyChoiceContext,
+    filter: string,
+  ) => PropertyGridChoice[];
+  loadPage: (
+    ctx: PropertyGridLazyChoiceContext,
+    params: PropertyGridLazyChoicePageParams,
+    deps: ExtensionRuntimeDeps,
+  ) => Promise<{ items: PropertyGridChoice[]; total: number }>;
+  resolveDisplayValues: (
+    ctx: PropertyGridLazyChoiceContext,
+    values: string[],
+    deps: ExtensionRuntimeDeps,
+  ) => Promise<string[]>;
+};

--- a/lib/survey-features/data-lists/use-cases/__tests__/load-choices-in-creator.test.ts
+++ b/lib/survey-features/data-lists/use-cases/__tests__/load-choices-in-creator.test.ts
@@ -391,6 +391,69 @@ describe("loadChoicesInCreator", () => {
     consoleError.mockRestore();
   });
 
+  it("advances skip past a failed source when its total can be probed", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    vi.mocked(searchDataListChoices).mockImplementation(
+      async (_deps, dataListId, params) => {
+        if (dataListId === "games") {
+          if (params.skip > 0) {
+            return ApiResult.authError("Games unavailable");
+          }
+
+          return mockSource(
+            "games",
+            params,
+            [{ value: "game-1", text: "Game 1" }],
+            100,
+          );
+        }
+
+        return mockSource(
+          "brands",
+          params,
+          Array.from({ length: params.take }, (_, index) => ({
+            value: `brand-${index + 1 + params.skip}`,
+            text: `Brand ${index + 1 + params.skip}`,
+          })),
+          300,
+        );
+      },
+    );
+
+    const result = await loadChoicesInCreator(
+      deps,
+      [
+        { sourceName: "games", dataListId: "games" },
+        { sourceName: "brands", dataListId: "brands" },
+      ],
+      [],
+      { skip: 120, take: 25 },
+      formatLabel,
+    );
+
+    expect(result.items[0]).toEqual({
+      value: "brand-21",
+      text: "brands: (Brand 21)",
+    });
+    expect(searchDataListChoices).toHaveBeenNthCalledWith(
+      2,
+      deps,
+      "games",
+      expect.objectContaining({ skip: 0, take: 1 }),
+    );
+    expect(searchDataListChoices).toHaveBeenNthCalledWith(
+      3,
+      deps,
+      "brands",
+      expect.objectContaining({ skip: 20, take: 25 }),
+    );
+
+    consoleError.mockRestore();
+  });
+
   it("reports merged total when the first page is filled entirely by static items", async () => {
     vi.mocked(searchDataListChoices).mockImplementation(
       async (_deps, dataListId, params) => {

--- a/lib/survey-features/data-lists/use-cases/__tests__/load-choices-in-creator.test.ts
+++ b/lib/survey-features/data-lists/use-cases/__tests__/load-choices-in-creator.test.ts
@@ -1,0 +1,362 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiResult } from "@/lib/endatix-api/shared/api-result";
+import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
+import { loadChoicesInCreator } from "../load-choices-in-creator";
+import { searchDataListChoices } from "../search-data-list-choices";
+
+vi.mock("../search-data-list-choices", () => ({
+  searchDataListChoices: vi.fn(),
+}));
+
+const deps = {} as ExtensionRuntimeDeps;
+const formatLabel = (sourceName: string, value: string, text: string) =>
+  `${sourceName}: (${text || value})`;
+
+function mockSource(
+  _dataListId: string,
+  _params: { skip: number; take: number },
+  items: Array<{ value: string; text: string }>,
+  total: number,
+) {
+  return ApiResult.success({ items, total });
+}
+
+describe("loadChoicesInCreator", () => {
+  beforeEach(() => {
+    vi.mocked(searchDataListChoices).mockReset();
+  });
+
+  it("loads the first page from the first data-list source only", async () => {
+    vi.mocked(searchDataListChoices).mockImplementation(
+      async (_deps, dataListId, params) => {
+        if (dataListId === "games") {
+          return mockSource(
+            "games",
+            params,
+            Array.from({ length: params.take }, (_, index) => ({
+              value: `game-${index + 1 + params.skip}`,
+              text: `Game ${index + 1 + params.skip}`,
+            })),
+            400,
+          );
+        }
+
+        return ApiResult.success({ items: [], total: 0 });
+      },
+    );
+
+    const result = await loadChoicesInCreator(
+      deps,
+      [{ sourceName: "games", dataListId: "games" }],
+      [],
+      { skip: 0, take: 25 },
+      formatLabel,
+    );
+
+    expect(result.items).toHaveLength(25);
+    expect(result.items[0]).toEqual({
+      value: "game-1",
+      text: "games: (Game 1)",
+    });
+    expect(result.total).toBe(400);
+    expect(searchDataListChoices).toHaveBeenCalledTimes(1);
+    expect(searchDataListChoices).toHaveBeenCalledWith(
+      deps,
+      "games",
+      expect.objectContaining({ skip: 0, take: 25 }),
+    );
+  });
+
+  it("continues into the next source when the first list is exhausted", async () => {
+    vi.mocked(searchDataListChoices).mockImplementation(
+      async (_deps, dataListId, params) => {
+        if (dataListId === "games") {
+          const start = params.skip;
+          const values = Array.from(
+            { length: Math.max(0, 100 - start) },
+            (_, index) => ({
+              value: `game-${start + index + 1}`,
+              text: `Game ${start + index + 1}`,
+            }),
+          ).slice(0, params.take);
+
+          return mockSource("games", params, values, 100);
+        }
+
+        if (dataListId === "brands") {
+          return mockSource(
+            "brands",
+            params,
+            Array.from({ length: params.take }, (_, index) => ({
+              value: `brand-${index + 1 + params.skip}`,
+              text: `Brand ${index + 1 + params.skip}`,
+            })),
+            300,
+          );
+        }
+
+        return ApiResult.success({ items: [], total: 0 });
+      },
+    );
+
+    const result = await loadChoicesInCreator(
+      deps,
+      [
+        { sourceName: "games", dataListId: "games" },
+        { sourceName: "brands", dataListId: "brands" },
+      ],
+      [],
+      { skip: 100, take: 25 },
+      formatLabel,
+    );
+
+    expect(result.items).toHaveLength(25);
+    expect(result.items[0]).toEqual({
+      value: "brand-1",
+      text: "brands: (Brand 1)",
+    });
+    expect(result.total).toBe(400);
+
+    expect(searchDataListChoices).toHaveBeenNthCalledWith(
+      1,
+      deps,
+      "games",
+      expect.objectContaining({ skip: 100, take: 25 }),
+    );
+    expect(searchDataListChoices).toHaveBeenNthCalledWith(
+      2,
+      deps,
+      "brands",
+      expect.objectContaining({ skip: 0, take: 25 }),
+    );
+  });
+
+  it("spans the tail of one source and the head of the next in a single page", async () => {
+    vi.mocked(searchDataListChoices).mockImplementation(
+      async (_deps, dataListId, params) => {
+        if (dataListId === "games") {
+          const start = params.skip;
+          const values = Array.from(
+            { length: Math.max(0, 100 - start) },
+            (_, index) => ({
+              value: `game-${start + index + 1}`,
+              text: `Game ${start + index + 1}`,
+            }),
+          ).slice(0, params.take);
+
+          return mockSource("games", params, values, 100);
+        }
+
+        if (dataListId === "brands") {
+          return mockSource(
+            "brands",
+            params,
+            Array.from({ length: params.take }, (_, index) => ({
+              value: `brand-${index + 1 + params.skip}`,
+              text: `Brand ${index + 1 + params.skip}`,
+            })),
+            300,
+          );
+        }
+
+        return ApiResult.success({ items: [], total: 0 });
+      },
+    );
+
+    const result = await loadChoicesInCreator(
+      deps,
+      [
+        { sourceName: "games", dataListId: "games" },
+        { sourceName: "brands", dataListId: "brands" },
+      ],
+      [],
+      { skip: 95, take: 25 },
+      formatLabel,
+    );
+
+    expect(result.items).toHaveLength(25);
+    expect(result.items.slice(0, 5).map((item) => item.value)).toEqual([
+      "game-96",
+      "game-97",
+      "game-98",
+      "game-99",
+      "game-100",
+    ]);
+    expect(result.items.slice(5, 10).map((item) => item.value)).toEqual([
+      "brand-1",
+      "brand-2",
+      "brand-3",
+      "brand-4",
+      "brand-5",
+    ]);
+
+    expect(searchDataListChoices).toHaveBeenNthCalledWith(
+      2,
+      deps,
+      "brands",
+      expect.objectContaining({ skip: 0, take: 20 }),
+    );
+  });
+
+  it("offsets into later sources after earlier sources are fully skipped", async () => {
+    vi.mocked(searchDataListChoices).mockImplementation(
+      async (_deps, dataListId, params) => {
+        if (dataListId === "games") {
+          return mockSource("games", params, [], 100);
+        }
+
+        if (dataListId === "brands") {
+          return mockSource(
+            "brands",
+            params,
+            Array.from({ length: params.take }, (_, index) => ({
+              value: `brand-${index + 1 + params.skip}`,
+              text: `Brand ${index + 1 + params.skip}`,
+            })),
+            300,
+          );
+        }
+
+        return ApiResult.success({ items: [], total: 0 });
+      },
+    );
+
+    const result = await loadChoicesInCreator(
+      deps,
+      [
+        { sourceName: "games", dataListId: "games" },
+        { sourceName: "brands", dataListId: "brands" },
+      ],
+      [],
+      { skip: 120, take: 25 },
+      formatLabel,
+    );
+
+    expect(result.items[0]).toEqual({
+      value: "brand-21",
+      text: "brands: (Brand 21)",
+    });
+    expect(searchDataListChoices).toHaveBeenNthCalledWith(
+      2,
+      deps,
+      "brands",
+      expect.objectContaining({ skip: 20, take: 25 }),
+    );
+  });
+
+  it("deduplicates values that appear in multiple sources", async () => {
+    vi.mocked(searchDataListChoices).mockImplementation(
+      async (_deps, dataListId, params) => {
+        if (dataListId === "games") {
+          return mockSource(
+            "games",
+            params,
+            [{ value: "shared", text: "Shared Game" }],
+            1,
+          );
+        }
+
+        if (dataListId === "brands") {
+          return mockSource(
+            "brands",
+            params,
+            [
+              { value: "shared", text: "Shared Brand" },
+              { value: "brand-2", text: "Brand 2" },
+            ],
+            2,
+          );
+        }
+
+        return ApiResult.success({ items: [], total: 0 });
+      },
+    );
+
+    const result = await loadChoicesInCreator(
+      deps,
+      [
+        { sourceName: "games", dataListId: "games" },
+        { sourceName: "brands", dataListId: "brands" },
+      ],
+      [],
+      { skip: 0, take: 25 },
+      formatLabel,
+    );
+
+    expect(result.items).toEqual([
+      { value: "shared", text: "games: (Shared Game)" },
+      { value: "brand-2", text: "brands: (Brand 2)" },
+    ]);
+  });
+
+  it("continues loading from healthy sources when one source fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    vi.mocked(searchDataListChoices).mockImplementation(
+      async (_deps, dataListId, params) => {
+        if (dataListId === "games") {
+          return ApiResult.authError("Games unavailable");
+        }
+
+        return mockSource(
+          "brands",
+          params,
+          [{ value: "brand-1", text: "Brand 1" }],
+          1,
+        );
+      },
+    );
+
+    const result = await loadChoicesInCreator(
+      deps,
+      [
+        { sourceName: "games", dataListId: "games" },
+        { sourceName: "brands", dataListId: "brands" },
+      ],
+      [],
+      { skip: 0, take: 25 },
+      formatLabel,
+    );
+
+    expect(result.items).toEqual([
+      { value: "brand-1", text: "brands: (Brand 1)" },
+    ]);
+    expect(result.total).toBe(1);
+    expect(consoleError).toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+
+  it("merges static choices before paging into data-list sources", async () => {
+    vi.mocked(searchDataListChoices).mockImplementation(
+      async (_deps, _dataListId, params) =>
+        mockSource("games", params, [{ value: "game-1", text: "Game 1" }], 400),
+    );
+
+    const result = await loadChoicesInCreator(
+      deps,
+      [{ sourceName: "games", dataListId: "games" }],
+      [
+        { value: "static-a", text: "static-a" },
+        { value: "static-b", text: "static-b" },
+        { value: "static-c", text: "static-c" },
+      ],
+      { skip: 2, take: 25 },
+      formatLabel,
+    );
+
+    expect(result.items[0]).toEqual({ value: "static-c", text: "static-c" });
+    expect(result.items[1]).toEqual({
+      value: "game-1",
+      text: "games: (Game 1)",
+    });
+    expect(result.total).toBe(403);
+    expect(searchDataListChoices).toHaveBeenCalledWith(
+      deps,
+      "games",
+      expect.objectContaining({ skip: 0, take: 24 }),
+    );
+  });
+});

--- a/lib/survey-features/data-lists/use-cases/__tests__/load-choices-in-creator.test.ts
+++ b/lib/survey-features/data-lists/use-cases/__tests__/load-choices-in-creator.test.ts
@@ -287,6 +287,68 @@ describe("loadChoicesInCreator", () => {
       { value: "shared", text: "games: (Shared Game)" },
       { value: "brand-2", text: "brands: (Brand 2)" },
     ]);
+    // Summed API totals (1 + 2); only two distinct values are returned.
+    expect(result.total).toBe(3);
+  });
+
+  it("reports summed source totals when values overlap across sources", async () => {
+    const listA = ["v1", "v2", "v3", "shared", "x4"];
+    const listB = ["shared", "x5", "x6", "x7", "x8"];
+
+    vi.mocked(searchDataListChoices).mockImplementation(
+      async (_deps, dataListId, params) => {
+        const source = dataListId === "list-a" ? listA : listB;
+        const items = source
+          .slice(params.skip, params.skip + params.take)
+          .map((value) => ({ value, text: value }));
+
+        return mockSource(dataListId, params, items, source.length);
+      },
+    );
+
+    const result = await loadChoicesInCreator(
+      deps,
+      [
+        { sourceName: "sourceA", dataListId: "list-a" },
+        { sourceName: "sourceB", dataListId: "list-b" },
+      ],
+      [],
+      { skip: 0, take: 25 },
+      formatLabel,
+    );
+
+    expect(result.items).toHaveLength(9);
+    expect(result.total).toBe(10);
+  });
+
+  it("returns an empty page only after summed total is exceeded when sources overlap", async () => {
+    const listA = ["v1", "v2", "v3", "shared", "x4"];
+    const listB = ["shared", "x5", "x6", "x7", "x8"];
+
+    vi.mocked(searchDataListChoices).mockImplementation(
+      async (_deps, dataListId, params) => {
+        const source = dataListId === "list-a" ? listA : listB;
+        const items = source
+          .slice(params.skip, params.skip + params.take)
+          .map((value) => ({ value, text: value }));
+
+        return mockSource(dataListId, params, items, source.length);
+      },
+    );
+
+    const result = await loadChoicesInCreator(
+      deps,
+      [
+        { sourceName: "sourceA", dataListId: "list-a" },
+        { sourceName: "sourceB", dataListId: "list-b" },
+      ],
+      [],
+      { skip: 10, take: 25 },
+      formatLabel,
+    );
+
+    expect(result.items).toHaveLength(0);
+    expect(result.total).toBe(10);
   });
 
   it("continues loading from healthy sources when one source fails", async () => {

--- a/lib/survey-features/data-lists/use-cases/__tests__/load-choices-in-creator.test.ts
+++ b/lib/survey-features/data-lists/use-cases/__tests__/load-choices-in-creator.test.ts
@@ -329,6 +329,39 @@ describe("loadChoicesInCreator", () => {
     consoleError.mockRestore();
   });
 
+  it("reports merged total when the first page is filled entirely by static items", async () => {
+    vi.mocked(searchDataListChoices).mockImplementation(
+      async (_deps, dataListId, params) => {
+        if (dataListId === "cars-list") {
+          expect(params).toEqual(expect.objectContaining({ skip: 0, take: 1 }));
+          return mockSource("cars", params, [], 400);
+        }
+
+        return ApiResult.success({ items: [], total: 0 });
+      },
+    );
+
+    const staticItems = Array.from({ length: 10 }, (_, index) => ({
+      value: `static-${index}`,
+      text: `Static ${index}`,
+    }));
+
+    const result = await loadChoicesInCreator(
+      deps,
+      [{ sourceName: "Cars", dataListId: "cars-list" }],
+      staticItems,
+      { skip: 0, take: 10 },
+      formatLabel,
+    );
+
+    expect(result.items).toHaveLength(10);
+    expect(result.items[0]).toEqual({
+      value: "static-0",
+      text: "Static 0",
+    });
+    expect(result.total).toBe(410);
+  });
+
   it("merges static choices before paging into data-list sources", async () => {
     vi.mocked(searchDataListChoices).mockImplementation(
       async (_deps, _dataListId, params) =>

--- a/lib/survey-features/data-lists/use-cases/__tests__/resolve-multi-source-display-values.test.ts
+++ b/lib/survey-features/data-lists/use-cases/__tests__/resolve-multi-source-display-values.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SurveyModel } from "survey-core";
+import { ApiResult } from "@/lib/endatix-api/shared/api-result";
+import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
+import { registerDataListGlobals } from "../../infrastructure/registry";
+import { resolveMultiSourceDisplayValues } from "../resolve-multi-source-display-values";
+import { resolveDataListDisplayValues } from "../resolve-data-list-display-values";
+
+vi.mock("../resolve-data-list-display-values", () => ({
+  resolveDataListDisplayValues: vi.fn(),
+}));
+
+const deps = {} as ExtensionRuntimeDeps;
+
+describe("resolveMultiSourceDisplayValues", () => {
+  beforeEach(() => {
+    registerDataListGlobals();
+    vi.mocked(resolveDataListDisplayValues).mockReset();
+  });
+
+  it("resolves static choices without calling data-list APIs", async () => {
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "checkbox",
+          name: "brands",
+          choices: ["A", "B"],
+        },
+      ],
+    });
+
+    const labels = await resolveMultiSourceDisplayValues(
+      deps,
+      [survey.getQuestionByName("brands")!],
+      ["A"],
+    );
+
+    expect(labels).toEqual(["brands: (A)"]);
+    expect(resolveDataListDisplayValues).not.toHaveBeenCalled();
+  });
+
+  it("queries data-list sources in order until values are resolved", async () => {
+    const survey = new SurveyModel({
+      elements: [
+        { type: "tagbox", name: "games", edxDataListId: "games-list" },
+        { type: "tagbox", name: "brands", edxDataListId: "brands-list" },
+      ],
+    });
+
+    vi.mocked(resolveDataListDisplayValues).mockImplementation(
+      async (_deps, dataListId, values) => {
+        if (dataListId === "games-list") {
+          return ApiResult.success(new Map());
+        }
+
+        return ApiResult.success(
+          new Map(values.map((value) => [value, `Label ${value}`] as const)),
+        );
+      },
+    );
+
+    const labels = await resolveMultiSourceDisplayValues(
+      deps,
+      [survey.getQuestionByName("games")!, survey.getQuestionByName("brands")!],
+      ["brand-1"],
+    );
+
+    expect(labels).toEqual(["brands: (Label brand-1)"]);
+    expect(resolveDataListDisplayValues).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues resolving from later sources when an earlier source fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const survey = new SurveyModel({
+      elements: [
+        { type: "tagbox", name: "games", edxDataListId: "games-list" },
+        { type: "tagbox", name: "brands", edxDataListId: "brands-list" },
+      ],
+    });
+
+    vi.mocked(resolveDataListDisplayValues).mockImplementation(
+      async (_deps, dataListId) => {
+        if (dataListId === "games-list") {
+          return ApiResult.authError("Unavailable");
+        }
+
+        return ApiResult.success(new Map([["brand-1", "Brand One"]]));
+      },
+    );
+
+    const labels = await resolveMultiSourceDisplayValues(
+      deps,
+      [survey.getQuestionByName("games")!, survey.getQuestionByName("brands")!],
+      ["brand-1"],
+    );
+
+    expect(labels).toEqual(["brands: (Brand One)"]);
+    expect(consoleError).toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+});

--- a/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
+++ b/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
@@ -1,0 +1,105 @@
+import { normalizeChoiceKey } from "@/lib/utils/survey";
+import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
+import type { DataListSourceRef, PropertyGridChoice } from "../types";
+import { searchDataListChoices } from "./search-data-list-choices";
+
+/**
+ * Loads a paged choice list for Creator property-grid tagboxes that aggregate
+ * static source choices with one or more data-list sources.
+ */
+export async function loadChoicesInCreator(
+  deps: ExtensionRuntimeDeps,
+  dataListSources: DataListSourceRef[],
+  staticItems: PropertyGridChoice[],
+  params: { filter?: string; skip: number; take: number },
+  formatLabel: (sourceName: string, value: string, text: string) => string,
+): Promise<{ items: PropertyGridChoice[]; total: number }> {
+  const filter = params.filter ?? "";
+
+  if (dataListSources.length === 0) {
+    const page = staticItems.slice(params.skip, params.skip + params.take);
+    return { items: page, total: staticItems.length };
+  }
+
+  if (params.skip < staticItems.length) {
+    const staticPage = staticItems.slice(
+      params.skip,
+      params.skip + params.take,
+    );
+    const apiTake = params.take - staticPage.length;
+
+    if (apiTake <= 0) {
+      return { items: staticPage, total: staticItems.length };
+    }
+
+    const apiItems = await fetchMergedDataListChoices(
+      deps,
+      dataListSources,
+      { filter, skip: 0, take: apiTake },
+      formatLabel,
+    );
+
+    return {
+      items: [...staticPage, ...apiItems.items],
+      total: staticItems.length + apiItems.total,
+    };
+  }
+
+  const apiSkip = params.skip - staticItems.length;
+  const apiItems = await fetchMergedDataListChoices(
+    deps,
+    dataListSources,
+    { filter, skip: apiSkip, take: params.take },
+    formatLabel,
+  );
+
+  return {
+    items: apiItems.items,
+    total: staticItems.length + apiItems.total,
+  };
+}
+
+async function fetchMergedDataListChoices(
+  deps: ExtensionRuntimeDeps,
+  dataListSources: DataListSourceRef[],
+  params: { filter?: string; skip: number; take: number },
+  formatLabel: (sourceName: string, value: string, text: string) => string,
+): Promise<{ items: PropertyGridChoice[]; total: number }> {
+  const seen = new Set<string>();
+  const merged: PropertyGridChoice[] = [];
+  let total = 0;
+
+  const responses = await Promise.all(
+    dataListSources.map(async ({ sourceName, dataListId }) => {
+      const response = await searchDataListChoices(deps, dataListId, params);
+      return { sourceName, response };
+    }),
+  );
+
+  for (const { sourceName, response } of responses) {
+    if (!response.success) {
+      continue;
+    }
+
+    total += response.data.total;
+
+    for (const item of response.data.items) {
+      const value = normalizeChoiceKey(item.value);
+      if (!value || seen.has(value)) {
+        continue;
+      }
+
+      seen.add(value);
+      merged.push({
+        value,
+        text: formatLabel(sourceName, value, item.text),
+      });
+
+      if (merged.length >= params.take) {
+        break;
+      }
+    }
+  }
+
+  return { items: merged.slice(0, params.take), total };
+}

--- a/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
+++ b/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
@@ -106,8 +106,16 @@ async function fetchMergedDataListChoices(
 
     if (!response.success) {
       logDataListSourceError(sourceName, dataListId, response);
-      if (sourceTotal !== null && remainingSkip >= sourceTotal) {
-        remainingSkip -= sourceTotal;
+      if (remainingSkip > 0) {
+        const probeResponse = await probeDataListSourceTotal(
+          deps,
+          dataListId,
+          params.filter ?? "",
+        );
+        const probedTotal = resolveSourceTotal(probeResponse);
+        if (probedTotal !== null && remainingSkip >= probedTotal) {
+          remainingSkip -= probedTotal;
+        }
       }
       continue;
     }
@@ -140,12 +148,7 @@ async function getMergedDataListChoicesTotal(
 ): Promise<number> {
   const totals = await Promise.all(
     dataListSources.map(async ({ sourceName, dataListId }) => {
-      const response = await searchDataListChoices(deps, dataListId, {
-        filter,
-        skip: 0,
-        take: 1,
-      });
-
+      const response = await probeDataListSourceTotal(deps, dataListId, filter);
       if (!response.success) {
         logDataListSourceError(sourceName, dataListId, response);
         return 0;
@@ -156,6 +159,18 @@ async function getMergedDataListChoicesTotal(
   );
 
   return totals.reduce((sum, total) => sum + total, 0);
+}
+
+async function probeDataListSourceTotal(
+  deps: ExtensionRuntimeDeps,
+  dataListId: string,
+  filter: string,
+): Promise<DataListSearchResult> {
+  return searchDataListChoices(deps, dataListId, {
+    filter,
+    skip: 0,
+    take: 1,
+  });
 }
 
 function resolveSourceTotal(response: DataListSearchResult): number | null {

--- a/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
+++ b/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
@@ -30,8 +30,17 @@ export async function loadChoicesInCreator(
     );
     const apiTake = params.take - staticPage.length;
 
-    if (apiTake <= 0) {
-      return { items: staticPage, total: staticItems.length };
+    if (apiTake === 0) {
+      const dataListTotal = await getMergedDataListChoicesTotal(
+        deps,
+        dataListSources,
+        filter,
+      );
+
+      return {
+        items: staticPage,
+        total: staticItems.length + dataListTotal,
+      };
     }
 
     const apiItems = await fetchMergedDataListChoices(
@@ -116,6 +125,31 @@ async function fetchMergedDataListChoices(
   }
 
   return { items: merged.slice(0, params.take), total };
+}
+
+async function getMergedDataListChoicesTotal(
+  deps: ExtensionRuntimeDeps,
+  dataListSources: DataListSourceRef[],
+  filter: string,
+): Promise<number> {
+  const totals = await Promise.all(
+    dataListSources.map(async ({ sourceName, dataListId }) => {
+      const response = await searchDataListChoices(deps, dataListId, {
+        filter,
+        skip: 0,
+        take: 1,
+      });
+
+      if (!response.success) {
+        logDataListSourceError(sourceName, dataListId, response);
+        return 0;
+      }
+
+      return response.data.total;
+    }),
+  );
+
+  return totals.reduce((sum, total) => sum + total, 0);
 }
 
 function resolveSourceTotal(response: DataListSearchResult): number | null {

--- a/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
+++ b/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
@@ -8,6 +8,12 @@ type DataListSearchResult = Awaited<ReturnType<typeof searchDataListChoices>>;
 /**
  * Loads a paged choice list for Creator property-grid tagboxes that aggregate
  * static source choices with one or more data-list sources.
+ *
+ * **Total count:** `total` is `staticItems.length` plus the sum of each data-list
+ * source's API `total`. Cross-source duplicate values are removed from `items`, but
+ * not subtracted from `total`, so `total` may exceed the number of distinct choices
+ * when sources overlap. SurveyJS may allow scrolling slightly past the last distinct
+ * item before pages return empty.
  */
 export async function loadChoicesInCreator(
   deps: ExtensionRuntimeDeps,

--- a/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
+++ b/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
@@ -3,6 +3,8 @@ import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
 import type { DataListSourceRef, PropertyGridChoice } from "../types";
 import { searchDataListChoices } from "./search-data-list-choices";
 
+type DataListSearchResult = Awaited<ReturnType<typeof searchDataListChoices>>;
+
 /**
  * Loads a paged choice list for Creator property-grid tagboxes that aggregate
  * static source choices with one or more data-list sources.
@@ -68,38 +70,102 @@ async function fetchMergedDataListChoices(
   const seen = new Set<string>();
   const merged: PropertyGridChoice[] = [];
   let total = 0;
+  let remainingSkip = params.skip;
+  let remainingTake = params.take;
 
-  const responses = await Promise.all(
-    dataListSources.map(async ({ sourceName, dataListId }) => {
-      const response = await searchDataListChoices(deps, dataListId, params);
-      return { sourceName, response };
-    }),
-  );
+  for (const { sourceName, dataListId } of dataListSources) {
+    if (remainingTake <= 0) {
+      break;
+    }
 
-  for (const { sourceName, response } of responses) {
+    const response = await searchDataListChoices(deps, dataListId, {
+      filter: params.filter,
+      skip: remainingSkip,
+      take: remainingTake,
+    });
+
+    const sourceTotal = resolveSourceTotal(response);
+    if (sourceTotal !== null) {
+      total += sourceTotal;
+    }
+
     if (!response.success) {
+      logDataListSourceError(sourceName, dataListId, response);
+      if (sourceTotal !== null && remainingSkip >= sourceTotal) {
+        remainingSkip -= sourceTotal;
+      }
       continue;
     }
 
-    total += response.data.total;
-
-    for (const item of response.data.items) {
-      const value = normalizeChoiceKey(item.value);
-      if (!value || seen.has(value)) {
-        continue;
-      }
-
-      seen.add(value);
-      merged.push({
-        value,
-        text: formatLabel(sourceName, value, item.text),
-      });
-
-      if (merged.length >= params.take) {
-        break;
-      }
+    if (remainingSkip >= response.data.total) {
+      remainingSkip -= response.data.total;
+      continue;
     }
+
+    appendUniqueChoices(
+      merged,
+      seen,
+      response.data.items,
+      sourceName,
+      formatLabel,
+      params.take,
+    );
+
+    remainingSkip = 0;
+    remainingTake = params.take - merged.length;
   }
 
   return { items: merged.slice(0, params.take), total };
+}
+
+function resolveSourceTotal(response: DataListSearchResult): number | null {
+  if (response.success) {
+    return response.data.total;
+  }
+
+  return null;
+}
+
+function logDataListSourceError(
+  sourceName: string,
+  dataListId: string,
+  response: DataListSearchResult,
+): void {
+  if (response.success) {
+    return;
+  }
+
+  console.error("Failed to lazy-load data list choices for merged source.", {
+    sourceName,
+    dataListId,
+    type: response.error.type,
+    message: response.error.message,
+    errorCode: response.error.errorCode,
+  });
+}
+
+function appendUniqueChoices(
+  merged: PropertyGridChoice[],
+  seen: Set<string>,
+  items: Array<{ value: string; text: string }>,
+  sourceName: string,
+  formatLabel: (sourceName: string, value: string, text: string) => string,
+  takeTarget: number,
+): void {
+  for (const item of items) {
+    if (merged.length >= takeTarget) {
+      break;
+    }
+
+    const value = normalizeChoiceKey(item.value);
+    if (!value || seen.has(value)) {
+      continue;
+    }
+
+    seen.add(value);
+    merged.push({
+      value,
+      text: formatLabel(sourceName, value, item.text),
+    });
+  }
 }

--- a/lib/survey-features/data-lists/use-cases/load-multi-source-choices-in-creator.ts
+++ b/lib/survey-features/data-lists/use-cases/load-multi-source-choices-in-creator.ts
@@ -1,0 +1,34 @@
+import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
+import type { Question } from "survey-core";
+import type {
+  PropertyGridChoice,
+  PropertyGridLazyChoicePageParams,
+} from "../types";
+import {
+  formatSourceChoiceLabel,
+  getDataListSourceRefs,
+  getStaticChoicesFromSources,
+} from "../utils/property-grid-source-choices";
+import { loadChoicesInCreator } from "./load-choices-in-creator";
+
+/**
+ * Loads a paged property-grid choice list from survey source questions that may
+ * mix static inline choices with one or more data-list powered sources.
+ */
+export async function loadMultiSourceChoicesInCreator(
+  deps: ExtensionRuntimeDeps,
+  sources: Question[],
+  params: PropertyGridLazyChoicePageParams,
+): Promise<{ items: PropertyGridChoice[]; total: number }> {
+  const filter = params.filter ?? "";
+  const staticItems = getStaticChoicesFromSources(sources, filter);
+  const dataListSources = getDataListSourceRefs(sources);
+
+  return loadChoicesInCreator(
+    deps,
+    dataListSources,
+    staticItems,
+    params,
+    formatSourceChoiceLabel,
+  );
+}

--- a/lib/survey-features/data-lists/use-cases/resolve-data-list-display-values.ts
+++ b/lib/survey-features/data-lists/use-cases/resolve-data-list-display-values.ts
@@ -1,0 +1,34 @@
+import { createEndatixPublicApi } from "@/lib/endatix-api/public";
+import { ApiResult } from "@/lib/endatix-api/shared/api-result";
+import { resolveFormRuntimeState } from "@/lib/form-runtime/resolve-form-runtime-state";
+import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
+import { withFormAccessJwtRetry } from "../utils/with-form-access-jwt-retry";
+
+export async function resolveDataListDisplayValues(
+  deps: ExtensionRuntimeDeps,
+  dataListId: string,
+  values: string[],
+): Promise<ApiResult<Map<string, string>>> {
+  const runtime = resolveFormRuntimeState(deps.getRuntimeState());
+  if (!runtime || values.length === 0) {
+    return ApiResult.authError("Form runtime is not available.");
+  }
+
+  const api = createEndatixPublicApi().dataLists;
+  const response = await withFormAccessJwtRetry(runtime, (jwt) =>
+    api.getDisplayValues({
+      formId: runtime.formId,
+      dataListId,
+      formAccessJwt: jwt,
+      values,
+    }),
+  );
+
+  if (!response.success) {
+    return response;
+  }
+
+  return ApiResult.success(
+    new Map(response.data.map((item) => [item.value, item.label] as const)),
+  );
+}

--- a/lib/survey-features/data-lists/use-cases/resolve-multi-source-display-values.ts
+++ b/lib/survey-features/data-lists/use-cases/resolve-multi-source-display-values.ts
@@ -1,0 +1,78 @@
+import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
+import { normalizeChoiceKey } from "@/lib/utils/survey";
+import type { Question } from "survey-core";
+import {
+  formatSourceChoiceLabel,
+  getDataListSourceRefs,
+  getStaticChoicesFromSources,
+} from "../utils/property-grid-source-choices";
+import { resolveDataListDisplayValues } from "./resolve-data-list-display-values";
+
+/**
+ * Resolves display labels for values selected from aggregated survey sources
+ * (static inline choices first, then data-list sources in source order).
+ */
+export async function resolveMultiSourceDisplayValues(
+  deps: ExtensionRuntimeDeps,
+  sources: Question[],
+  values: string[],
+): Promise<string[]> {
+  if (values.length === 0) {
+    return [];
+  }
+
+  const labels = new Map<string, string>();
+  const staticChoices = getStaticChoicesFromSources(sources, "");
+
+  for (const value of values) {
+    const normalized = normalizeChoiceKey(value);
+    const staticMatch = staticChoices.find((item) => item.value === normalized);
+    if (staticMatch) {
+      labels.set(normalized, staticMatch.text);
+    }
+  }
+
+  const dataListSources = getDataListSourceRefs(sources);
+
+  for (const { sourceName, dataListId } of dataListSources) {
+    const unresolved = values
+      .map((value) => normalizeChoiceKey(value))
+      .filter((value) => value && !labels.has(value));
+
+    if (unresolved.length === 0) {
+      break;
+    }
+
+    const response = await resolveDataListDisplayValues(
+      deps,
+      dataListId,
+      unresolved,
+    );
+
+    if (!response.success) {
+      console.error(
+        "Failed to resolve data list display values for merged source.",
+        {
+          sourceName,
+          dataListId,
+          type: response.error.type,
+          message: response.error.message,
+          errorCode: response.error.errorCode,
+        },
+      );
+      continue;
+    }
+
+    for (const value of unresolved) {
+      const label = response.data.get(value);
+      if (label) {
+        labels.set(value, formatSourceChoiceLabel(sourceName, value, label));
+      }
+    }
+  }
+
+  return values.map((value) => {
+    const normalized = normalizeChoiceKey(value);
+    return labels.get(normalized) ?? String(value);
+  });
+}

--- a/lib/survey-features/data-lists/use-cases/search-data-list-choices.ts
+++ b/lib/survey-features/data-lists/use-cases/search-data-list-choices.ts
@@ -1,0 +1,41 @@
+import { createEndatixPublicApi } from "@/lib/endatix-api/public";
+import { ApiResult } from "@/lib/endatix-api/shared/api-result";
+import { resolveFormRuntimeState } from "@/lib/form-runtime/resolve-form-runtime-state";
+import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
+import type { DataListChoiceItem, DataListChoicePageParams } from "../types";
+import { withFormAccessJwtRetry } from "../utils/with-form-access-jwt-retry";
+
+export async function searchDataListChoices(
+  deps: ExtensionRuntimeDeps,
+  dataListId: string,
+  params: DataListChoicePageParams,
+): Promise<ApiResult<{ items: DataListChoiceItem[]; total: number }>> {
+  const runtime = resolveFormRuntimeState(deps.getRuntimeState());
+  if (!runtime) {
+    return ApiResult.authError("Form runtime is not available.");
+  }
+
+  const api = createEndatixPublicApi().dataLists;
+  const response = await withFormAccessJwtRetry(runtime, (jwt) =>
+    api.search({
+      formId: runtime.formId,
+      dataListId,
+      formAccessJwt: jwt,
+      query: params.filter,
+      skip: params.skip,
+      take: params.take,
+    }),
+  );
+
+  if (!response.success) {
+    return response;
+  }
+
+  return ApiResult.success({
+    items: response.data.items.map((item) => ({
+      value: item.value,
+      text: item.label,
+    })),
+    total: response.data.totalRecords,
+  });
+}

--- a/lib/survey-features/data-lists/utils/__tests__/property-grid-source-choices.test.ts
+++ b/lib/survey-features/data-lists/utils/__tests__/property-grid-source-choices.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { SurveyModel } from "survey-core";
+import { registerDataListGlobals } from "../../infrastructure/registry";
+import {
+  formatSourceChoiceLabel,
+  getStaticChoicesFromSources,
+  hasDataListSource,
+} from "../property-grid-source-choices";
+
+describe("property-grid-source-choices", () => {
+  beforeAll(() => {
+    registerDataListGlobals();
+  });
+
+  it("detects data-list powered sources", () => {
+    const survey = new SurveyModel({
+      elements: [
+        { type: "tagbox", name: "src", edxDataListId: "list-1" },
+        { type: "checkbox", name: "static", choices: ["A"] },
+      ],
+    });
+
+    expect(
+      hasDataListSource([
+        survey.getQuestionByName("src")!,
+        survey.getQuestionByName("static")!,
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns static choices with source labels", () => {
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "checkbox",
+          name: "brands",
+          choices: ["A", "B"],
+        },
+      ],
+    });
+
+    const choices = getStaticChoicesFromSources(
+      [survey.getQuestionByName("brands")!],
+      "",
+      formatSourceChoiceLabel,
+    );
+
+    expect(choices).toEqual([
+      { value: "A", text: "brands: (A)" },
+      { value: "B", text: "brands: (B)" },
+    ]);
+  });
+
+  it("filters static choices by search text", () => {
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "checkbox",
+          name: "brands",
+          choices: ["Apple", "Banana"],
+        },
+      ],
+    });
+
+    const choices = getStaticChoicesFromSources(
+      [survey.getQuestionByName("brands")!],
+      "ban",
+      formatSourceChoiceLabel,
+    );
+
+    expect(choices).toEqual([{ value: "Banana", text: "brands: (Banana)" }]);
+  });
+});

--- a/lib/survey-features/data-lists/utils/index.ts
+++ b/lib/survey-features/data-lists/utils/index.ts
@@ -29,3 +29,9 @@ export {
   parseSurveyJsonRoot,
 } from "./survey-json-walk";
 export { resolveLocalizedText, toPlainText } from "./survey-localized-text";
+export {
+  formatSourceChoiceLabel,
+  getDataListSourceRefs,
+  getStaticChoicesFromSources,
+  hasDataListSource,
+} from "./property-grid-source-choices";

--- a/lib/survey-features/data-lists/utils/property-grid-source-choices.ts
+++ b/lib/survey-features/data-lists/utils/property-grid-source-choices.ts
@@ -1,0 +1,75 @@
+import type { Question } from "survey-core";
+import { normalizeChoiceKey } from "@/lib/utils/survey";
+import { getDataListIdFromQuestion } from "../infrastructure/data-list-survey-integration";
+import type { PropertyGridChoice } from "../types";
+
+export function formatSourceChoiceLabel(
+  sourceName: string,
+  value: string,
+  text: string,
+): string {
+  return `${sourceName}: (${text || value})`;
+}
+
+export function hasDataListSource(sources: Question[]): boolean {
+  return sources.some((source) => getDataListIdFromQuestion(source) !== null);
+}
+
+export function getStaticChoicesFromSources(
+  sources: Question[],
+  filter: string,
+  formatLabel: (
+    sourceName: string,
+    value: string,
+    text: string,
+  ) => string = formatSourceChoiceLabel,
+): PropertyGridChoice[] {
+  const normalizedFilter = filter.trim().toLowerCase();
+  const seen = new Set<string>();
+  const items: PropertyGridChoice[] = [];
+
+  for (const source of sources) {
+    if (getDataListIdFromQuestion(source)) {
+      continue;
+    }
+
+    for (const choice of source.choices ?? []) {
+      const value = normalizeChoiceKey(choice.value);
+      if (!value || seen.has(value)) {
+        continue;
+      }
+
+      const text = formatLabel(
+        source.name,
+        value,
+        String(choice.text ?? choice.value),
+      );
+
+      if (
+        normalizedFilter &&
+        !text.toLowerCase().includes(normalizedFilter) &&
+        !value.toLowerCase().includes(normalizedFilter)
+      ) {
+        continue;
+      }
+
+      seen.add(value);
+      items.push({ value, text });
+    }
+  }
+
+  return items;
+}
+
+export function getDataListSourceRefs(
+  sources: Question[],
+): Array<{ sourceName: string; dataListId: string }> {
+  return sources.flatMap((source) => {
+    const dataListId = getDataListIdFromQuestion(source);
+    if (!dataListId) {
+      return [];
+    }
+
+    return [{ sourceName: source.name, dataListId }];
+  });
+}

--- a/lib/survey-features/data-lists/utils/with-form-access-jwt-retry.ts
+++ b/lib/survey-features/data-lists/utils/with-form-access-jwt-retry.ts
@@ -1,0 +1,34 @@
+import { ApiErrorType, ApiResult } from "@/lib/endatix-api/shared/api-result";
+import {
+  ensureRuntimeFormAccessJwt,
+  invalidateRuntimeFormAccessJwt,
+} from "@/lib/form-runtime/form-access-jwt-orchestrator";
+import type { FormRuntimeState } from "@/lib/form-runtime/form-runtime.context";
+
+/**
+ * Ensures a form access JWT is available and retries the given function if an authentication error occurs.
+ * @param runtimeState - The form runtime state.
+ * @param call - The function to call with the JWT.
+ * @returns The result of the function.
+ */
+export async function withFormAccessJwtRetry<T>(
+  runtimeState: FormRuntimeState,
+  call: (jwt: string) => Promise<ApiResult<T>>,
+): Promise<ApiResult<T>> {
+  let jwt = await ensureRuntimeFormAccessJwt(runtimeState);
+  if (!jwt) {
+    return ApiResult.authError<T>("Could not obtain form access token.");
+  }
+
+  let response = await call(jwt);
+  if (!response.success && response.error.type === ApiErrorType.AuthError) {
+    invalidateRuntimeFormAccessJwt(runtimeState);
+    jwt = await ensureRuntimeFormAccessJwt(runtimeState);
+    if (!jwt) {
+      return response;
+    }
+    response = await call(jwt);
+  }
+
+  return response;
+}

--- a/lib/survey-features/question-loops/dynamic-loop-question.ts
+++ b/lib/survey-features/question-loops/dynamic-loop-question.ts
@@ -1,4 +1,4 @@
-import { IJsonPropertyInfo, ItemValue, SurveyModel } from "survey-core";
+import { IJsonPropertyInfo, SurveyModel } from "survey-core";
 import {
   ConditionRunnerContext,
   DynamicLoopDefinition,
@@ -6,11 +6,15 @@ import {
   SourceSelectionModes,
 } from "./types";
 import {
-  getAllUniqueChoices,
   getAllSelectBasedQuestions,
   isLoopQuestion,
   isSelectBaseQuestion,
 } from "./loop-utils";
+import {
+  formatSourceChoiceLabel,
+  getStaticChoicesFromSources,
+  hasDataListSource,
+} from "@/lib/survey-features/data-lists/utils/property-grid-source-choices";
 import { createLoopExitQuery } from "./use-cases/handle-loop-exit";
 
 const PANEL_QUESTION_TYPE = "paneldynamic";
@@ -34,11 +38,11 @@ export function isLoopExitedFunction(
   ];
 
   const survey: SurveyModel | undefined = this.survey ?? this.question?.survey;
-  
+
   if (!survey) return false;
 
   const panel = survey.getQuestionByName(panelName);
-  
+
   if (!panel?.exitMeta?.exitAll && !panel?.exitMeta?.exitCurrent) return false;
 
   const query = createLoopExitQuery(panel.exitMeta);
@@ -112,7 +116,7 @@ const PRIORITY_ITEMS_PROPERTY: IJsonPropertyInfo = {
   type: "multiplevalues",
   choices: function (
     obj: { survey: SurveyModel; loopSource: string[] },
-    choicesCallback: (choices: ItemValue[]) => void,
+    choicesCallback: (choices: { value: string; text: string }[]) => void,
   ) {
     const { survey, loopSource } = obj || {};
     if (!survey || !loopSource) return choicesCallback([]);
@@ -121,12 +125,18 @@ const PRIORITY_ITEMS_PROPERTY: IJsonPropertyInfo = {
       .map((name) => survey.getQuestionByName(name))
       .filter(isSelectBaseQuestion);
 
-    const uniqueChoices = getAllUniqueChoices(
-      loopSourceQuestions,
-      (question, choice) => `${question.name}: (${choice.value})`,
-    );
+    if (hasDataListSource(loopSourceQuestions)) {
+      choicesCallback([]);
+      return;
+    }
 
-    choicesCallback(uniqueChoices);
+    choicesCallback(
+      getStaticChoicesFromSources(
+        loopSourceQuestions,
+        "",
+        formatSourceChoiceLabel,
+      ),
+    );
   },
   visibleIf: isLoopQuestion,
 };

--- a/lib/survey-features/question-loops/infrastructure/loop-priority-lazy-provider.ts
+++ b/lib/survey-features/question-loops/infrastructure/loop-priority-lazy-provider.ts
@@ -1,0 +1,58 @@
+import { registerPropertyGridLazyChoiceProvider } from "@/lib/survey-features/data-lists/infrastructure/property-grid-lazy-choice-registry";
+import { loadMultiSourceChoicesInCreator } from "@/lib/survey-features/data-lists/use-cases/load-multi-source-choices-in-creator";
+import { resolveMultiSourceDisplayValues } from "@/lib/survey-features/data-lists/use-cases/resolve-multi-source-display-values";
+import type {
+  PropertyGridLazyChoiceContext,
+  PropertyGridLazyChoiceProvider,
+} from "@/lib/survey-features/data-lists/types";
+import {
+  getStaticChoicesFromSources,
+  hasDataListSource,
+} from "@/lib/survey-features/data-lists/utils/property-grid-source-choices";
+import { isSelectBaseQuestion } from "@/lib/utils/survey";
+
+const LOOP_PRIORITY_ITEMS_PROPERTY = "priorityItems";
+
+type LoopEditingObj = {
+  loopSource?: string[];
+};
+
+function getLoopSources(ctx: PropertyGridLazyChoiceContext) {
+  const editingObj = ctx.editingObj as LoopEditingObj | null;
+  const loopSource = editingObj?.loopSource;
+  if (!loopSource?.length) {
+    return [];
+  }
+
+  return loopSource
+    .map((name) => ctx.designerSurvey.getQuestionByName(name))
+    .filter(
+      (question): question is NonNullable<typeof question> => question != null,
+    )
+    .filter(isSelectBaseQuestion);
+}
+
+const loopPriorityLazyProvider: PropertyGridLazyChoiceProvider = {
+  propertyName: LOOP_PRIORITY_ITEMS_PROPERTY,
+
+  shouldEnable(ctx) {
+    const sources = getLoopSources(ctx);
+    return sources.length > 0 && hasDataListSource(sources);
+  },
+
+  getStaticChoices(ctx, filter) {
+    return getStaticChoicesFromSources(getLoopSources(ctx), filter);
+  },
+
+  loadPage(ctx, params, deps) {
+    return loadMultiSourceChoicesInCreator(deps, getLoopSources(ctx), params);
+  },
+
+  resolveDisplayValues(ctx, values, deps) {
+    return resolveMultiSourceDisplayValues(deps, getLoopSources(ctx), values);
+  },
+};
+
+export function registerLoopPriorityLazyProvider(): void {
+  registerPropertyGridLazyChoiceProvider(loopPriorityLazyProvider);
+}

--- a/lib/survey-features/question-loops/infrastructure/registry.ts
+++ b/lib/survey-features/question-loops/infrastructure/registry.ts
@@ -1,5 +1,6 @@
 import { FunctionFactory, Serializer } from "survey-core";
 import { getDynamicLoopDefinition } from "../dynamic-loop-question";
+import { registerLoopPriorityLazyProvider } from "./loop-priority-lazy-provider";
 import { LOOP_EXIT_FUNCTION_NAME } from "../types";
 
 let areGlobalsRegistered = false;
@@ -24,6 +25,8 @@ export function registerQuestionLoopsGlobals() {
     false,
     false,
   );
+
+  registerLoopPriorityLazyProvider();
 
   areGlobalsRegistered = true;
 }


### PR DESCRIPTION
# feat(h717): Enable lazy loading of data list properties for the property grid

## Description
- Adds support for lazy loading in the Survey Creator property grid, so that we can enable lazy loading of data lists in data list dependent properties like priorityItems for loops and carry-forward where the source questions use data lists
- Adds priority resolution when a single field uses static + dynamic data sources e.g. static list + one or more data lists + search in all data lists altogether
- Refactor data lists vertical slices to improve DRY and readability

## Related Issues
- closes #717 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)


## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="436" height="335" alt="image" src="https://github.com/user-attachments/assets/2ef49713-3b9a-4596-ac90-2c2faad3bde2" />
