### PR TITLE
feat(h697): export request filters + custom export dialog

### DIFF
--- a/app/api/forms/[formId]/export/route.ts
+++ b/app/api/forms/[formId]/export/route.ts
@@ -10,8 +10,12 @@ import { reportingExportFlag } from "@/lib/feature-flags/flags";
 import {
   parseIncludeTestSubmissionsQuery,
   parseLegacyExportFormat,
+  parseOptionalIsoDateQuery,
+  parseOptionalLocaleQuery,
+  parseOptionalPositiveIdQuery,
   parseReportingExportWireKey,
 } from "@/features/export/export-submissions";
+import { isCodebookWireKey } from "@/features/export/export-url";
 import { Result } from "@/lib/result";
 import { validateEndatixId } from "@/lib/utils/type-validators";
 
@@ -71,15 +75,44 @@ export async function GET(
     ? parseReportingExportWireKey(format)
     : parseLegacyExportFormat(format);
 
+  const wireKey = exportFormat ?? format ?? "";
+  const isCodebook = isCodebookWireKey(wireKey);
+
   const exportOptions: ExportSubmissionsRequest = {
     formId,
     exportFormat,
     exportFormatId: validatedExportFormatId,
     exportId: validatedExportId,
-    includeTestSubmissions: parseIncludeTestSubmissionsQuery(
-      includeTestSubmissionsParam,
-    ),
   };
+
+  // Native codebook streams FormSchema JSON as-is; only Shoji codebook applies locale.
+  if (wireKey !== "codebook") {
+    exportOptions.locale = parseOptionalLocaleQuery(searchParams.get("locale"));
+  }
+
+  if (!isCodebook) {
+    exportOptions.includeTestSubmissions = parseIncludeTestSubmissionsQuery(
+      includeTestSubmissionsParam,
+    );
+    exportOptions.createdAfter = parseOptionalIsoDateQuery(
+      searchParams.get("createdAfter"),
+    );
+    exportOptions.createdBefore = parseOptionalIsoDateQuery(
+      searchParams.get("createdBefore"),
+    );
+    exportOptions.completedAfter = parseOptionalIsoDateQuery(
+      searchParams.get("completedAfter"),
+    );
+    exportOptions.completedBefore = parseOptionalIsoDateQuery(
+      searchParams.get("completedBefore"),
+    );
+    exportOptions.minSubmissionId = parseOptionalPositiveIdQuery(
+      searchParams.get("minSubmissionId"),
+    );
+    exportOptions.maxSubmissionId = parseOptionalPositiveIdQuery(
+      searchParams.get("maxSubmissionId"),
+    );
+  }
 
   const endatix = new EndatixApi(session?.accessToken);
   const exportResult = await endatix.submissions.export(exportOptions);

--- a/features/export/export-submissions/__tests__/custom-export-dialog.test.tsx
+++ b/features/export/export-submissions/__tests__/custom-export-dialog.test.tsx
@@ -1,0 +1,401 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ExportSubmissionsDialog,
+  type ExportSubmissionsDialogProps,
+} from "../ui/custom-export-dialog";
+
+const mockToastError = vi.fn();
+const mockOnExport = vi.fn();
+const mockOnOpenChange = vi.fn();
+
+type ExportTarget = "Submissions" | "Codebook";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  vi.fn(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+);
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
+  DialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h1>{children}</h1>
+  ),
+}));
+
+vi.mock("@/components/ui/select", async (importOriginal) => {
+  const React = await import("react");
+
+  function walkOptions(
+    node: React.ReactNode,
+  ): Array<{ value: string; label: string }> {
+    const opts: Array<{ value: string; label: string }> = [];
+    React.Children.forEach(node, (child) => {
+      if (React.isValidElement(child)) {
+        if (
+          typeof child.props.value === "string" &&
+          typeof child.props.children === "string"
+        ) {
+          opts.push({
+            value: child.props.value,
+            label: child.props.children,
+          });
+        }
+        if (child.props.children) {
+          opts.push(...walkOptions(child.props.children));
+        }
+      }
+    });
+    return opts;
+  }
+
+  return {
+    Select: ({
+      value,
+      onValueChange,
+      children,
+      disabled,
+    }: {
+      value: string;
+      onValueChange: (v: string) => void;
+      children: React.ReactNode;
+      disabled?: boolean;
+    }) => {
+      const items = walkOptions(children);
+      return (
+        <select
+          value={value}
+          onChange={(e) => onValueChange(e.target.value)}
+          disabled={disabled}
+          data-testid="format-select"
+        >
+          {items.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      );
+    },
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    SelectValue: ({ placeholder }: { placeholder?: string }) => (
+      <span>{placeholder}</span>
+    ),
+    SelectContent: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    SelectGroup: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    SelectLabel: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    SelectItem: () => null,
+    SelectScrollUpButton: () => null,
+    SelectScrollDownButton: () => null,
+    SelectSeparator: () => null,
+  };
+});
+
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+    disabled,
+    ...props
+  }: {
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+    disabled?: boolean;
+    id?: string;
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+      disabled={disabled}
+      {...props}
+    />
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+    type,
+    ref,
+    ...props
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+    type?: "button" | "submit";
+    ref?: React.Ref<HTMLButtonElement>;
+  }) => (
+    <button type={type} disabled={disabled} onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({
+    children,
+    htmlFor,
+    ...props
+  }: {
+    children: React.ReactNode;
+    htmlFor?: string;
+    className?: string;
+  }) => (
+    <label htmlFor={htmlFor} {...props}>
+      {children}
+    </label>
+  ),
+}));
+
+vi.mock("@/components/ui/toast", () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+function createProps(
+  overrides?: Partial<ExportSubmissionsDialogProps>,
+): ExportSubmissionsDialogProps {
+  return {
+    open: true,
+    onOpenChange: mockOnOpenChange,
+    groups: [
+      {
+        target: "Submissions" as ExportTarget,
+        label: "Submissions",
+        options: [
+          {
+            exportFormatId: "csv-1",
+            wireKey: "csv",
+            label: "CSV",
+            fallbackExtension: "csv",
+            exportTarget: "Submissions" as ExportTarget,
+          },
+          {
+            exportFormatId: "json-1",
+            wireKey: "json",
+            label: "JSON",
+            fallbackExtension: "json",
+            exportTarget: "Submissions" as ExportTarget,
+          },
+        ],
+      },
+      {
+        target: "Codebook" as ExportTarget,
+        label: "Codebook",
+        options: [
+          {
+            exportFormatId: "cb-native",
+            wireKey: "codebook",
+            label: "Native codebook",
+            fallbackExtension: "json",
+            exportTarget: "Codebook" as ExportTarget,
+          },
+          {
+            exportFormatId: "cb-shoji",
+            wireKey: "codebook-shoji",
+            label: "Shoji codebook",
+            fallbackExtension: "json",
+            exportTarget: "Codebook" as ExportTarget,
+          },
+        ],
+      },
+    ],
+    listFilters: undefined,
+    isExporting: false,
+    onExport: mockOnExport,
+    ...overrides,
+  };
+}
+
+describe("ExportSubmissionsDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the dialog title and description when open", () => {
+    render(<ExportSubmissionsDialog {...createProps()} />);
+    expect(screen.getByText("Export submissions")).toBeDefined();
+    expect(screen.getByText(/Choose a format/)).toBeDefined();
+  });
+
+  it("does not render when closed", () => {
+    render(<ExportSubmissionsDialog {...createProps({ open: false })} />);
+    expect(screen.queryByText("Export submissions")).toBeNull();
+  });
+
+  it("shows row filters by default for submission formats", () => {
+    render(<ExportSubmissionsDialog {...createProps()} />);
+    expect(screen.getByText("Include test submissions")).toBeDefined();
+    expect(screen.getByText("Created at")).toBeDefined();
+    expect(screen.getByText("Completed at")).toBeDefined();
+  });
+
+  it("shows toast error when created from > created to", () => {
+    render(<ExportSubmissionsDialog {...createProps()} />);
+
+    const fromInput = screen.getAllByLabelText("From")[0];
+    const toInput = screen.getAllByLabelText("To")[0];
+
+    fireEvent.change(fromInput, { target: { value: "2026-01-10" } });
+    fireEvent.change(toInput, { target: { value: "2026-01-01" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    expect(mockToastError).toHaveBeenCalledWith({
+      title: "Invalid date range",
+      description: "Created From must be on or before Created To.",
+    });
+    expect(mockOnExport).not.toHaveBeenCalled();
+  });
+
+  it("shows toast error when completed from > completed to", () => {
+    render(<ExportSubmissionsDialog {...createProps()} />);
+
+    const completedFrom = screen.getAllByLabelText("From")[1];
+    const completedTo = screen.getAllByLabelText("To")[1];
+
+    fireEvent.change(completedFrom, { target: { value: "2026-01-10" } });
+    fireEvent.change(completedTo, { target: { value: "2026-01-01" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    expect(mockToastError).toHaveBeenCalledWith({
+      title: "Invalid date range",
+      description: "Completed From must be on or before Completed To.",
+    });
+    expect(mockOnExport).not.toHaveBeenCalled();
+  });
+
+  it("passes filters to onExport on submit", () => {
+    render(<ExportSubmissionsDialog {...createProps()} />);
+
+    const fromInput = screen.getAllByLabelText("From")[0];
+    fireEvent.change(fromInput, { target: { value: "2026-01-01" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    expect(mockOnExport).toHaveBeenCalledWith({
+      wireKey: "csv",
+      exportName: "CSV",
+      exportFormatId: "csv-1",
+      fallbackExtension: "csv",
+      filters: {
+        includeTestSubmissions: false,
+        createdAtFrom: "2026-01-01",
+        createdAtTo: undefined,
+        completedAtFrom: undefined,
+        completedAtTo: undefined,
+      },
+    });
+  });
+
+  it("hides row filters and shows codebook note when codebook is selected", () => {
+    render(<ExportSubmissionsDialog {...createProps()} />);
+
+    fireEvent.change(screen.getByTestId("format-select"), {
+      target: { value: "cb-native" },
+    });
+
+    expect(
+      screen.getByText(
+        "Codebook exports do not use submission row filters (test or dates).",
+      ),
+    ).toBeDefined();
+    expect(
+      screen.queryByText("Include test submissions"),
+    ).toBeNull();
+  });
+
+  it("hides locale field for native codebook", () => {
+    render(<ExportSubmissionsDialog {...createProps()} />);
+
+    fireEvent.change(screen.getByTestId("format-select"), {
+      target: { value: "cb-native" },
+    });
+
+    expect(screen.queryByText("Locale")).toBeNull();
+  });
+
+  it("shows locale field for Shoji codebook", () => {
+    render(<ExportSubmissionsDialog {...createProps()} />);
+
+    fireEvent.change(screen.getByTestId("format-select"), {
+      target: { value: "cb-shoji" },
+    });
+
+    expect(screen.getByText("Locale")).toBeDefined();
+  });
+
+  it("prefills filters from listFilters", () => {
+    render(
+      <ExportSubmissionsDialog
+        {...createProps({
+          listFilters: {
+            includeTestSubmissions: true,
+            createdAtFrom: "2026-03-01",
+            createdAtTo: "2026-03-15",
+            locale: "fr",
+          },
+        })}
+      />,
+    );
+
+    expect(
+      (screen.getAllByLabelText("From")[0] as HTMLInputElement).value,
+    ).toBe("2026-03-01");
+    expect(
+      (screen.getByLabelText("Include test submissions") as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+  });
+
+  it("calls onOpenChange(false) when cancel is clicked", () => {
+    render(<ExportSubmissionsDialog {...createProps()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("disables form elements while exporting", () => {
+    render(<ExportSubmissionsDialog {...createProps({ isExporting: true })} />);
+
+    expect(
+      (screen.getByRole("button", { name: /exporting/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: /cancel/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+});

--- a/features/export/export-submissions/__tests__/custom-export-dialog.test.tsx
+++ b/features/export/export-submissions/__tests__/custom-export-dialog.test.tsx
@@ -198,6 +198,12 @@ function createProps(
             label: "CSV",
             fallbackExtension: "csv",
             exportTarget: "Submissions" as ExportTarget,
+            allowedFilters: [
+              "includeTestSubmissions",
+              "createdAtRange",
+              "completedAtRange",
+              "locale",
+            ],
           },
           {
             exportFormatId: "json-1",
@@ -205,6 +211,12 @@ function createProps(
             label: "JSON",
             fallbackExtension: "json",
             exportTarget: "Submissions" as ExportTarget,
+            allowedFilters: [
+              "includeTestSubmissions",
+              "createdAtRange",
+              "completedAtRange",
+              "locale",
+            ],
           },
         ],
       },
@@ -218,6 +230,7 @@ function createProps(
             label: "Native codebook",
             fallbackExtension: "json",
             exportTarget: "Codebook" as ExportTarget,
+            allowedFilters: [],
           },
           {
             exportFormatId: "cb-shoji",
@@ -225,6 +238,7 @@ function createProps(
             label: "Shoji codebook",
             fallbackExtension: "json",
             exportTarget: "Codebook" as ExportTarget,
+            allowedFilters: ["locale"],
           },
         ],
       },

--- a/features/export/export-submissions/__tests__/custom-export-dialog.test.tsx
+++ b/features/export/export-submissions/__tests__/custom-export-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ExportSubmissionsDialog,
@@ -8,6 +8,7 @@ import {
 const mockToastError = vi.fn();
 const mockOnExport = vi.fn();
 const mockOnOpenChange = vi.fn();
+const mockTrackFeatureUsage = vi.fn();
 
 type ExportTarget = "Submissions" | "Codebook";
 
@@ -19,6 +20,12 @@ vi.stubGlobal(
     disconnect: vi.fn(),
   })),
 );
+
+vi.mock("@/features/analytics/posthog/client", () => ({
+  useTrackEvent: () => ({
+    trackFeatureUsage: mockTrackFeatureUsage,
+  }),
+}));
 
 vi.mock("@/components/ui/dialog", () => ({
   Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
@@ -275,6 +282,7 @@ describe("ExportSubmissionsDialog", () => {
       description: "Created From must be on or before Created To.",
     });
     expect(mockOnExport).not.toHaveBeenCalled();
+    expect(mockTrackFeatureUsage).not.toHaveBeenCalled();
   });
 
   it("shows toast error when completed from > completed to", () => {
@@ -293,9 +301,11 @@ describe("ExportSubmissionsDialog", () => {
       description: "Completed From must be on or before Completed To.",
     });
     expect(mockOnExport).not.toHaveBeenCalled();
+    expect(mockTrackFeatureUsage).not.toHaveBeenCalled();
   });
 
-  it("passes filters to onExport on submit", () => {
+  it("passes filters to onExport on submit", async () => {
+    mockOnExport.mockResolvedValue(true);
     render(<ExportSubmissionsDialog {...createProps()} />);
 
     const fromInput = screen.getAllByLabelText("From")[0];
@@ -303,19 +313,56 @@ describe("ExportSubmissionsDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /export/i }));
 
-    expect(mockOnExport).toHaveBeenCalledWith({
-      wireKey: "csv",
-      exportName: "CSV",
-      exportFormatId: "csv-1",
-      fallbackExtension: "csv",
-      filters: {
-        includeTestSubmissions: false,
-        createdAtFrom: "2026-01-01",
-        createdAtTo: undefined,
-        completedAtFrom: undefined,
-        completedAtTo: undefined,
-      },
+    await waitFor(() => {
+      expect(mockOnExport).toHaveBeenCalledWith({
+        wireKey: "csv",
+        exportName: "CSV",
+        exportFormatId: "csv-1",
+        fallbackExtension: "csv",
+        filters: {
+          includeTestSubmissions: false,
+          createdAtFrom: "2026-01-01",
+          createdAtTo: undefined,
+          completedAtFrom: undefined,
+          completedAtTo: undefined,
+        },
+      });
     });
+
+    expect(mockTrackFeatureUsage).toHaveBeenCalledWith(
+      "export",
+      "submissions_export",
+      {
+        wire_key: "csv",
+        export_format_id: "csv-1",
+        export_target: "Submissions",
+        export_name: "CSV",
+      },
+    );
+  });
+
+  it("does not track analytics when onExport returns false", async () => {
+    mockOnExport.mockResolvedValue(false);
+    render(<ExportSubmissionsDialog {...createProps()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    await waitFor(() => {
+      expect(mockOnExport).toHaveBeenCalled();
+    });
+    expect(mockTrackFeatureUsage).not.toHaveBeenCalled();
+  });
+
+  it("does not track analytics when onExport rejects", async () => {
+    mockOnExport.mockRejectedValue(new Error("export failed"));
+    render(<ExportSubmissionsDialog {...createProps()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /export/i }));
+
+    await waitFor(() => {
+      expect(mockOnExport).toHaveBeenCalled();
+    });
+    expect(mockTrackFeatureUsage).not.toHaveBeenCalled();
   });
 
   it("hides row filters and shows codebook note when codebook is selected", () => {

--- a/features/export/export-submissions/__tests__/custom-export-dialog.test.tsx
+++ b/features/export/export-submissions/__tests__/custom-export-dialog.test.tsx
@@ -5,7 +5,6 @@ import {
   type ExportSubmissionsDialogProps,
 } from "../ui/custom-export-dialog";
 
-const mockToastError = vi.fn();
 const mockOnExport = vi.fn();
 const mockOnOpenChange = vi.fn();
 const mockTrackFeatureUsage = vi.fn();
@@ -182,12 +181,6 @@ vi.mock("@/components/ui/label", () => ({
   ),
 }));
 
-vi.mock("@/components/ui/toast", () => ({
-  toast: {
-    error: (...args: unknown[]) => mockToastError(...args),
-  },
-}));
-
 function createProps(
   overrides?: Partial<ExportSubmissionsDialogProps>,
 ): ExportSubmissionsDialogProps {
@@ -266,7 +259,7 @@ describe("ExportSubmissionsDialog", () => {
     expect(screen.getByText("Completed at")).toBeDefined();
   });
 
-  it("shows toast error when created from > created to", () => {
+  it("shows inline error when created from > created to", () => {
     render(<ExportSubmissionsDialog {...createProps()} />);
 
     const fromInput = screen.getAllByLabelText("From")[0];
@@ -277,15 +270,14 @@ describe("ExportSubmissionsDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /export/i }));
 
-    expect(mockToastError).toHaveBeenCalledWith({
-      title: "Invalid date range",
-      description: "Created From must be on or before Created To.",
-    });
+    expect(
+      screen.getByText("Created From must be on or before Created To."),
+    ).toBeDefined();
     expect(mockOnExport).not.toHaveBeenCalled();
     expect(mockTrackFeatureUsage).not.toHaveBeenCalled();
   });
 
-  it("shows toast error when completed from > completed to", () => {
+  it("shows inline error when completed from > completed to", () => {
     render(<ExportSubmissionsDialog {...createProps()} />);
 
     const completedFrom = screen.getAllByLabelText("From")[1];
@@ -296,10 +288,9 @@ describe("ExportSubmissionsDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /export/i }));
 
-    expect(mockToastError).toHaveBeenCalledWith({
-      title: "Invalid date range",
-      description: "Completed From must be on or before Completed To.",
-    });
+    expect(
+      screen.getByText("Completed From must be on or before Completed To."),
+    ).toBeDefined();
     expect(mockOnExport).not.toHaveBeenCalled();
     expect(mockTrackFeatureUsage).not.toHaveBeenCalled();
   });

--- a/features/export/export-submissions/__tests__/export-url.test.ts
+++ b/features/export/export-submissions/__tests__/export-url.test.ts
@@ -129,4 +129,24 @@ describe("export url builders", () => {
     expect(shoji).toContain("locale=es");
     expect(shoji).not.toContain("includeTestSubmissions");
   });
+
+  it("uses allowedFilters allow-list instead of wireKey fallback gating", () => {
+    const listFilters = {
+      includeTestSubmissions: true,
+      createdAtFrom: "2026-01-01",
+      locale: "es",
+    };
+
+    const url = buildReportingExportUrl({
+      formId: "100",
+      wireKey: "csv",
+      exportFormatId: "42",
+      listFilters,
+      allowedFilters: ["locale"],
+    });
+
+    expect(url).toContain("locale=es");
+    expect(url).not.toContain("includeTestSubmissions");
+    expect(url).not.toContain("createdAfter=");
+  });
 });

--- a/features/export/export-submissions/__tests__/export-url.test.ts
+++ b/features/export/export-submissions/__tests__/export-url.test.ts
@@ -23,4 +23,110 @@ describe("export url builders", () => {
       "/api/forms/100/export?format=codebook-shoji&exportFormatId=44",
     );
   });
+
+  it("attaches list filters for submission exports and strips them for codebook", () => {
+    const listFilters = {
+      includeTestSubmissions: false,
+      createdAtFrom: "2026-01-01",
+      createdAtTo: "2026-01-02",
+      locale: "es",
+    };
+
+    const csvUrl = buildReportingExportUrl({
+      formId: "100",
+      wireKey: "csv",
+      exportFormatId: "42",
+      listFilters,
+    });
+    expect(csvUrl).toContain("includeTestSubmissions=false");
+    expect(csvUrl).toContain("createdAfter=");
+    expect(csvUrl).toContain("createdBefore=");
+    expect(csvUrl).toContain("locale=es");
+
+    const codebookUrl = buildReportingExportUrl({
+      formId: "100",
+      wireKey: "codebook-shoji",
+      exportFormatId: "44",
+      listFilters,
+    });
+    expect(codebookUrl).not.toContain("includeTestSubmissions");
+    expect(codebookUrl).not.toContain("createdAfter");
+    expect(codebookUrl).toContain("locale=es");
+  });
+
+  it("uses explicit includeTestSubmissions from the export dialog", () => {
+    const url = buildReportingExportUrl({
+      formId: "100",
+      wireKey: "csv",
+      exportFormatId: "42",
+      listFilters: {
+        includeTestSubmissions: true,
+      },
+    });
+    expect(url).toContain("includeTestSubmissions=true");
+  });
+
+  it("does not map grid test-only filter to includeTestSubmissions", () => {
+    const url = buildReportingExportUrl({
+      formId: "100",
+      wireKey: "csv",
+      exportFormatId: "42",
+      listFilters: {
+        isTestSubmission: ["true"],
+        createdAtFrom: "2026-01-01",
+      },
+    });
+    expect(url).not.toContain("includeTestSubmissions");
+    expect(url).toContain("createdAfter=");
+  });
+
+  it("attaches submissionIdRange filters for submission exports and strips them for codebook", () => {
+    const listFilters = {
+      minSubmissionId: "100",
+      maxSubmissionId: "200",
+    };
+
+    const csvUrl = buildReportingExportUrl({
+      formId: "100",
+      wireKey: "csv",
+      exportFormatId: "42",
+      listFilters,
+    });
+    expect(csvUrl).toContain("minSubmissionId=100");
+    expect(csvUrl).toContain("maxSubmissionId=200");
+
+    const codebookUrl = buildReportingExportUrl({
+      formId: "100",
+      wireKey: "codebook-shoji",
+      exportFormatId: "44",
+      listFilters,
+    });
+    expect(codebookUrl).not.toContain("minSubmissionId");
+    expect(codebookUrl).not.toContain("maxSubmissionId");
+  });
+
+  it("strips locale for native codebook but keeps it for Shoji codebook", () => {
+    const listFilters = {
+      locale: "es",
+      includeTestSubmissions: false,
+    };
+
+    const native = buildReportingExportUrl({
+      formId: "100",
+      wireKey: "codebook",
+      exportFormatId: "44",
+      listFilters,
+    });
+    expect(native).not.toContain("locale=");
+    expect(native).not.toContain("includeTestSubmissions");
+
+    const shoji = buildReportingExportUrl({
+      formId: "100",
+      wireKey: "codebook-shoji",
+      exportFormatId: "45",
+      listFilters,
+    });
+    expect(shoji).toContain("locale=es");
+    expect(shoji).not.toContain("includeTestSubmissions");
+  });
 });

--- a/features/export/export-submissions/__tests__/map-tenant-export-options.test.ts
+++ b/features/export/export-submissions/__tests__/map-tenant-export-options.test.ts
@@ -25,22 +25,50 @@ function format(
 
 describe("mapFormatsToTenantExportOptions", () => {
   it("maps tenant formats to dropdown options with fallback extensions", () => {
-    const options = mapFormatsToTenantExportOptions([
-      format({
-        id: "10",
-        name: "Submissions CSV",
-        wireKey: "csv",
-        exportTarget: "Submissions",
-      }),
-      format({
-        id: "11",
-        name: "Shoji codebook",
-        wireKey: "codebook-shoji",
-        exportTarget: "Codebook",
-        deliveryFormat: "Json",
-        profile: "Shoji",
-      }),
-    ]);
+    const options = mapFormatsToTenantExportOptions(
+      [
+        format({
+          id: "10",
+          name: "Submissions CSV",
+          wireKey: "csv",
+          exportTarget: "Submissions",
+        }),
+        format({
+          id: "11",
+          name: "Shoji codebook",
+          wireKey: "codebook-shoji",
+          exportTarget: "Codebook",
+          deliveryFormat: "Json",
+          profile: "Shoji",
+        }),
+      ],
+      [
+        {
+          target: "Submissions",
+          deliveryFormat: "Csv",
+          profile: "Native",
+          wireKey: "csv",
+          label: "CSV",
+          itemTypeName: "submission",
+          description: "CSV",
+          allowedFilters: [
+            "includeTestSubmissions",
+            "createdAtRange",
+            "locale",
+          ],
+        },
+        {
+          target: "Codebook",
+          deliveryFormat: "Json",
+          profile: "Shoji",
+          wireKey: "codebook-shoji",
+          label: "Shoji codebook",
+          itemTypeName: "codebook",
+          description: "Shoji",
+          allowedFilters: ["locale"],
+        },
+      ],
+    );
 
     expect(options).toEqual([
       {
@@ -49,6 +77,7 @@ describe("mapFormatsToTenantExportOptions", () => {
         wireKey: "csv",
         label: "Submissions CSV",
         fallbackExtension: "csv",
+        allowedFilters: ["includeTestSubmissions", "createdAtRange", "locale"],
       },
       {
         exportFormatId: "11",
@@ -56,6 +85,7 @@ describe("mapFormatsToTenantExportOptions", () => {
         wireKey: "codebook-shoji",
         label: "Shoji codebook",
         fallbackExtension: "json",
+        allowedFilters: ["locale"],
       },
     ]);
   });
@@ -70,6 +100,7 @@ describe("groupTenantExportOptions", () => {
         wireKey: "csv",
         label: "CSV",
         fallbackExtension: "csv",
+        allowedFilters: ["includeTestSubmissions"],
       },
       {
         exportFormatId: "11",
@@ -77,6 +108,7 @@ describe("groupTenantExportOptions", () => {
         wireKey: "codebook",
         label: "Codebook",
         fallbackExtension: "json",
+        allowedFilters: [],
       },
       {
         exportFormatId: "12",
@@ -84,6 +116,7 @@ describe("groupTenantExportOptions", () => {
         wireKey: "json",
         label: "JSON",
         fallbackExtension: "json",
+        allowedFilters: ["includeTestSubmissions"],
       },
     ]);
 
@@ -98,6 +131,7 @@ describe("groupTenantExportOptions", () => {
             wireKey: "csv",
             label: "CSV",
             fallbackExtension: "csv",
+            allowedFilters: ["includeTestSubmissions"],
           },
           {
             exportFormatId: "12",
@@ -105,6 +139,7 @@ describe("groupTenantExportOptions", () => {
             wireKey: "json",
             label: "JSON",
             fallbackExtension: "json",
+            allowedFilters: ["includeTestSubmissions"],
           },
         ],
       },
@@ -118,6 +153,7 @@ describe("groupTenantExportOptions", () => {
             wireKey: "codebook",
             label: "Codebook",
             fallbackExtension: "json",
+            allowedFilters: [],
           },
         ],
       },
@@ -132,6 +168,7 @@ describe("groupTenantExportOptions", () => {
         wireKey: "codebook",
         label: "Codebook",
         fallbackExtension: "json",
+        allowedFilters: [],
       },
       {
         exportFormatId: "10",
@@ -139,6 +176,7 @@ describe("groupTenantExportOptions", () => {
         wireKey: "csv",
         label: "CSV",
         fallbackExtension: "csv",
+        allowedFilters: ["includeTestSubmissions"],
       },
     ]);
 

--- a/features/export/export-submissions/__tests__/map-tenant-export-options.test.ts
+++ b/features/export/export-submissions/__tests__/map-tenant-export-options.test.ts
@@ -123,4 +123,28 @@ describe("groupTenantExportOptions", () => {
       },
     ]);
   });
+
+  it("keeps Submissions before Codebook regardless of input order", () => {
+    const groups = groupTenantExportOptions([
+      {
+        exportFormatId: "11",
+        exportTarget: "Codebook",
+        wireKey: "codebook",
+        label: "Codebook",
+        fallbackExtension: "json",
+      },
+      {
+        exportFormatId: "10",
+        exportTarget: "Submissions",
+        wireKey: "csv",
+        label: "CSV",
+        fallbackExtension: "csv",
+      },
+    ]);
+
+    expect(groups.map((group) => group.target)).toEqual([
+      "Submissions",
+      "Codebook",
+    ]);
+  });
 });

--- a/features/export/export-submissions/index.ts
+++ b/features/export/export-submissions/index.ts
@@ -2,6 +2,9 @@ export { ExportSubmissionsButton } from "./ui/export-submissions-button";
 export {
   parseIncludeTestSubmissionsQuery,
   parseLegacyExportFormat,
+  parseOptionalIsoDateQuery,
+  parseOptionalLocaleQuery,
+  parseOptionalPositiveIdQuery,
   parseReportingExportWireKey,
-} from "./parse-export-bff-request";
+} from "./parse-export-query";
 export { useTenantExportFormats } from "./use-tenant-export-formats.hook";

--- a/features/export/export-submissions/map-tenant-export-options.ts
+++ b/features/export/export-submissions/map-tenant-export-options.ts
@@ -33,6 +33,12 @@ export function mapFormatsToTenantExportOptions(
   }));
 }
 
+/** Stable UX order for export target groups (matches former dropdown). */
+const EXPORT_TARGET_GROUP_ORDER: readonly ExportTarget[] = [
+  "Submissions",
+  "Codebook",
+];
+
 export function groupTenantExportOptions(
   options: TenantExportOption[],
 ): TenantExportOptionGroup[] {
@@ -45,9 +51,16 @@ export function groupTenantExportOptions(
   }
 
   // Group heading uses the wire target name (API enum), not a Hub label catalog.
-  return Array.from(grouped.entries()).map(([target, groupOptions]) => ({
+  const orderedTargets = [
+    ...EXPORT_TARGET_GROUP_ORDER.filter((target) => grouped.has(target)),
+    ...Array.from(grouped.keys()).filter(
+      (target) => !EXPORT_TARGET_GROUP_ORDER.includes(target),
+    ),
+  ];
+
+  return orderedTargets.map((target) => ({
     target,
     label: target,
-    options: groupOptions,
+    options: grouped.get(target) ?? [],
   }));
 }

--- a/features/export/export-submissions/map-tenant-export-options.ts
+++ b/features/export/export-submissions/map-tenant-export-options.ts
@@ -1,8 +1,10 @@
 import type {
+  ExportCapabilityDto,
   ExportFormatListItem,
   ExportTarget,
 } from "@/lib/endatix-api/reporting/reporting";
 import {
+  getExportCapabilityForSelection,
   getExportFormatFallbackExtension,
   getExportFormatLabel,
 } from "@/lib/endatix-api/reporting/export-format-types";
@@ -13,6 +15,8 @@ export interface TenantExportOption {
   wireKey: string;
   label: string;
   fallbackExtension: string;
+  /** Capability allow-list for request-time filters (Reporting API wire names). */
+  allowedFilters: readonly string[];
 }
 
 export interface TenantExportOptionGroup {
@@ -23,14 +27,25 @@ export interface TenantExportOptionGroup {
 
 export function mapFormatsToTenantExportOptions(
   formats: ExportFormatListItem[],
+  capabilities: ReadonlyArray<ExportCapabilityDto> = [],
 ): TenantExportOption[] {
-  return formats.map((format) => ({
-    exportFormatId: format.id,
-    exportTarget: format.exportTarget,
-    wireKey: format.wireKey,
-    label: getExportFormatLabel(format),
-    fallbackExtension: getExportFormatFallbackExtension(format.wireKey),
-  }));
+  return formats.map((format) => {
+    const capability = getExportCapabilityForSelection(
+      format.exportTarget,
+      format.deliveryFormat,
+      format.profile,
+      capabilities,
+    );
+
+    return {
+      exportFormatId: format.id,
+      exportTarget: format.exportTarget,
+      wireKey: format.wireKey,
+      label: getExportFormatLabel(format),
+      fallbackExtension: getExportFormatFallbackExtension(format.wireKey),
+      allowedFilters: capability?.allowedFilters ?? [],
+    };
+  });
 }
 
 /** Stable UX order for export target groups (matches former dropdown). */

--- a/features/export/export-submissions/parse-export-query.ts
+++ b/features/export/export-submissions/parse-export-query.ts
@@ -15,6 +15,7 @@ export function parseReportingExportWireKey(
 ): ReportingExportFormat | undefined {
   if (
     format === "csv" ||
+    format === "csv-shoji" ||
     format === "json" ||
     format === "codebook" ||
     format === "codebook-shoji"
@@ -37,4 +38,44 @@ export function parseIncludeTestSubmissionsQuery(
   }
 
   return undefined;
+}
+
+export function parseOptionalIsoDateQuery(
+  value: string | null,
+): string | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    return undefined;
+  }
+
+  return new Date(parsed).toISOString();
+}
+
+export function parseOptionalPositiveIdQuery(
+  value: string | null,
+): string | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+
+  if (!/^\d+$/.test(value.trim())) {
+    return undefined;
+  }
+
+  return value.trim();
+}
+
+export function parseOptionalLocaleQuery(
+  value: string | null,
+): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.length > 32) {
+    return undefined;
+  }
+
+  return trimmed;
 }

--- a/features/export/export-submissions/ui/custom-export-dialog.tsx
+++ b/features/export/export-submissions/ui/custom-export-dialog.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type SubmitEvent,
-} from "react";
+import { useEffect, useMemo, useRef, useState, type SubmitEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -30,6 +24,7 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/loaders/spinner";
 import { toast } from "@/components/ui/toast";
+import { useTrackEvent } from "@/features/analytics/posthog/client";
 import type { ExportTarget } from "@/lib/endatix-api/reporting/reporting";
 import {
   isCodebookWireKey,
@@ -50,7 +45,7 @@ export interface ExportSubmissionsDialogProps {
     exportFormatId: string;
     fallbackExtension: string;
     filters: SubmissionExportListFilters;
-  }) => void | Promise<void>;
+  }) => boolean | void | Promise<boolean | void>;
 }
 
 function showsSubmissionRowFilters(
@@ -77,6 +72,7 @@ export function ExportSubmissionsDialog({
   isExporting,
   onExport,
 }: Readonly<ExportSubmissionsDialogProps>) {
+  const { trackFeatureUsage } = useTrackEvent();
   const exportButtonRef = useRef<HTMLButtonElement>(null);
   const wasOpenRef = useRef(false);
   const [exportFormatId, setExportFormatId] = useState("");
@@ -181,13 +177,28 @@ export function ExportSubmissionsDialog({
       filters.completedAtTo = completedAtTo || undefined;
     }
 
-    await onExport({
-      wireKey: selectedOption.wireKey,
-      exportName: selectedOption.label,
-      exportFormatId: selectedOption.exportFormatId,
-      fallbackExtension: selectedOption.fallbackExtension,
-      filters,
-    });
+    try {
+      const succeeded = await onExport({
+        wireKey: selectedOption.wireKey,
+        exportName: selectedOption.label,
+        exportFormatId: selectedOption.exportFormatId,
+        fallbackExtension: selectedOption.fallbackExtension,
+        filters,
+      });
+
+      if (succeeded === false) {
+        return;
+      }
+
+      trackFeatureUsage("export", "submissions_export", {
+        wire_key: selectedOption.wireKey,
+        export_format_id: selectedOption.exportFormatId,
+        export_target: selectedOption.exportTarget,
+        export_name: selectedOption.label,
+      });
+    } catch {
+      // Export failures are reported by the owner; do not track.
+    }
   };
 
   return (
@@ -216,7 +227,10 @@ export function ExportSubmissionsDialog({
                 onValueChange={setExportFormatId}
                 disabled={isExporting || options.length === 0}
               >
-                <SelectTrigger id="export-submissions-format" className="w-full">
+                <SelectTrigger
+                  id="export-submissions-format"
+                  className="w-full"
+                >
                   <SelectValue placeholder="Select format" />
                 </SelectTrigger>
                 <SelectContent>

--- a/features/export/export-submissions/ui/custom-export-dialog.tsx
+++ b/features/export/export-submissions/ui/custom-export-dialog.tsx
@@ -78,6 +78,7 @@ export function ExportSubmissionsDialog({
   onExport,
 }: Readonly<ExportSubmissionsDialogProps>) {
   const exportButtonRef = useRef<HTMLButtonElement>(null);
+  const wasOpenRef = useRef(false);
   const [exportFormatId, setExportFormatId] = useState("");
   const [includeTestSubmissions, setIncludeTestSubmissions] = useState(false);
   const [createdAtFrom, setCreatedAtFrom] = useState("");
@@ -107,7 +108,10 @@ export function ExportSubmissionsDialog({
     : false;
 
   useEffect(() => {
-    if (!open) {
+    const justOpened = open && !wasOpenRef.current;
+    wasOpenRef.current = open;
+
+    if (!justOpened) {
       return;
     }
 

--- a/features/export/export-submissions/ui/custom-export-dialog.tsx
+++ b/features/export/export-submissions/ui/custom-export-dialog.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type SubmitEvent,
+} from "react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/loaders/spinner";
+import { toast } from "@/components/ui/toast";
+import type { ExportTarget } from "@/lib/endatix-api/reporting/reporting";
+import {
+  isCodebookWireKey,
+  type SubmissionExportListFilters,
+} from "../../export-url";
+import type { TenantExportOptionGroup } from "../map-tenant-export-options";
+
+export interface ExportSubmissionsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Grouped by export target (Submissions / Codebook) — same grouping as the former dropdown. */
+  groups: TenantExportOptionGroup[];
+  listFilters?: SubmissionExportListFilters;
+  isExporting: boolean;
+  onExport: (args: {
+    wireKey: string;
+    exportName: string;
+    exportFormatId: string;
+    fallbackExtension: string;
+    filters: SubmissionExportListFilters;
+  }) => void | Promise<void>;
+}
+
+function showsSubmissionRowFilters(
+  exportTarget: ExportTarget,
+  wireKey: string,
+): boolean {
+  if (exportTarget === "Codebook" || isCodebookWireKey(wireKey)) {
+    return false;
+  }
+
+  return true;
+}
+
+function showsLocale(wireKey: string): boolean {
+  // Native codebook streams FormSchema JSON as-is (no request locale).
+  return wireKey !== "codebook";
+}
+
+export function ExportSubmissionsDialog({
+  open,
+  onOpenChange,
+  groups,
+  listFilters,
+  isExporting,
+  onExport,
+}: Readonly<ExportSubmissionsDialogProps>) {
+  const exportButtonRef = useRef<HTMLButtonElement>(null);
+  const [exportFormatId, setExportFormatId] = useState("");
+  const [includeTestSubmissions, setIncludeTestSubmissions] = useState(false);
+  const [createdAtFrom, setCreatedAtFrom] = useState("");
+  const [createdAtTo, setCreatedAtTo] = useState("");
+  const [completedAtFrom, setCompletedAtFrom] = useState("");
+  const [completedAtTo, setCompletedAtTo] = useState("");
+  const [locale, setLocale] = useState("default");
+
+  const options = useMemo(
+    () => groups.flatMap((group) => group.options),
+    [groups],
+  );
+
+  const selectedOption = useMemo(
+    () => options.find((option) => option.exportFormatId === exportFormatId),
+    [exportFormatId, options],
+  );
+
+  const showRowFilters = selectedOption
+    ? showsSubmissionRowFilters(
+        selectedOption.exportTarget,
+        selectedOption.wireKey,
+      )
+    : false;
+  const showLocaleField = selectedOption
+    ? showsLocale(selectedOption.wireKey)
+    : false;
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const defaultFormatId = options[0]?.exportFormatId ?? "";
+    setExportFormatId((current) =>
+      current && options.some((option) => option.exportFormatId === current)
+        ? current
+        : defaultFormatId,
+    );
+    // Include-test defaults off. Grid "test only" is not mirrored (API has no test-only mode).
+    setIncludeTestSubmissions(listFilters?.includeTestSubmissions ?? false);
+    setCreatedAtFrom(listFilters?.createdAtFrom ?? "");
+    setCreatedAtTo(listFilters?.createdAtTo ?? "");
+    setCompletedAtFrom(listFilters?.completedAtFrom ?? "");
+    setCompletedAtTo(listFilters?.completedAtTo ?? "");
+    setLocale(listFilters?.locale?.trim() || "default");
+  }, [open, options, listFilters]);
+
+  const showGroupLabels = groups.length > 1;
+
+  const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedOption) {
+      return;
+    }
+
+    if (
+      showRowFilters &&
+      createdAtFrom &&
+      createdAtTo &&
+      createdAtFrom > createdAtTo
+    ) {
+      toast.error({
+        title: "Invalid date range",
+        description: "Created From must be on or before Created To.",
+      });
+      return;
+    }
+
+    if (
+      showRowFilters &&
+      completedAtFrom &&
+      completedAtTo &&
+      completedAtFrom > completedAtTo
+    ) {
+      toast.error({
+        title: "Invalid date range",
+        description: "Completed From must be on or before Completed To.",
+      });
+      return;
+    }
+
+    const filters: SubmissionExportListFilters = {};
+
+    if (showLocaleField) {
+      const trimmedLocale = locale.trim();
+      if (trimmedLocale && trimmedLocale !== "default") {
+        filters.locale = trimmedLocale;
+      }
+    }
+
+    if (showRowFilters) {
+      filters.includeTestSubmissions = includeTestSubmissions;
+      filters.createdAtFrom = createdAtFrom || undefined;
+      filters.createdAtTo = createdAtTo || undefined;
+      filters.completedAtFrom = completedAtFrom || undefined;
+      filters.completedAtTo = completedAtTo || undefined;
+    }
+
+    await onExport({
+      wireKey: selectedOption.wireKey,
+      exportName: selectedOption.label,
+      exportFormatId: selectedOption.exportFormatId,
+      fallbackExtension: selectedOption.fallbackExtension,
+      filters,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="sm:max-w-md"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          exportButtonRef.current?.focus();
+        }}
+      >
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Export submissions</DialogTitle>
+            <DialogDescription>
+              Choose a format and filters. Date ranges are prefilled from the
+              table when set. Press Enter to export with the current options.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="export-submissions-format">Export format</Label>
+              <Select
+                value={exportFormatId}
+                onValueChange={setExportFormatId}
+                disabled={isExporting || options.length === 0}
+              >
+                <SelectTrigger id="export-submissions-format" className="w-full">
+                  <SelectValue placeholder="Select format" />
+                </SelectTrigger>
+                <SelectContent>
+                  {groups.map((group) => (
+                    <SelectGroup key={group.target}>
+                      {showGroupLabels ? (
+                        <SelectLabel>{group.label}</SelectLabel>
+                      ) : null}
+                      {group.options.map((option) => (
+                        <SelectItem
+                          key={option.exportFormatId}
+                          value={option.exportFormatId}
+                        >
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {showLocaleField ? (
+              <div className="grid gap-2">
+                <Label htmlFor="export-submissions-locale">Locale</Label>
+                <Input
+                  id="export-submissions-locale"
+                  value={locale}
+                  onChange={(event) => setLocale(event.target.value)}
+                  placeholder="default"
+                  maxLength={32}
+                  disabled={isExporting}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Leave as <code>default</code> or set a locale code (e.g.{" "}
+                  <code>es</code>) for translated labels.
+                </p>
+              </div>
+            ) : null}
+
+            {showRowFilters ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="export-submissions-include-test"
+                    checked={includeTestSubmissions}
+                    onCheckedChange={(checked) =>
+                      setIncludeTestSubmissions(checked === true)
+                    }
+                    disabled={isExporting}
+                  />
+                  <Label htmlFor="export-submissions-include-test">
+                    Include test submissions
+                  </Label>
+                </div>
+
+                <fieldset className="grid gap-2">
+                  <legend className="text-sm font-medium">Created at</legend>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="grid gap-1">
+                      <Label
+                        htmlFor="export-submissions-created-from"
+                        className="text-xs text-muted-foreground"
+                      >
+                        From
+                      </Label>
+                      <Input
+                        id="export-submissions-created-from"
+                        type="date"
+                        value={createdAtFrom}
+                        onChange={(event) =>
+                          setCreatedAtFrom(event.target.value)
+                        }
+                        disabled={isExporting}
+                      />
+                    </div>
+                    <div className="grid gap-1">
+                      <Label
+                        htmlFor="export-submissions-created-to"
+                        className="text-xs text-muted-foreground"
+                      >
+                        To
+                      </Label>
+                      <Input
+                        id="export-submissions-created-to"
+                        type="date"
+                        value={createdAtTo}
+                        onChange={(event) => setCreatedAtTo(event.target.value)}
+                        disabled={isExporting}
+                      />
+                    </div>
+                  </div>
+                </fieldset>
+
+                <fieldset className="grid gap-2">
+                  <legend className="text-sm font-medium">Completed at</legend>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="grid gap-1">
+                      <Label
+                        htmlFor="export-submissions-completed-from"
+                        className="text-xs text-muted-foreground"
+                      >
+                        From
+                      </Label>
+                      <Input
+                        id="export-submissions-completed-from"
+                        type="date"
+                        value={completedAtFrom}
+                        onChange={(event) =>
+                          setCompletedAtFrom(event.target.value)
+                        }
+                        disabled={isExporting}
+                      />
+                    </div>
+                    <div className="grid gap-1">
+                      <Label
+                        htmlFor="export-submissions-completed-to"
+                        className="text-xs text-muted-foreground"
+                      >
+                        To
+                      </Label>
+                      <Input
+                        id="export-submissions-completed-to"
+                        type="date"
+                        value={completedAtTo}
+                        onChange={(event) =>
+                          setCompletedAtTo(event.target.value)
+                        }
+                        disabled={isExporting}
+                      />
+                    </div>
+                  </div>
+                </fieldset>
+              </>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Codebook exports do not use submission row filters (test or
+                dates).
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isExporting}
+            >
+              Cancel
+            </Button>
+            <Button
+              ref={exportButtonRef}
+              type="submit"
+              disabled={isExporting || !selectedOption}
+            >
+              {isExporting ? (
+                <>
+                  <Spinner className="mr-2 h-4 w-4" />
+                  Exporting...
+                </>
+              ) : (
+                "Export"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/export/export-submissions/ui/custom-export-dialog.tsx
+++ b/features/export/export-submissions/ui/custom-export-dialog.tsx
@@ -31,8 +31,7 @@ import {
 } from "../../export-url";
 import type { TenantExportOptionGroup } from "../map-tenant-export-options";
 
-const CREATED_AT_RANGE_ERROR =
-  "Created From must be on or before Created To.";
+const CREATED_AT_RANGE_ERROR = "Created From must be on or before Created To.";
 const COMPLETED_AT_RANGE_ERROR =
   "Completed From must be on or before Completed To.";
 
@@ -66,6 +65,137 @@ function showsSubmissionRowFilters(
 function showsLocale(wireKey: string): boolean {
   // Native codebook streams FormSchema JSON as-is (no request locale).
   return wireKey !== "codebook";
+}
+
+function isInvalidDateRange(from: string, to: string): boolean {
+  return Boolean(from && to && from > to);
+}
+
+function resolveDateRangeErrors(args: {
+  showRowFilters: boolean;
+  createdAtFrom: string;
+  createdAtTo: string;
+  completedAtFrom: string;
+  completedAtTo: string;
+}): {
+  createdAtRangeError: string | null;
+  completedAtRangeError: string | null;
+} {
+  if (!args.showRowFilters) {
+    return { createdAtRangeError: null, completedAtRangeError: null };
+  }
+
+  return {
+    createdAtRangeError: isInvalidDateRange(
+      args.createdAtFrom,
+      args.createdAtTo,
+    )
+      ? CREATED_AT_RANGE_ERROR
+      : null,
+    completedAtRangeError: isInvalidDateRange(
+      args.completedAtFrom,
+      args.completedAtTo,
+    )
+      ? COMPLETED_AT_RANGE_ERROR
+      : null,
+  };
+}
+
+function buildExportFilters(args: {
+  showLocaleField: boolean;
+  showRowFilters: boolean;
+  locale: string;
+  includeTestSubmissions: boolean;
+  createdAtFrom: string;
+  createdAtTo: string;
+  completedAtFrom: string;
+  completedAtTo: string;
+}): SubmissionExportListFilters {
+  const filters: SubmissionExportListFilters = {};
+
+  if (args.showLocaleField) {
+    const trimmedLocale = args.locale.trim();
+    if (trimmedLocale && trimmedLocale !== "default") {
+      filters.locale = trimmedLocale;
+    }
+  }
+
+  if (args.showRowFilters) {
+    filters.includeTestSubmissions = args.includeTestSubmissions;
+    filters.createdAtFrom = args.createdAtFrom || undefined;
+    filters.createdAtTo = args.createdAtTo || undefined;
+    filters.completedAtFrom = args.completedAtFrom || undefined;
+    filters.completedAtTo = args.completedAtTo || undefined;
+  }
+
+  return filters;
+}
+
+function ExportDateRangeFieldset({
+  legend,
+  fromId,
+  toId,
+  errorId,
+  fromValue,
+  toValue,
+  error,
+  disabled,
+  onFromChange,
+  onToChange,
+}: Readonly<{
+  legend: string;
+  fromId: string;
+  toId: string;
+  errorId: string;
+  fromValue: string;
+  toValue: string;
+  error: string | null;
+  disabled: boolean;
+  onFromChange: (value: string) => void;
+  onToChange: (value: string) => void;
+}>) {
+  const hasError = error != null;
+
+  return (
+    <fieldset className="grid gap-2">
+      <legend className="text-sm font-medium">{legend}</legend>
+      <div className="grid grid-cols-2 gap-2">
+        <div className="grid gap-1">
+          <Label htmlFor={fromId} className="text-xs text-muted-foreground">
+            From
+          </Label>
+          <Input
+            id={fromId}
+            type="date"
+            value={fromValue}
+            onChange={(event) => onFromChange(event.target.value)}
+            disabled={disabled}
+            aria-invalid={hasError}
+            aria-describedby={hasError ? errorId : undefined}
+          />
+        </div>
+        <div className="grid gap-1">
+          <Label htmlFor={toId} className="text-xs text-muted-foreground">
+            To
+          </Label>
+          <Input
+            id={toId}
+            type="date"
+            value={toValue}
+            onChange={(event) => onToChange(event.target.value)}
+            disabled={disabled}
+            aria-invalid={hasError}
+            aria-describedby={hasError ? errorId : undefined}
+          />
+        </div>
+      </div>
+      {hasError ? (
+        <p id={errorId} className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </fieldset>
+  );
 }
 
 export function ExportSubmissionsDialog({
@@ -146,44 +276,30 @@ export function ExportSubmissionsDialog({
       return;
     }
 
-    const nextCreatedAtError =
-      showRowFilters &&
-      createdAtFrom &&
-      createdAtTo &&
-      createdAtFrom > createdAtTo
-        ? CREATED_AT_RANGE_ERROR
-        : null;
-    const nextCompletedAtError =
-      showRowFilters &&
-      completedAtFrom &&
-      completedAtTo &&
-      completedAtFrom > completedAtTo
-        ? COMPLETED_AT_RANGE_ERROR
-        : null;
+    const rangeErrors = resolveDateRangeErrors({
+      showRowFilters,
+      createdAtFrom,
+      createdAtTo,
+      completedAtFrom,
+      completedAtTo,
+    });
+    setCreatedAtRangeError(rangeErrors.createdAtRangeError);
+    setCompletedAtRangeError(rangeErrors.completedAtRangeError);
 
-    setCreatedAtRangeError(nextCreatedAtError);
-    setCompletedAtRangeError(nextCompletedAtError);
-
-    if (nextCreatedAtError || nextCompletedAtError) {
+    if (rangeErrors.createdAtRangeError || rangeErrors.completedAtRangeError) {
       return;
     }
 
-    const filters: SubmissionExportListFilters = {};
-
-    if (showLocaleField) {
-      const trimmedLocale = locale.trim();
-      if (trimmedLocale && trimmedLocale !== "default") {
-        filters.locale = trimmedLocale;
-      }
-    }
-
-    if (showRowFilters) {
-      filters.includeTestSubmissions = includeTestSubmissions;
-      filters.createdAtFrom = createdAtFrom || undefined;
-      filters.createdAtTo = createdAtTo || undefined;
-      filters.completedAtFrom = completedAtFrom || undefined;
-      filters.completedAtTo = completedAtTo || undefined;
-    }
+    const filters = buildExportFilters({
+      showLocaleField,
+      showRowFilters,
+      locale,
+      includeTestSubmissions,
+      createdAtFrom,
+      createdAtTo,
+      completedAtFrom,
+      completedAtTo,
+    });
 
     try {
       const succeeded = await onExport({
@@ -295,131 +411,43 @@ export function ExportSubmissionsDialog({
                   </Label>
                 </div>
 
-                <fieldset className="grid gap-2">
-                  <legend className="text-sm font-medium">Created at</legend>
-                  <div className="grid grid-cols-2 gap-2">
-                    <div className="grid gap-1">
-                      <Label
-                        htmlFor="export-submissions-created-from"
-                        className="text-xs text-muted-foreground"
-                      >
-                        From
-                      </Label>
-                      <Input
-                        id="export-submissions-created-from"
-                        type="date"
-                        value={createdAtFrom}
-                        onChange={(event) => {
-                          setCreatedAtFrom(event.target.value);
-                          setCreatedAtRangeError(null);
-                        }}
-                        disabled={isExporting}
-                        aria-invalid={createdAtRangeError != null}
-                        aria-describedby={
-                          createdAtRangeError
-                            ? "export-submissions-created-range-error"
-                            : undefined
-                        }
-                      />
-                    </div>
-                    <div className="grid gap-1">
-                      <Label
-                        htmlFor="export-submissions-created-to"
-                        className="text-xs text-muted-foreground"
-                      >
-                        To
-                      </Label>
-                      <Input
-                        id="export-submissions-created-to"
-                        type="date"
-                        value={createdAtTo}
-                        onChange={(event) => {
-                          setCreatedAtTo(event.target.value);
-                          setCreatedAtRangeError(null);
-                        }}
-                        disabled={isExporting}
-                        aria-invalid={createdAtRangeError != null}
-                        aria-describedby={
-                          createdAtRangeError
-                            ? "export-submissions-created-range-error"
-                            : undefined
-                        }
-                      />
-                    </div>
-                  </div>
-                  {createdAtRangeError ? (
-                    <p
-                      id="export-submissions-created-range-error"
-                      className="text-sm text-destructive"
-                      role="alert"
-                    >
-                      {createdAtRangeError}
-                    </p>
-                  ) : null}
-                </fieldset>
+                <ExportDateRangeFieldset
+                  legend="Created at"
+                  fromId="export-submissions-created-from"
+                  toId="export-submissions-created-to"
+                  errorId="export-submissions-created-range-error"
+                  fromValue={createdAtFrom}
+                  toValue={createdAtTo}
+                  error={createdAtRangeError}
+                  disabled={isExporting}
+                  onFromChange={(value) => {
+                    setCreatedAtFrom(value);
+                    setCreatedAtRangeError(null);
+                  }}
+                  onToChange={(value) => {
+                    setCreatedAtTo(value);
+                    setCreatedAtRangeError(null);
+                  }}
+                />
 
-                <fieldset className="grid gap-2">
-                  <legend className="text-sm font-medium">Completed at</legend>
-                  <div className="grid grid-cols-2 gap-2">
-                    <div className="grid gap-1">
-                      <Label
-                        htmlFor="export-submissions-completed-from"
-                        className="text-xs text-muted-foreground"
-                      >
-                        From
-                      </Label>
-                      <Input
-                        id="export-submissions-completed-from"
-                        type="date"
-                        value={completedAtFrom}
-                        onChange={(event) => {
-                          setCompletedAtFrom(event.target.value);
-                          setCompletedAtRangeError(null);
-                        }}
-                        disabled={isExporting}
-                        aria-invalid={completedAtRangeError != null}
-                        aria-describedby={
-                          completedAtRangeError
-                            ? "export-submissions-completed-range-error"
-                            : undefined
-                        }
-                      />
-                    </div>
-                    <div className="grid gap-1">
-                      <Label
-                        htmlFor="export-submissions-completed-to"
-                        className="text-xs text-muted-foreground"
-                      >
-                        To
-                      </Label>
-                      <Input
-                        id="export-submissions-completed-to"
-                        type="date"
-                        value={completedAtTo}
-                        onChange={(event) => {
-                          setCompletedAtTo(event.target.value);
-                          setCompletedAtRangeError(null);
-                        }}
-                        disabled={isExporting}
-                        aria-invalid={completedAtRangeError != null}
-                        aria-describedby={
-                          completedAtRangeError
-                            ? "export-submissions-completed-range-error"
-                            : undefined
-                        }
-                      />
-                    </div>
-                  </div>
-                  {completedAtRangeError ? (
-                    <p
-                      id="export-submissions-completed-range-error"
-                      className="text-sm text-destructive"
-                      role="alert"
-                    >
-                      {completedAtRangeError}
-                    </p>
-                  ) : null}
-                </fieldset>
+                <ExportDateRangeFieldset
+                  legend="Completed at"
+                  fromId="export-submissions-completed-from"
+                  toId="export-submissions-completed-to"
+                  errorId="export-submissions-completed-range-error"
+                  fromValue={completedAtFrom}
+                  toValue={completedAtTo}
+                  error={completedAtRangeError}
+                  disabled={isExporting}
+                  onFromChange={(value) => {
+                    setCompletedAtFrom(value);
+                    setCompletedAtRangeError(null);
+                  }}
+                  onToChange={(value) => {
+                    setCompletedAtTo(value);
+                    setCompletedAtRangeError(null);
+                  }}
+                />
               </>
             ) : (
               <p className="text-xs text-muted-foreground">

--- a/features/export/export-submissions/ui/custom-export-dialog.tsx
+++ b/features/export/export-submissions/ui/custom-export-dialog.tsx
@@ -23,7 +23,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/loaders/spinner";
-import { toast } from "@/components/ui/toast";
 import { useTrackEvent } from "@/features/analytics/posthog/client";
 import type { ExportTarget } from "@/lib/endatix-api/reporting/reporting";
 import {
@@ -31,6 +30,11 @@ import {
   type SubmissionExportListFilters,
 } from "../../export-url";
 import type { TenantExportOptionGroup } from "../map-tenant-export-options";
+
+const CREATED_AT_RANGE_ERROR =
+  "Created From must be on or before Created To.";
+const COMPLETED_AT_RANGE_ERROR =
+  "Completed From must be on or before Completed To.";
 
 export interface ExportSubmissionsDialogProps {
   open: boolean;
@@ -82,6 +86,12 @@ export function ExportSubmissionsDialog({
   const [completedAtFrom, setCompletedAtFrom] = useState("");
   const [completedAtTo, setCompletedAtTo] = useState("");
   const [locale, setLocale] = useState("default");
+  const [createdAtRangeError, setCreatedAtRangeError] = useState<string | null>(
+    null,
+  );
+  const [completedAtRangeError, setCompletedAtRangeError] = useState<
+    string | null
+  >(null);
 
   const options = useMemo(
     () => groups.flatMap((group) => group.options),
@@ -124,6 +134,8 @@ export function ExportSubmissionsDialog({
     setCompletedAtFrom(listFilters?.completedAtFrom ?? "");
     setCompletedAtTo(listFilters?.completedAtTo ?? "");
     setLocale(listFilters?.locale?.trim() || "default");
+    setCreatedAtRangeError(null);
+    setCompletedAtRangeError(null);
   }, [open, options, listFilters]);
 
   const showGroupLabels = groups.length > 1;
@@ -134,29 +146,25 @@ export function ExportSubmissionsDialog({
       return;
     }
 
-    if (
+    const nextCreatedAtError =
       showRowFilters &&
       createdAtFrom &&
       createdAtTo &&
       createdAtFrom > createdAtTo
-    ) {
-      toast.error({
-        title: "Invalid date range",
-        description: "Created From must be on or before Created To.",
-      });
-      return;
-    }
-
-    if (
+        ? CREATED_AT_RANGE_ERROR
+        : null;
+    const nextCompletedAtError =
       showRowFilters &&
       completedAtFrom &&
       completedAtTo &&
       completedAtFrom > completedAtTo
-    ) {
-      toast.error({
-        title: "Invalid date range",
-        description: "Completed From must be on or before Completed To.",
-      });
+        ? COMPLETED_AT_RANGE_ERROR
+        : null;
+
+    setCreatedAtRangeError(nextCreatedAtError);
+    setCompletedAtRangeError(nextCompletedAtError);
+
+    if (nextCreatedAtError || nextCompletedAtError) {
       return;
     }
 
@@ -301,10 +309,17 @@ export function ExportSubmissionsDialog({
                         id="export-submissions-created-from"
                         type="date"
                         value={createdAtFrom}
-                        onChange={(event) =>
-                          setCreatedAtFrom(event.target.value)
-                        }
+                        onChange={(event) => {
+                          setCreatedAtFrom(event.target.value);
+                          setCreatedAtRangeError(null);
+                        }}
                         disabled={isExporting}
+                        aria-invalid={createdAtRangeError != null}
+                        aria-describedby={
+                          createdAtRangeError
+                            ? "export-submissions-created-range-error"
+                            : undefined
+                        }
                       />
                     </div>
                     <div className="grid gap-1">
@@ -318,11 +333,29 @@ export function ExportSubmissionsDialog({
                         id="export-submissions-created-to"
                         type="date"
                         value={createdAtTo}
-                        onChange={(event) => setCreatedAtTo(event.target.value)}
+                        onChange={(event) => {
+                          setCreatedAtTo(event.target.value);
+                          setCreatedAtRangeError(null);
+                        }}
                         disabled={isExporting}
+                        aria-invalid={createdAtRangeError != null}
+                        aria-describedby={
+                          createdAtRangeError
+                            ? "export-submissions-created-range-error"
+                            : undefined
+                        }
                       />
                     </div>
                   </div>
+                  {createdAtRangeError ? (
+                    <p
+                      id="export-submissions-created-range-error"
+                      className="text-sm text-destructive"
+                      role="alert"
+                    >
+                      {createdAtRangeError}
+                    </p>
+                  ) : null}
                 </fieldset>
 
                 <fieldset className="grid gap-2">
@@ -339,10 +372,17 @@ export function ExportSubmissionsDialog({
                         id="export-submissions-completed-from"
                         type="date"
                         value={completedAtFrom}
-                        onChange={(event) =>
-                          setCompletedAtFrom(event.target.value)
-                        }
+                        onChange={(event) => {
+                          setCompletedAtFrom(event.target.value);
+                          setCompletedAtRangeError(null);
+                        }}
                         disabled={isExporting}
+                        aria-invalid={completedAtRangeError != null}
+                        aria-describedby={
+                          completedAtRangeError
+                            ? "export-submissions-completed-range-error"
+                            : undefined
+                        }
                       />
                     </div>
                     <div className="grid gap-1">
@@ -356,13 +396,29 @@ export function ExportSubmissionsDialog({
                         id="export-submissions-completed-to"
                         type="date"
                         value={completedAtTo}
-                        onChange={(event) =>
-                          setCompletedAtTo(event.target.value)
-                        }
+                        onChange={(event) => {
+                          setCompletedAtTo(event.target.value);
+                          setCompletedAtRangeError(null);
+                        }}
                         disabled={isExporting}
+                        aria-invalid={completedAtRangeError != null}
+                        aria-describedby={
+                          completedAtRangeError
+                            ? "export-submissions-completed-range-error"
+                            : undefined
+                        }
                       />
                     </div>
                   </div>
+                  {completedAtRangeError ? (
+                    <p
+                      id="export-submissions-completed-range-error"
+                      className="text-sm text-destructive"
+                      role="alert"
+                    >
+                      {completedAtRangeError}
+                    </p>
+                  ) : null}
                 </fieldset>
               </>
             ) : (

--- a/features/export/export-submissions/ui/export-submissions-button.tsx
+++ b/features/export/export-submissions/ui/export-submissions-button.tsx
@@ -67,7 +67,8 @@ function ReportingExportSubmissionsButton({
   listFilters,
 }: Readonly<Omit<ExportSubmissionsButtonProps, "useReportingExport">>) {
   const { isExporting, runExport } = useSubmissionsExport();
-  const { groups, isLoading, isEmpty, loadError } = useTenantExportFormats();
+  const { options, groups, isLoading, isEmpty, loadError } =
+    useTenantExportFormats();
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const handleExport = async (
@@ -76,8 +77,12 @@ function ReportingExportSubmissionsButton({
     exportFormatId: string,
     fallbackExtension: string,
     filters: SubmissionExportListFilters,
-  ): Promise<boolean> =>
-    runExport({
+  ): Promise<boolean> => {
+    const selected = options.find(
+      (option) => option.exportFormatId === exportFormatId,
+    );
+
+    return runExport({
       exportName,
       fallbackFilename: `form-${formId}-submissions.${fallbackExtension}`,
       url: buildReportingExportUrl({
@@ -85,9 +90,10 @@ function ReportingExportSubmissionsButton({
         wireKey,
         exportFormatId,
         listFilters: filters,
+        allowedFilters: selected?.allowedFilters,
       }),
     });
-
+  };
   if (isLoading) {
     return (
       <Button variant="outline" disabled className={className}>

--- a/features/export/export-submissions/ui/export-submissions-button.tsx
+++ b/features/export/export-submissions/ui/export-submissions-button.tsx
@@ -19,15 +19,18 @@ import { Result } from "@/lib/result";
 import {
   buildLegacyExportUrl,
   buildReportingExportUrl,
+  type SubmissionExportListFilters,
 } from "../../export-url";
 import { useSubmissionsExport } from "../use-submissions-export.hook";
 import { useTenantExportFormats } from "../use-tenant-export-formats.hook";
+import { ExportSubmissionsDialog } from "./custom-export-dialog";
 
 interface ExportSubmissionsButtonProps {
   formId: string;
   className?: string;
   disabled?: boolean;
   useReportingExport?: boolean;
+  listFilters?: SubmissionExportListFilters;
 }
 
 export function ExportSubmissionsButton({
@@ -35,6 +38,7 @@ export function ExportSubmissionsButton({
   className,
   disabled = false,
   useReportingExport = false,
+  listFilters,
 }: Readonly<ExportSubmissionsButtonProps>) {
   if (useReportingExport) {
     return (
@@ -42,6 +46,7 @@ export function ExportSubmissionsButton({
         formId={formId}
         className={className}
         disabled={disabled}
+        listFilters={listFilters}
       />
     );
   }
@@ -59,20 +64,28 @@ function ReportingExportSubmissionsButton({
   formId,
   className,
   disabled,
+  listFilters,
 }: Readonly<Omit<ExportSubmissionsButtonProps, "useReportingExport">>) {
-  const { currentExportName, isExporting, runExport } = useSubmissionsExport();
+  const { isExporting, runExport } = useSubmissionsExport();
   const { groups, isLoading, isEmpty, loadError } = useTenantExportFormats();
+  const [dialogOpen, setDialogOpen] = useState(false);
 
-  const handleExport = (
+  const handleExport = async (
     wireKey: string,
     exportName: string,
     exportFormatId: string,
     fallbackExtension: string,
-  ) =>
+    filters: SubmissionExportListFilters,
+  ): Promise<boolean> =>
     runExport({
       exportName,
       fallbackFilename: `form-${formId}-submissions.${fallbackExtension}`,
-      url: buildReportingExportUrl(formId, wireKey, exportFormatId),
+      url: buildReportingExportUrl({
+        formId,
+        wireKey,
+        exportFormatId,
+        listFilters: filters,
+      }),
     });
 
   if (isLoading) {
@@ -101,60 +114,48 @@ function ReportingExportSubmissionsButton({
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          disabled={disabled || isExporting}
-          className={className}
-          title={loadError ?? undefined}
-        >
-          {isExporting ? (
-            <Spinner className="mr-2 h-4 w-4" />
-          ) : (
-            <Download className="mr-2 h-4 w-4" />
-          )}
-          {isExporting ? "Exporting..." : "Export Submissions"}
-          <ChevronDown className="ml-2 h-4 w-4" />
-        </Button>
-      </DropdownMenuTrigger>
+    <>
+      <Button
+        variant="outline"
+        disabled={disabled || isExporting}
+        className={className}
+        title={loadError ?? undefined}
+        onClick={() => setDialogOpen(true)}
+      >
+        {isExporting ? (
+          <Spinner className="mr-2 h-4 w-4" />
+        ) : (
+          <Download className="mr-2 h-4 w-4" />
+        )}
+        {isExporting ? "Exporting..." : "Export Submissions"}
+      </Button>
 
-      <DropdownMenuContent align="end">
-        {groups.map((group, groupIndex) => (
-          <div key={group.target}>
-            {groupIndex > 0 ? <DropdownMenuSeparator /> : null}
-            {groups.length > 1 ? (
-              <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
-                {group.label}
-              </div>
-            ) : null}
-            {group.options.map(
-              ({ wireKey, label, exportFormatId, fallbackExtension }) => (
-                <DropdownMenuItem
-                  key={exportFormatId}
-                  onClick={() =>
-                    handleExport(
-                      wireKey,
-                      label,
-                      exportFormatId,
-                      fallbackExtension,
-                    )
-                  }
-                  disabled={disabled || isExporting}
-                >
-                  {isExporting && currentExportName === label ? (
-                    <Spinner className="mr-2 h-4 w-4" />
-                  ) : (
-                    <Download className="mr-2 h-4 w-4" />
-                  )}
-                  {label}
-                </DropdownMenuItem>
-              ),
-            )}
-          </div>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+      <ExportSubmissionsDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        groups={groups}
+        listFilters={listFilters}
+        isExporting={isExporting}
+        onExport={async ({
+          wireKey,
+          exportName,
+          exportFormatId,
+          fallbackExtension,
+          filters,
+        }) => {
+          const succeeded = await handleExport(
+            wireKey,
+            exportName,
+            exportFormatId,
+            fallbackExtension,
+            filters,
+          );
+          if (succeeded) {
+            setDialogOpen(false);
+          }
+        }}
+      />
+    </>
   );
 }
 

--- a/features/export/export-submissions/ui/export-submissions-button.tsx
+++ b/features/export/export-submissions/ui/export-submissions-button.tsx
@@ -153,6 +153,7 @@ function ReportingExportSubmissionsButton({
           if (succeeded) {
             setDialogOpen(false);
           }
+          return succeeded;
         }}
       />
     </>

--- a/features/export/export-submissions/use-submissions-export.hook.ts
+++ b/features/export/export-submissions/use-submissions-export.hook.ts
@@ -31,7 +31,7 @@ export function useSubmissionsExport() {
     exportName = null,
     fallbackFilename,
     url,
-  }: RunSubmissionsExportOptions) => {
+  }: RunSubmissionsExportOptions): Promise<boolean> => {
     try {
       setIsExporting(true);
       setCurrentExportName(exportName);
@@ -47,12 +47,14 @@ export function useSubmissionsExport() {
         title: "Export successful",
         description: "Your file has been downloaded successfully.",
       });
+      return true;
     } catch (error) {
       console.error("Export failed:", error);
       toast.error({
         title: "Export failed",
         description: getExportFailureMessage(error),
       });
+      return false;
     } finally {
       setIsExporting(false);
       setCurrentExportName(null);

--- a/features/export/export-submissions/use-submissions-export.hook.ts
+++ b/features/export/export-submissions/use-submissions-export.hook.ts
@@ -2,8 +2,11 @@
 
 import { useState } from "react";
 import { toast } from "@/components/ui/toast";
+import { TelemetryLogger } from "@/features/telemetry";
 import { getExportFailureMessage } from "../export-error-message";
 import { downloadSubmissionsExport } from "./download-submissions-export";
+
+const LOGGER_NAME = "export.submissions-export";
 
 /**
  * Options for running a submissions export.
@@ -49,7 +52,16 @@ export function useSubmissionsExport() {
       });
       return true;
     } catch (error) {
-      console.error("Export failed:", error);
+      TelemetryLogger.error(
+        "Submissions export failed",
+        undefined,
+        {
+          "export.has_name": Boolean(exportName?.trim()),
+          "export.fallback_filename_length": fallbackFilename.length,
+          "error.type": error instanceof Error ? error.name : typeof error,
+        },
+        LOGGER_NAME,
+      );
       toast.error({
         title: "Export failed",
         description: getExportFailureMessage(error),

--- a/features/export/export-submissions/use-tenant-export-formats.hook.ts
+++ b/features/export/export-submissions/use-tenant-export-formats.hook.ts
@@ -31,7 +31,12 @@ export function useTenantExportFormats() {
       }
 
       if (Result.isSuccess(result)) {
-        setOptions(mapFormatsToTenantExportOptions(result.value));
+        setOptions(
+          mapFormatsToTenantExportOptions(
+            result.value.formats,
+            result.value.capabilities,
+          ),
+        );
       } else {
         setOptions([]);
         setLoadError(result.message);

--- a/features/export/export-url.ts
+++ b/features/export/export-url.ts
@@ -4,7 +4,8 @@ import {
 } from "@/lib/endatix-api/submissions/submission-list-query-params";
 
 /** Query param / capability filter name for including test submissions. */
-export const INCLUDE_TEST_SUBMISSIONS_FILTER = "includeTestSubmissions" as const;
+export const INCLUDE_TEST_SUBMISSIONS_FILTER =
+  "includeTestSubmissions" as const;
 
 /** Wire names from ExportCapabilityDto.allowedFilters (Reporting API). */
 export type ExportRequestFilter =
@@ -116,6 +117,102 @@ function appendCalendarRange(
   }
 }
 
+function appendIncludeTestSubmissionsFilter(
+  params: URLSearchParams,
+  filters: SubmissionExportListFilters,
+): void {
+  if (filters.includeTestSubmissions !== undefined) {
+    params.set(
+      INCLUDE_TEST_SUBMISSIONS_FILTER,
+      String(filters.includeTestSubmissions),
+    );
+    return;
+  }
+
+  if (filters.isTestSubmission === undefined) {
+    return;
+  }
+
+  const includeTest = mapIncludeTestSubmissions(filters.isTestSubmission);
+  if (includeTest !== undefined) {
+    params.set(INCLUDE_TEST_SUBMISSIONS_FILTER, String(includeTest));
+  }
+}
+
+function appendSubmissionIdRangeFilter(
+  params: URLSearchParams,
+  filters: SubmissionExportListFilters,
+): void {
+  if (filters.minSubmissionId) {
+    params.set("minSubmissionId", filters.minSubmissionId);
+  }
+  if (filters.maxSubmissionId) {
+    params.set("maxSubmissionId", filters.maxSubmissionId);
+  }
+}
+
+function appendAllowedListFilters(
+  params: URLSearchParams,
+  filters: SubmissionExportListFilters,
+  allowedFilters: ReadonlyArray<string> | undefined,
+  wireKey: string,
+): void {
+  if (allowsFilter(allowedFilters, INCLUDE_TEST_SUBMISSIONS_FILTER, wireKey)) {
+    appendIncludeTestSubmissionsFilter(params, filters);
+  }
+
+  if (allowsFilter(allowedFilters, "createdAtRange", wireKey)) {
+    appendCalendarRange(
+      params,
+      "createdAfter",
+      "createdBefore",
+      filters.createdAtFrom,
+      filters.createdAtTo,
+    );
+  }
+
+  if (allowsFilter(allowedFilters, "completedAtRange", wireKey)) {
+    appendCalendarRange(
+      params,
+      "completedAfter",
+      "completedBefore",
+      filters.completedAtFrom,
+      filters.completedAtTo,
+    );
+  }
+
+  if (allowsFilter(allowedFilters, "submissionIdRange", wireKey)) {
+    appendSubmissionIdRangeFilter(params, filters);
+  }
+
+  if (
+    allowsFilter(allowedFilters, "locale", wireKey) &&
+    filters.locale?.trim()
+  ) {
+    params.set("locale", filters.locale.trim());
+  }
+}
+
+function toReportingExportUrlOptions(
+  formIdOrOptions: string | ReportingExportUrlOptions,
+  wireKey?: string,
+  exportFormatId?: string,
+  listFilters?: SubmissionExportListFilters,
+  allowedFilters?: ReadonlyArray<string>,
+): ReportingExportUrlOptions {
+  if (typeof formIdOrOptions !== "string") {
+    return formIdOrOptions;
+  }
+
+  return {
+    formId: formIdOrOptions,
+    wireKey: wireKey!,
+    exportFormatId: exportFormatId!,
+    listFilters,
+    allowedFilters,
+  };
+}
+
 export function buildReportingExportUrl(
   formId: string,
   wireKey: string,
@@ -133,75 +230,26 @@ export function buildReportingExportUrl(
   listFilters?: SubmissionExportListFilters,
   allowedFilters?: ReadonlyArray<string>,
 ): string {
-  const options: ReportingExportUrlOptions =
-    typeof formIdOrOptions === "string"
-      ? {
-          formId: formIdOrOptions,
-          wireKey: wireKey!,
-          exportFormatId: exportFormatId!,
-          listFilters,
-          allowedFilters,
-        }
-      : formIdOrOptions;
+  const options = toReportingExportUrlOptions(
+    formIdOrOptions,
+    wireKey,
+    exportFormatId,
+    listFilters,
+    allowedFilters,
+  );
 
   const params = new URLSearchParams({
     format: options.wireKey,
     exportFormatId: options.exportFormatId,
   });
 
-  const filters = options.listFilters;
-  if (!filters) {
-    return `/api/forms/${options.formId}/export?${params.toString()}`;
-  }
-
-  const allowed = options.allowedFilters;
-  const wireKeyValue = options.wireKey;
-
-  if (allowsFilter(allowed, INCLUDE_TEST_SUBMISSIONS_FILTER, wireKeyValue)) {
-    if (filters.includeTestSubmissions !== undefined) {
-      params.set(
-        INCLUDE_TEST_SUBMISSIONS_FILTER,
-        String(filters.includeTestSubmissions),
-      );
-    } else if (filters.isTestSubmission !== undefined) {
-      const includeTest = mapIncludeTestSubmissions(filters.isTestSubmission);
-      if (includeTest !== undefined) {
-        params.set(INCLUDE_TEST_SUBMISSIONS_FILTER, String(includeTest));
-      }
-    }
-  }
-
-  if (allowsFilter(allowed, "createdAtRange", wireKeyValue)) {
-    appendCalendarRange(
+  if (options.listFilters) {
+    appendAllowedListFilters(
       params,
-      "createdAfter",
-      "createdBefore",
-      filters.createdAtFrom,
-      filters.createdAtTo,
+      options.listFilters,
+      options.allowedFilters,
+      options.wireKey,
     );
-  }
-
-  if (allowsFilter(allowed, "completedAtRange", wireKeyValue)) {
-    appendCalendarRange(
-      params,
-      "completedAfter",
-      "completedBefore",
-      filters.completedAtFrom,
-      filters.completedAtTo,
-    );
-  }
-
-  if (allowsFilter(allowed, "submissionIdRange", wireKeyValue)) {
-    if (filters.minSubmissionId) {
-      params.set("minSubmissionId", filters.minSubmissionId);
-    }
-    if (filters.maxSubmissionId) {
-      params.set("maxSubmissionId", filters.maxSubmissionId);
-    }
-  }
-
-  if (allowsFilter(allowed, "locale", wireKeyValue) && filters.locale?.trim()) {
-    params.set("locale", filters.locale.trim());
   }
 
   return `/api/forms/${options.formId}/export?${params.toString()}`;

--- a/features/export/export-url.ts
+++ b/features/export/export-url.ts
@@ -1,14 +1,210 @@
+import {
+  utcCalendarDayStartIso,
+  utcCalendarNextDayStartIso,
+} from "@/lib/endatix-api/submissions/submission-list-query-params";
+
+/** Query param / capability filter name for including test submissions. */
+export const INCLUDE_TEST_SUBMISSIONS_FILTER = "includeTestSubmissions" as const;
+
+/** Wire names from ExportCapabilityDto.allowedFilters (Reporting API). */
+export type ExportRequestFilter =
+  | typeof INCLUDE_TEST_SUBMISSIONS_FILTER
+  | "createdAtRange"
+  | "completedAtRange"
+  | "submissionIdRange"
+  | "locale"
+  | "columnScope";
+
+export const CODEBOOK_WIRE_KEYS: ReadonlySet<string> = new Set([
+  "codebook",
+  "codebook-shoji",
+]);
+
+export function isCodebookWireKey(wireKey: string): boolean {
+  return CODEBOOK_WIRE_KEYS.has(wireKey);
+}
+
+/** Filters inherited from the submissions list URL or custom export dialog. */
+export interface SubmissionExportListFilters {
+  isTestSubmission?: string[];
+  /** Explicit override (custom export dialog). Wins over `isTestSubmission` mapping. */
+  includeTestSubmissions?: boolean;
+  createdAtFrom?: string;
+  createdAtTo?: string;
+  completedAtFrom?: string;
+  completedAtTo?: string;
+  minSubmissionId?: string;
+  maxSubmissionId?: string;
+  locale?: string;
+}
+
+export interface ReportingExportUrlOptions {
+  formId: string;
+  wireKey: string;
+  exportFormatId: string;
+  allowedFilters?: ReadonlyArray<string>;
+  listFilters?: SubmissionExportListFilters;
+}
+
+function allowsFilter(
+  allowedFilters: ReadonlyArray<string> | undefined,
+  filter: ExportRequestFilter,
+  wireKey: string,
+): boolean {
+  if (allowedFilters !== undefined) {
+    return allowedFilters.includes(filter);
+  }
+
+  // Fallback when capabilities are not loaded.
+  if (wireKey === "codebook") {
+    return false;
+  }
+
+  if (wireKey === "codebook-shoji") {
+    return filter === "locale";
+  }
+
+  return true;
+}
+
+/**
+ * Maps grid isTestSubmission multi-select to export override.
+ * Production-only → false. Empty / test-only / both → undefined (no test-only API mode).
+ */
+export function mapIncludeTestSubmissions(
+  isTestSubmission: string[] | undefined,
+): boolean | undefined {
+  if (!isTestSubmission || isTestSubmission.length === 0) {
+    return undefined;
+  }
+
+  const hasTrue = isTestSubmission.includes("true");
+  const hasFalse = isTestSubmission.includes("false");
+  if (hasFalse && !hasTrue) {
+    return false;
+  }
+
+  return undefined;
+}
+
+function isValidCalendarDateYmd(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+function appendCalendarRange(
+  params: URLSearchParams,
+  fromKey: string,
+  toKey: string,
+  from: string | undefined,
+  to: string | undefined,
+): void {
+  if (from && isValidCalendarDateYmd(from)) {
+    params.set(fromKey, utcCalendarDayStartIso(from));
+  }
+  if (to && isValidCalendarDateYmd(to)) {
+    params.set(toKey, utcCalendarNextDayStartIso(to));
+  }
+}
+
 export function buildReportingExportUrl(
   formId: string,
   wireKey: string,
   exportFormatId: string,
+  listFilters?: SubmissionExportListFilters,
+  allowedFilters?: ReadonlyArray<string>,
+): string;
+export function buildReportingExportUrl(
+  options: ReportingExportUrlOptions,
+): string;
+export function buildReportingExportUrl(
+  formIdOrOptions: string | ReportingExportUrlOptions,
+  wireKey?: string,
+  exportFormatId?: string,
+  listFilters?: SubmissionExportListFilters,
+  allowedFilters?: ReadonlyArray<string>,
 ): string {
+  const options: ReportingExportUrlOptions =
+    typeof formIdOrOptions === "string"
+      ? {
+          formId: formIdOrOptions,
+          wireKey: wireKey!,
+          exportFormatId: exportFormatId!,
+          listFilters,
+          allowedFilters,
+        }
+      : formIdOrOptions;
+
   const params = new URLSearchParams({
-    format: wireKey,
-    exportFormatId,
+    format: options.wireKey,
+    exportFormatId: options.exportFormatId,
   });
 
-  return `/api/forms/${formId}/export?${params.toString()}`;
+  const filters = options.listFilters;
+  if (!filters) {
+    return `/api/forms/${options.formId}/export?${params.toString()}`;
+  }
+
+  const allowed = options.allowedFilters;
+  const wireKeyValue = options.wireKey;
+
+  if (allowsFilter(allowed, INCLUDE_TEST_SUBMISSIONS_FILTER, wireKeyValue)) {
+    if (filters.includeTestSubmissions !== undefined) {
+      params.set(
+        INCLUDE_TEST_SUBMISSIONS_FILTER,
+        String(filters.includeTestSubmissions),
+      );
+    } else if (filters.isTestSubmission !== undefined) {
+      const includeTest = mapIncludeTestSubmissions(filters.isTestSubmission);
+      if (includeTest !== undefined) {
+        params.set(INCLUDE_TEST_SUBMISSIONS_FILTER, String(includeTest));
+      }
+    }
+  }
+
+  if (allowsFilter(allowed, "createdAtRange", wireKeyValue)) {
+    appendCalendarRange(
+      params,
+      "createdAfter",
+      "createdBefore",
+      filters.createdAtFrom,
+      filters.createdAtTo,
+    );
+  }
+
+  if (allowsFilter(allowed, "completedAtRange", wireKeyValue)) {
+    appendCalendarRange(
+      params,
+      "completedAfter",
+      "completedBefore",
+      filters.completedAtFrom,
+      filters.completedAtTo,
+    );
+  }
+
+  if (allowsFilter(allowed, "submissionIdRange", wireKeyValue)) {
+    if (filters.minSubmissionId) {
+      params.set("minSubmissionId", filters.minSubmissionId);
+    }
+    if (filters.maxSubmissionId) {
+      params.set("maxSubmissionId", filters.maxSubmissionId);
+    }
+  }
+
+  if (allowsFilter(allowed, "locale", wireKeyValue) && filters.locale?.trim()) {
+    params.set("locale", filters.locale.trim());
+  }
+
+  return `/api/forms/${options.formId}/export?${params.toString()}`;
 }
 
 export function buildLegacyExportUrl(

--- a/features/export/manage-export-formats/list-export-formats.action.ts
+++ b/features/export/manage-export-formats/list-export-formats.action.ts
@@ -3,7 +3,11 @@
 import { auth } from "@/auth";
 import { authorization, Permissions } from "@/features/auth/authorization";
 import { EndatixApi } from "@/lib/endatix-api";
-import type { ExportFormatListItem } from "@/lib/endatix-api/reporting/reporting";
+import { normalizeExportCapabilities } from "@/lib/endatix-api/reporting/normalize-export-capabilities";
+import type {
+  ExportCapabilityDto,
+  ExportFormatListItem,
+} from "@/lib/endatix-api/reporting/reporting";
 import { reportingExportFlag } from "@/lib/feature-flags/flags";
 import { Result } from "@/lib/result";
 import { toResult } from "@/lib/result/map-api-result-to-result";
@@ -11,8 +15,13 @@ import { toResult } from "@/lib/result/map-api-result-to-result";
 const REPORTING_EXPORT_DISABLED_MESSAGE =
   "Reporting export is not enabled for this environment.";
 
+export interface TenantExportFormatsCatalog {
+  formats: ExportFormatListItem[];
+  capabilities: ExportCapabilityDto[];
+}
+
 export async function listTenantExportFormatsAction(): Promise<
-  Result<ExportFormatListItem[]>
+  Result<TenantExportFormatsCatalog>
 > {
   const session = await auth();
   const { evaluatePermissions } = await authorization(session);
@@ -41,11 +50,31 @@ export async function listTenantExportFormatsAction(): Promise<
   }
 
   const api = new EndatixApi(session?.accessToken);
-  const apiResult = await api.reporting.exportFormats.list();
+  const [formatsApiResult, capabilitiesApiResult] = await Promise.all([
+    api.reporting.exportFormats.list(),
+    api.reporting.exportCapabilities.list(),
+  ]);
 
-  return toResult(apiResult, {
+  const formatsResult = toResult(formatsApiResult, {
     fallbackMessage: "Failed to load export formats.",
     logMessage: "Failed to load tenant export formats.",
     loggerName: "export.list-export-formats",
+  });
+  if (Result.isError(formatsResult)) {
+    return formatsResult;
+  }
+
+  const capabilitiesResult = toResult(capabilitiesApiResult, {
+    fallbackMessage: "Failed to load export capabilities.",
+    logMessage: "Failed to load export capabilities for tenant export formats.",
+    loggerName: "export.list-export-formats",
+  });
+  if (Result.isError(capabilitiesResult)) {
+    return capabilitiesResult;
+  }
+
+  return Result.success({
+    formats: formatsResult.value,
+    capabilities: normalizeExportCapabilities(capabilitiesResult.value),
   });
 }

--- a/features/submissions/ui/submissions-with-filters.tsx
+++ b/features/submissions/ui/submissions-with-filters.tsx
@@ -230,6 +230,12 @@ function SubmissionsContent({
             formId={formId}
             disabled={disableTableControls}
             useReportingExport={useReportingExport}
+            listFilters={{
+              createdAtFrom: dateFilters.createdAt?.from,
+              createdAtTo: dateFilters.createdAt?.to,
+              completedAtFrom: dateFilters.completedAt?.from,
+              completedAtTo: dateFilters.completedAt?.to,
+            }}
           />
         </div>
       </div>

--- a/features/submissions/ui/submissions-with-filters.tsx
+++ b/features/submissions/ui/submissions-with-filters.tsx
@@ -71,6 +71,18 @@ const SUBMITTER_FILTER_DEBOUNCE_MS = 300;
 
 type NavigationMode = "push" | "replace";
 
+interface UpdateSubmissionListUrlArgs {
+  isComplete: Set<string>;
+  status: Set<string>;
+  isTestSubmission: Set<string>;
+  submitterDisplayId: string;
+  submitterEmail: string;
+  dates: SubmissionDateFilters;
+  page: number;
+  pageSize: number;
+  navigation?: NavigationMode;
+}
+
 function SubmissionsContent({
   data,
   formId,
@@ -378,17 +390,17 @@ export function SubmissionsWithFilters({
     }
   };
 
-  const updateURL = (
-    isComplete: Set<string>,
-    status: Set<string>,
-    isTestSubmission: Set<string>,
-    submitterDisplayId: string,
-    submitterEmail: string,
-    dates: SubmissionDateFilters,
-    page: number,
-    pageSize: number,
-    navigation: NavigationMode = "push",
-  ) => {
+  const updateURL = ({
+    isComplete,
+    status,
+    isTestSubmission,
+    submitterDisplayId,
+    submitterEmail,
+    dates,
+    page,
+    pageSize,
+    navigation = "push",
+  }: UpdateSubmissionListUrlArgs) => {
     clearPendingSubmitterFilterUpdate();
 
     const listState = submissionListUrlStateFromClientFilters({
@@ -425,17 +437,17 @@ export function SubmissionsWithFilters({
     clearPendingSubmitterFilterUpdate();
 
     submitterFilterDebounceRef.current = setTimeout(() => {
-      updateURL(
-        isCompleteFilter,
-        statusFilter,
-        testSubmissionFilter,
-        nextSubmitterDisplayId,
-        nextSubmitterEmail,
-        dateFilters,
-        1,
-        pagination.pageSize,
-        "replace",
-      );
+      updateURL({
+        isComplete: isCompleteFilter,
+        status: statusFilter,
+        isTestSubmission: testSubmissionFilter,
+        submitterDisplayId: nextSubmitterDisplayId,
+        submitterEmail: nextSubmitterEmail,
+        dates: dateFilters,
+        page: 1,
+        pageSize: pagination.pageSize,
+        navigation: "replace",
+      });
     }, SUBMITTER_FILTER_DEBOUNCE_MS);
   };
 
@@ -446,46 +458,46 @@ export function SubmissionsWithFilters({
   const handleIsCompleteChange = (values: Set<string>) => {
     setIsCompleteFilter(values);
     setPagination((current) => ({ ...current, pageIndex: 0 }));
-    updateURL(
-      values,
-      statusFilter,
-      testSubmissionFilter,
-      submitterDisplayIdFilter,
-      submitterEmailFilter,
-      dateFilters,
-      1,
-      pagination.pageSize,
-    );
+    updateURL({
+      isComplete: values,
+      status: statusFilter,
+      isTestSubmission: testSubmissionFilter,
+      submitterDisplayId: submitterDisplayIdFilter,
+      submitterEmail: submitterEmailFilter,
+      dates: dateFilters,
+      page: 1,
+      pageSize: pagination.pageSize,
+    });
   };
 
   const handleStatusChange = (values: Set<string>) => {
     setStatusFilter(values);
     setPagination((current) => ({ ...current, pageIndex: 0 }));
-    updateURL(
-      isCompleteFilter,
-      values,
-      testSubmissionFilter,
-      submitterDisplayIdFilter,
-      submitterEmailFilter,
-      dateFilters,
-      1,
-      pagination.pageSize,
-    );
+    updateURL({
+      isComplete: isCompleteFilter,
+      status: values,
+      isTestSubmission: testSubmissionFilter,
+      submitterDisplayId: submitterDisplayIdFilter,
+      submitterEmail: submitterEmailFilter,
+      dates: dateFilters,
+      page: 1,
+      pageSize: pagination.pageSize,
+    });
   };
 
   const handleTestSubmissionChange = (values: Set<string>) => {
     setTestSubmissionFilter(values);
     setPagination((current) => ({ ...current, pageIndex: 0 }));
-    updateURL(
-      isCompleteFilter,
-      statusFilter,
-      values,
-      submitterDisplayIdFilter,
-      submitterEmailFilter,
-      dateFilters,
-      1,
-      pagination.pageSize,
-    );
+    updateURL({
+      isComplete: isCompleteFilter,
+      status: statusFilter,
+      isTestSubmission: values,
+      submitterDisplayId: submitterDisplayIdFilter,
+      submitterEmail: submitterEmailFilter,
+      dates: dateFilters,
+      page: 1,
+      pageSize: pagination.pageSize,
+    });
   };
 
   const handleDateFilterChange = (
@@ -498,16 +510,16 @@ export function SubmissionsWithFilters({
     };
     setDateFilters(nextDateFilters);
     setPagination((current) => ({ ...current, pageIndex: 0 }));
-    updateURL(
-      isCompleteFilter,
-      statusFilter,
-      testSubmissionFilter,
-      submitterDisplayIdFilter,
-      submitterEmailFilter,
-      nextDateFilters,
-      1,
-      pagination.pageSize,
-    );
+    updateURL({
+      isComplete: isCompleteFilter,
+      status: statusFilter,
+      isTestSubmission: testSubmissionFilter,
+      submitterDisplayId: submitterDisplayIdFilter,
+      submitterEmail: submitterEmailFilter,
+      dates: nextDateFilters,
+      page: 1,
+      pageSize: pagination.pageSize,
+    });
   };
 
   const handleSubmitterDisplayIdChange = (value: string) => {
@@ -531,16 +543,16 @@ export function SubmissionsWithFilters({
     setSubmitterEmailFilter("");
     setDateFilters(EMPTY_SUBMISSION_DATE_FILTERS);
     setPagination((current) => ({ ...current, pageIndex: 0 }));
-    updateURL(
-      emptySet,
-      emptySet,
-      emptySet,
-      "",
-      "",
-      EMPTY_SUBMISSION_DATE_FILTERS,
-      1,
-      pagination.pageSize,
-    );
+    updateURL({
+      isComplete: emptySet,
+      status: emptySet,
+      isTestSubmission: emptySet,
+      submitterDisplayId: "",
+      submitterEmail: "",
+      dates: EMPTY_SUBMISSION_DATE_FILTERS,
+      page: 1,
+      pageSize: pagination.pageSize,
+    });
   };
 
   const handleResetSorting = () => {
@@ -552,16 +564,16 @@ export function SubmissionsWithFilters({
   ) => {
     const next = typeof updater === "function" ? updater(pagination) : updater;
     setPagination(next);
-    updateURL(
-      isCompleteFilter,
-      statusFilter,
-      testSubmissionFilter,
-      submitterDisplayIdFilter,
-      submitterEmailFilter,
-      dateFilters,
-      next.pageIndex + 1,
-      next.pageSize,
-    );
+    updateURL({
+      isComplete: isCompleteFilter,
+      status: statusFilter,
+      isTestSubmission: testSubmissionFilter,
+      submitterDisplayId: submitterDisplayIdFilter,
+      submitterEmail: submitterEmailFilter,
+      dates: dateFilters,
+      page: next.pageIndex + 1,
+      pageSize: next.pageSize,
+    });
   };
 
   const tableKey = buildSubmissionsTableKey({

--- a/features/telemetry/index.ts
+++ b/features/telemetry/index.ts
@@ -6,4 +6,7 @@ export {
   parseErrorMessage,
   type LogAttributes,
 } from "./infrastructure/telemetry-logger";
-export { TelemetryInitializer } from "./infrastructure/telemetry-initializer";
+
+// TelemetryInitializer is Node-only (OTEL/gRPC). Import it from
+// `./infrastructure/telemetry-initializer` (as instrumentation.node.ts does),
+// not from this barrel — otherwise client bundles pull in `net`/`fs`.

--- a/lib/endatix-api/reporting/__tests__/export-capabilities.test.ts
+++ b/lib/endatix-api/reporting/__tests__/export-capabilities.test.ts
@@ -18,6 +18,32 @@ const CAPABILITIES: ExportCapabilityDto[] = [
     label: "CSV",
     itemTypeName: "Endatix.Core.Entities.SubmissionExportRow",
     description: "Tabular CSV export with one row per submission.",
+    allowedFilters: [
+      "includeTestSubmissions",
+      "createdAtRange",
+      "completedAtRange",
+      "submissionIdRange",
+      "locale",
+      "columnScope",
+    ],
+  },
+  {
+    target: "Submissions",
+    deliveryFormat: "Csv",
+    profile: "Shoji",
+    wireKey: "csv-shoji",
+    label: "CSV (Shoji / Crunch)",
+    itemTypeName: "Endatix.Core.Entities.SubmissionExportRow",
+    description:
+      "Crunch-compatible CSV: -- key separators and boolean category ids 0/1.",
+    allowedFilters: [
+      "includeTestSubmissions",
+      "createdAtRange",
+      "completedAtRange",
+      "submissionIdRange",
+      "locale",
+      "columnScope",
+    ],
   },
   {
     target: "Submissions",
@@ -27,6 +53,14 @@ const CAPABILITIES: ExportCapabilityDto[] = [
     label: "JSON",
     itemTypeName: "Endatix.Core.Entities.SubmissionExportRow",
     description: "Tabular JSON export with one object per submission.",
+    allowedFilters: [
+      "includeTestSubmissions",
+      "createdAtRange",
+      "completedAtRange",
+      "submissionIdRange",
+      "locale",
+      "columnScope",
+    ],
   },
   {
     target: "Codebook",
@@ -36,6 +70,7 @@ const CAPABILITIES: ExportCapabilityDto[] = [
     label: "Codebook",
     itemTypeName: "Endatix.Core.Entities.DynamicExportRow",
     description: "Standard Endatix codebook JSON for question metadata.",
+    allowedFilters: [],
   },
   {
     target: "Codebook",
@@ -45,6 +80,7 @@ const CAPABILITIES: ExportCapabilityDto[] = [
     label: "Codebook (Shoji)",
     itemTypeName: "Endatix.Core.Entities.DynamicExportRow",
     description: "Shoji produces Crunch-compatible codebook JSON.",
+    allowedFilters: ["locale"],
   },
 ];
 
@@ -70,6 +106,7 @@ describe("normalizeExportCapabilities", () => {
         label: "Codebook (Shoji)",
         itemTypeName: "Endatix.Core.Entities.DynamicExportRow",
         description: "",
+        allowedFilters: [],
       },
     ]);
   });

--- a/lib/endatix-api/reporting/export-format-types.ts
+++ b/lib/endatix-api/reporting/export-format-types.ts
@@ -18,6 +18,8 @@ export interface ExportCapabilityDto {
   label: string;
   itemTypeName: string;
   description: string;
+  /** Request-time filters this capability accepts (Reporting API wire names). */
+  allowedFilters: string[];
 }
 
 /** Persisted export format settings (locale / columnScope are request-time only). */
@@ -197,6 +199,10 @@ export function buildExportFormatSettingsInput(
 export function getExportFormatFallbackExtension(wireKey: string): string {
   if (wireKey === "codebook" || wireKey === "codebook-shoji") {
     return "json";
+  }
+
+  if (wireKey === "csv-shoji") {
+    return "csv";
   }
 
   return wireKey;

--- a/lib/endatix-api/reporting/normalize-export-capabilities.ts
+++ b/lib/endatix-api/reporting/normalize-export-capabilities.ts
@@ -61,6 +61,11 @@ export function normalizeExportCapability(
     label: capability.label,
     itemTypeName: capability.itemTypeName,
     description: capability.description ?? "",
+    allowedFilters: Array.isArray(capability.allowedFilters)
+      ? capability.allowedFilters.filter(
+          (filter): filter is string => typeof filter === "string",
+        )
+      : [],
   };
 }
 

--- a/lib/endatix-api/submissions/submissions.ts
+++ b/lib/endatix-api/submissions/submissions.ts
@@ -172,6 +172,12 @@ export class Submissions {
       includeTestSubmissions,
       columnScope,
       locale,
+      createdAfter,
+      createdBefore,
+      completedAfter,
+      completedBefore,
+      minSubmissionId,
+      maxSubmissionId,
     } = request;
 
     const validateFormIdResult = validateEndatixId(formId, "formId");
@@ -202,6 +208,12 @@ export class Submissions {
         includeTestSubmissions,
         columnScope,
         locale,
+        createdAfter,
+        createdBefore,
+        completedAfter,
+        completedBefore,
+        minSubmissionId,
+        maxSubmissionId,
       },
     );
   }

--- a/lib/endatix-api/submissions/types.ts
+++ b/lib/endatix-api/submissions/types.ts
@@ -85,6 +85,7 @@ export type UpdateSubmissionStatusDto = {
 
 export type ExportFormat =
   | "csv"
+  | "csv-shoji"
   | "xlsx"
   | "json"
   | "codebook"
@@ -101,6 +102,7 @@ export type ExportSubmissionsDto = {
 
 export type ReportingExportWireKey =
   | "csv"
+  | "csv-shoji"
   | "json"
   | "codebook"
   | "codebook-shoji";
@@ -116,6 +118,12 @@ export interface ExportSubmissionsRequest {
   columnScope?: string[];
   /** Optional codebook label locale for this export run. */
   locale?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+  completedAfter?: string;
+  completedBefore?: string;
+  minSubmissionId?: string;
+  maxSubmissionId?: string;
 }
 
 export interface ListSubmissionsRequest {

--- a/project-structure.md
+++ b/project-structure.md
@@ -60,10 +60,10 @@ Reporting export is a dedicated feature (not nested under `forms/` or `submissio
 | Slice | Scope | Responsibility |
 |-------|--------|----------------|
 | `prepare-reporting-export` | Form | Compile `FormSchema` + backfill flattened submissions (UAT / admin prep) |
-| `export-submissions` | Submissions list | Tenant-configured export download via `exportFormatId` (+ legacy `CustomExports` when flag off) |
+| `export-submissions` | Submissions list | Tenant-configured export download via `exportFormatId` (+ legacy `CustomExports` when flag off); Export dialog with format + capability-aware request filters (dates prefilled from table) |
 | `manage-export-formats` | Tenant settings (E10b) | CRUD UI for tenant export formats + tenant default mapping picker (alias, key separator, include-test) |
 
-Shared feature root: `types.ts`, `export-url.ts`, `export-error-message.ts`. BFF route `app/api/forms/[formId]/export/route.ts` stays thin and delegates parsing to `export-submissions/parse-export-bff-request.ts`.
+Shared feature root: `types.ts`, `export-url.ts`, `export-error-message.ts`. Export route `app/api/forms/[formId]/export/route.ts` stays thin and delegates parsing to `export-submissions/parse-export-query.ts`.
 
 Import from `@/features/export` (client UI) or `@/features/export/server` (server actions). Slice barrels: `@/features/export/export-submissions`, `@/features/export/manage-export-formats`.
 


### PR DESCRIPTION
# feat(h697): export request filters + custom export dialog

## Description
- Quick export for CSV/JSON inherits submissions-table **date + test** filters (not status/submitter); codebook omits row filters.
- Add **Custom export…** dialog (format, locale when applicable, submission filters), prefilled from the grid; closes only on successful download.
- BFF parses/forwards filter query params; strips codebook row filters; omits locale for native `codebook`.
- Normalize `allowedFilters` from capabilities; URL builder uses wire-key fallback when capabilities are absent.

## Test plan
- [ ] Submissions list: set date/test filters → quick CSV includes them; codebook does not
- [ ] Custom export: change filters without changing the grid; failure keeps dialog open
- [ ] Native codebook: no locale field; Shoji codebook: locale optional
- [ ] Empty test filter omits `includeTestSubmissions` (format default)
- [ ] `pnpm exec vitest run features/export/export-submissions/__tests__/export-url.test.ts lib/endatix-api/reporting/__tests__/export-capabilities.test.ts`

Depends on OSS #801 API

## Related Issues
- closes #697 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="455" height="583" alt="image" src="https://github.com/user-attachments/assets/82e1c863-67c8-4180-b6a6-aaf6a25a0b02" />
<img width="441" height="372" alt="image" src="https://github.com/user-attachments/assets/5e57587c-0acf-4b7a-8a6a-67b1f0b08a6f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dialog-based export experience for submissions and codebooks.
  * Added filtering by test submissions, date ranges, and submission ID ranges.
  * Added locale selection where supported.
  * Added CSV Shoji export support.
  * Export options now adapt to each format’s supported filters.

* **Bug Fixes**
  * Improved export validation, including clearer handling of invalid date ranges.
  * Preserved a consistent order for export target groups.
  * Export filters from the submissions view are now carried into generated exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->