### PR TITLE
feat(h108): Allow users to delete submissions (soft delete, grid + details)

### DIFF
--- a/features/submissions/ui/details/submission-details-header.tsx
+++ b/features/submissions/ui/details/submission-details-header.tsx
@@ -26,9 +26,11 @@ import {
   Trash2,
 } from "lucide-react";
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 import { useState } from "react";
 import { saveToFileHandler } from "survey-creator-core";
 import { StatusDropdownMenuItem } from "../../use-cases/change-status";
+import { DeleteSubmissionDialog } from "../../use-cases/delete-submission";
 import { SubmissionShareLinksDialog } from "../../share-links/submission-share-links-dialog";
 import { DownloadFilesDropdownItem } from "../download-files-dropdown-item";
 import {
@@ -49,6 +51,8 @@ export function SubmissionDetailsHeader({
   const [copying, setCopying] = useState(false);
   const [jsonCopied, setJsonCopied] = useState(false);
   const [isShareLinksOpen, setIsShareLinksOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const { data: session } = useSession();
   const { trackEvent } = useTrackEvent();
   const { viewOptions } = useSubmissionDetailsViewOptions();
   const { submission } = useSubmissionDetails();
@@ -173,6 +177,7 @@ export function SubmissionDetailsHeader({
             submissionId={submissionId}
             status={submission.status}
             onShareLinksOpen={() => setIsShareLinksOpen(true)}
+            onDeleteOpen={() => setIsDeleteOpen(true)}
             className="text-muted-foreground"
           />
         </div>
@@ -182,6 +187,17 @@ export function SubmissionDetailsHeader({
         submissionId={submissionId}
         open={isShareLinksOpen}
         onOpenChange={setIsShareLinksOpen}
+      />
+      <DeleteSubmissionDialog
+        open={isDeleteOpen}
+        onOpenChange={setIsDeleteOpen}
+        formId={formId}
+        submissionId={submissionId}
+        isTestSubmission={submission.isTestSubmission}
+        submitterId={submission.submitterId}
+        submitterDisplayId={submission.submitterDisplayId}
+        currentUserId={session?.user?.id}
+        redirectToList
       />
     </>
   );
@@ -194,6 +210,7 @@ interface SubmissionActionsDropdownProps extends React.ComponentProps<
   formId: string;
   status: string;
   onShareLinksOpen: () => void;
+  onDeleteOpen: () => void;
 }
 
 function SubmissionActionsDropdown({
@@ -201,6 +218,7 @@ function SubmissionActionsDropdown({
   formId,
   status,
   onShareLinksOpen,
+  onDeleteOpen,
   ...props
 }: Readonly<SubmissionActionsDropdownProps>) {
   return (
@@ -253,7 +271,10 @@ function SubmissionActionsDropdown({
           formId={formId}
           status={status}
         />
-        <DropdownMenuItem className="cursor-pointer" hidden>
+        <DropdownMenuItem
+          className="cursor-pointer text-destructive focus:text-destructive"
+          onSelect={onDeleteOpen}
+        >
           <Trash2 className="mr-2 size-4" />
           <span>Delete</span>
         </DropdownMenuItem>

--- a/features/submissions/ui/table/row-actions.tsx
+++ b/features/submissions/ui/table/row-actions.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenuContent,
@@ -6,6 +8,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
+import { DeleteSubmissionDialog } from "@/features/submissions/use-cases/delete-submission";
 import { Submission } from "@/lib/endatix-api";
 import { Row } from "@tanstack/react-table";
 import {
@@ -17,6 +20,7 @@ import {
   Trash2,
 } from "lucide-react";
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 import { useState } from "react";
 import { DownloadFilesDropdownItem } from "../download-files-dropdown-item";
 import { SubmissionShareLinksDialog } from "../../share-links/submission-share-links-dialog";
@@ -28,6 +32,8 @@ interface RowActionsProps<TData> {
 export function RowActions<TData>({ row }: RowActionsProps<TData>) {
   const [open, setOpen] = useState(false);
   const [isShareLinksOpen, setIsShareLinksOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const { data: session } = useSession();
   const item = row.original as Submission;
 
   return (
@@ -54,25 +60,25 @@ export function RowActions<TData>({ row }: RowActionsProps<TData>) {
         >
           <DropdownMenuItem asChild className="cursor-pointer">
             <Link href={`/forms/${item.formId}/submissions/${item.id}/edit`}>
-              <FilePenLine className="w-4 h-4 mr-2" />
+              <FilePenLine className="mr-2 h-4 w-4" />
               <span>Edit</span>
             </Link>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem className="cursor-not-allowed">
-            <FileDown className="w-4 h-4 mr-2" />
+            <FileDown className="mr-2 h-4 w-4" />
             <span>Export PDF</span>
           </DropdownMenuItem>
           <DropdownMenuItem
             className="cursor-pointer"
             onSelect={() => setIsShareLinksOpen(true)}
           >
-            <LinkIcon className="w-4 h-4 mr-2" />
+            <LinkIcon className="mr-2 h-4 w-4" />
             <span>Share Links</span>
           </DropdownMenuItem>
           <DropdownMenuItem asChild className="cursor-pointer">
             <Link href={`/forms/${item.formId}/submissions/${item.id}/files`}>
-              <Files className="w-4 h-4 mr-2" />
+              <Files className="mr-2 h-4 w-4" />
               <span>View Files</span>
             </Link>
           </DropdownMenuItem>
@@ -81,8 +87,11 @@ export function RowActions<TData>({ row }: RowActionsProps<TData>) {
             submissionId={item.id}
           />
           <DropdownMenuSeparator />
-          <DropdownMenuItem className="cursor-not-allowed">
-            <Trash2 className="w-4 h-4 mr-2" />
+          <DropdownMenuItem
+            className="cursor-pointer text-destructive focus:text-destructive"
+            onSelect={() => setIsDeleteOpen(true)}
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
             <span>Delete</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
@@ -92,6 +101,16 @@ export function RowActions<TData>({ row }: RowActionsProps<TData>) {
         submissionId={item.id}
         open={isShareLinksOpen}
         onOpenChange={setIsShareLinksOpen}
+      />
+      <DeleteSubmissionDialog
+        open={isDeleteOpen}
+        onOpenChange={setIsDeleteOpen}
+        formId={item.formId}
+        submissionId={item.id}
+        isTestSubmission={item.isTestSubmission}
+        submitterId={item.submitterId}
+        submitterDisplayId={item.submitterDisplayId}
+        currentUserId={session?.user?.id}
       />
     </>
   );

--- a/features/submissions/use-cases/delete-submission/__tests__/delete-submission-dialog.test.tsx
+++ b/features/submissions/use-cases/delete-submission/__tests__/delete-submission-dialog.test.tsx
@@ -1,0 +1,206 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Result } from "@/lib/result";
+import { DeleteSubmissionDialog } from "../ui/delete-submission-dialog";
+
+const mockDeleteSubmissionAction = vi.fn();
+const mockTrackFeatureUsage = vi.fn();
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock("../delete-submission.action", () => ({
+  deleteSubmissionAction: (...args: unknown[]) =>
+    mockDeleteSubmissionAction(...args),
+}));
+
+vi.mock("@/features/analytics/posthog", () => ({
+  useTrackEvent: () => ({
+    trackFeatureUsage: mockTrackFeatureUsage,
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    refresh: mockRefresh,
+  }),
+}));
+
+vi.mock("@/components/ui/toast", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({
+    children,
+    open,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+  }) => (open ? <div>{children}</div> : null),
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogCancel: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  AlertDialogAction: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+describe("DeleteSubmissionDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders low-risk copy for test submissions", () => {
+    render(
+      <DeleteSubmissionDialog
+        open
+        onOpenChange={vi.fn()}
+        formId="form-1"
+        submissionId="sub-1"
+        isTestSubmission
+      />,
+    );
+
+    expect(screen.getByText("Delete this test submission?")).toBeDefined();
+    expect(
+      screen.getByText(/remove the test submission from the grid/i),
+    ).toBeDefined();
+  });
+
+  it("renders elevated copy for respondent submissions", () => {
+    render(
+      <DeleteSubmissionDialog
+        open
+        onOpenChange={vi.fn()}
+        formId="form-1"
+        submissionId="sub-1"
+        isTestSubmission={false}
+        submitterId="respondent"
+        currentUserId="admin"
+      />,
+    );
+
+    expect(
+      screen.getByText("Delete this respondent submission?"),
+    ).toBeDefined();
+    expect(
+      screen.getByText(/delete a real respondent's submission/i),
+    ).toBeDefined();
+  });
+
+  it("renders owned copy when submitterDisplayId matches the session user", () => {
+    render(
+      <DeleteSubmissionDialog
+        open
+        onOpenChange={vi.fn()}
+        formId="form-1"
+        submissionId="sub-1"
+        isTestSubmission={false}
+        submitterId="internal-pk"
+        submitterDisplayId="1496113070806663168"
+        currentUserId="1496113070806663168"
+      />,
+    );
+
+    expect(screen.getByText("Delete your submission?")).toBeDefined();
+    expect(
+      screen.getByText(/remove your submission from the grid/i),
+    ).toBeDefined();
+  });
+
+  it("deletes, toasts, tracks, and refreshes on success from the grid", async () => {
+    mockDeleteSubmissionAction.mockResolvedValueOnce(Result.success("sub-1"));
+    const onOpenChange = vi.fn();
+
+    render(
+      <DeleteSubmissionDialog
+        open
+        onOpenChange={onOpenChange}
+        formId="form-1"
+        submissionId="sub-1"
+        isTestSubmission
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(mockDeleteSubmissionAction).toHaveBeenCalledWith(
+        "form-1",
+        "sub-1",
+      );
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: "Removed from the list, form counts, and exports.",
+        }),
+      );
+      expect(mockTrackFeatureUsage).toHaveBeenCalledWith(
+        "submissions",
+        "delete",
+        expect.objectContaining({
+          form_id: "form-1",
+          submission_id: "sub-1",
+          is_test: true,
+          kind: "test",
+          risk: "low",
+        }),
+      );
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(mockRefresh).toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  it("redirects to the submissions list when redirectToList is set", async () => {
+    mockDeleteSubmissionAction.mockResolvedValueOnce(Result.success("sub-1"));
+
+    render(
+      <DeleteSubmissionDialog
+        open
+        onOpenChange={vi.fn()}
+        formId="form-1"
+        submissionId="sub-1"
+        isTestSubmission
+        redirectToList
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/forms/form-1/submissions");
+      expect(mockRefresh).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/features/submissions/use-cases/delete-submission/__tests__/delete-submission-dialog.test.tsx
+++ b/features/submissions/use-cases/delete-submission/__tests__/delete-submission-dialog.test.tsx
@@ -3,12 +3,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Result } from "@/lib/result";
 import { DeleteSubmissionDialog } from "../ui/delete-submission-dialog";
 
-const mockDeleteSubmissionAction = vi.fn();
-const mockTrackFeatureUsage = vi.fn();
-const mockPush = vi.fn();
-const mockRefresh = vi.fn();
-const mockToastSuccess = vi.fn();
-const mockToastError = vi.fn();
+const {
+  mockDeleteSubmissionAction,
+  mockTrackFeatureUsage,
+  mockPush,
+  mockRefresh,
+  mockToastSuccess,
+  mockToastError,
+} = vi.hoisted(() => ({
+  mockDeleteSubmissionAction: vi.fn(),
+  mockTrackFeatureUsage: vi.fn(),
+  mockPush: vi.fn(),
+  mockRefresh: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
 
 vi.mock("../delete-submission.action", () => ({
   deleteSubmissionAction: (...args: unknown[]) =>

--- a/features/submissions/use-cases/delete-submission/__tests__/delete-submission-dialog.test.tsx
+++ b/features/submissions/use-cases/delete-submission/__tests__/delete-submission-dialog.test.tsx
@@ -212,4 +212,32 @@ describe("DeleteSubmissionDialog", () => {
       expect(mockRefresh).not.toHaveBeenCalled();
     });
   });
+
+  it("shows an inline alert on failure and keeps the dialog open", async () => {
+    mockDeleteSubmissionAction.mockResolvedValueOnce(
+      Result.error("You are not allowed to delete this submission"),
+    );
+    const onOpenChange = vi.fn();
+
+    render(
+      <DeleteSubmissionDialog
+        open
+        onOpenChange={onOpenChange}
+        formId="form-1"
+        submissionId="sub-1"
+        isTestSubmission
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("You are not allowed to delete this submission"),
+      ).toBeDefined();
+      expect(mockToastError).not.toHaveBeenCalled();
+      expect(onOpenChange).not.toHaveBeenCalled();
+      expect(mockRefresh).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/features/submissions/use-cases/delete-submission/__tests__/delete-submission-risk.test.ts
+++ b/features/submissions/use-cases/delete-submission/__tests__/delete-submission-risk.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  isOwnedByCurrentUser,
+  resolveDeleteSubmissionKind,
+  resolveDeleteSubmissionRisk,
+} from "../delete-submission-risk";
+
+describe("isOwnedByCurrentUser", () => {
+  it("matches submitterDisplayId to the session user id", () => {
+    expect(
+      isOwnedByCurrentUser({
+        submitterId: "999",
+        submitterDisplayId: "1496113070806663168",
+        currentUserId: "1496113070806663168",
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back to submitterId when display id is absent", () => {
+    expect(
+      isOwnedByCurrentUser({
+        submitterId: "1496113070806663168",
+        submitterDisplayId: null,
+        currentUserId: "1496113070806663168",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when neither identity matches", () => {
+    expect(
+      isOwnedByCurrentUser({
+        submitterId: "999",
+        submitterDisplayId: "someone-else",
+        currentUserId: "1496113070806663168",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveDeleteSubmissionKind", () => {
+  it("returns test for test submissions", () => {
+    expect(
+      resolveDeleteSubmissionKind({
+        isTestSubmission: true,
+        submitterId: "other-user",
+        currentUserId: "me",
+      }),
+    ).toBe("test");
+  });
+
+  it("returns owned when submitterDisplayId matches current user", () => {
+    expect(
+      resolveDeleteSubmissionKind({
+        isTestSubmission: false,
+        submitterId: "internal-submitter-pk",
+        submitterDisplayId: "user-1",
+        currentUserId: "user-1",
+      }),
+    ).toBe("owned");
+  });
+
+  it("returns owned when submitterId matches current user", () => {
+    expect(
+      resolveDeleteSubmissionKind({
+        isTestSubmission: false,
+        submitterId: "user-1",
+        currentUserId: "user-1",
+      }),
+    ).toBe("owned");
+  });
+
+  it("returns respondent for other submitters", () => {
+    expect(
+      resolveDeleteSubmissionKind({
+        isTestSubmission: false,
+        submitterId: "respondent-pk",
+        submitterDisplayId: "respondent",
+        currentUserId: "admin",
+      }),
+    ).toBe("respondent");
+  });
+});
+
+describe("resolveDeleteSubmissionRisk", () => {
+  it("returns low for test submissions", () => {
+    expect(
+      resolveDeleteSubmissionRisk({
+        isTestSubmission: true,
+        submitterId: "other-user",
+        currentUserId: "me",
+      }),
+    ).toBe("low");
+  });
+
+  it("returns low when submitter display id matches current user", () => {
+    expect(
+      resolveDeleteSubmissionRisk({
+        isTestSubmission: false,
+        submitterId: "pk",
+        submitterDisplayId: "user-1",
+        currentUserId: "user-1",
+      }),
+    ).toBe("low");
+  });
+
+  it("returns elevated for respondent submissions from others", () => {
+    expect(
+      resolveDeleteSubmissionRisk({
+        isTestSubmission: false,
+        submitterId: "respondent",
+        currentUserId: "admin",
+      }),
+    ).toBe("elevated");
+  });
+
+  it("returns elevated when submitter or current user is missing", () => {
+    expect(
+      resolveDeleteSubmissionRisk({
+        isTestSubmission: false,
+        submitterId: null,
+        currentUserId: "admin",
+      }),
+    ).toBe("elevated");
+
+    expect(
+      resolveDeleteSubmissionRisk({
+        isTestSubmission: undefined,
+        submitterId: "user-1",
+        currentUserId: undefined,
+      }),
+    ).toBe("elevated");
+  });
+});

--- a/features/submissions/use-cases/delete-submission/__tests__/delete-submission.action.test.ts
+++ b/features/submissions/use-cases/delete-submission/__tests__/delete-submission.action.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiResult } from "@/lib/endatix-api/shared/api-result";
+import { Result } from "@/lib/result";
+import { deleteSubmissionAction } from "../delete-submission.action";
+
+const mockRequireHubAccess = vi.fn();
+const mockDelete = vi.fn();
+const mockRevalidatePath = vi.fn();
+
+vi.mock("@/auth", () => ({
+  auth: vi.fn().mockResolvedValue({ accessToken: "token" }),
+}));
+
+vi.mock("@/features/auth/authorization", () => ({
+  authorization: vi.fn().mockResolvedValue({
+    requireHubAccess: (...args: unknown[]) => mockRequireHubAccess(...args),
+  }),
+}));
+
+vi.mock("@/lib/endatix-api", () => ({
+  EndatixApi: vi.fn().mockImplementation(function () {
+    return {
+      submissions: {
+        delete: (...args: unknown[]) => mockDelete(...args),
+      },
+    };
+  }),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}));
+
+describe("deleteSubmissionAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireHubAccess.mockResolvedValue(undefined);
+  });
+
+  it("deletes via API and revalidates list, details, and form paths", async () => {
+    mockDelete.mockResolvedValueOnce(ApiResult.success("sub-1"));
+
+    const result = await deleteSubmissionAction("form-1", "sub-1");
+
+    expect(mockRequireHubAccess).toHaveBeenCalled();
+    expect(mockDelete).toHaveBeenCalledWith("form-1", "sub-1");
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      "/(main)/forms/form-1/submissions",
+    );
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      "/(main)/forms/form-1/submissions/sub-1",
+    );
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/(main)/forms/form-1");
+    expect(Result.isSuccess(result)).toBe(true);
+    expect(result.value).toBe("sub-1");
+  });
+
+  it("maps API failures without revalidating", async () => {
+    mockDelete.mockResolvedValueOnce(
+      ApiResult.serverError("Failed to delete submission"),
+    );
+
+    const result = await deleteSubmissionAction("form-1", "sub-1");
+
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+    expect(Result.isError(result)).toBe(true);
+  });
+});

--- a/features/submissions/use-cases/delete-submission/__tests__/delete-success-toast-content.test.tsx
+++ b/features/submissions/use-cases/delete-submission/__tests__/delete-success-toast-content.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { deleteSuccessToastContent } from "../ui/delete-success-toast-content";
+
+describe("deleteSuccessToastContent", () => {
+  it("emphasizes Test for test submissions", () => {
+    const content = deleteSuccessToastContent("test");
+    render(
+      <div>
+        <div>{content.title}</div>
+        <div>{content.description}</div>
+      </div>,
+    );
+
+    expect(screen.getByText("Test")).toBeDefined();
+    expect(screen.getByText(/submission deleted/i)).toBeDefined();
+    expect(
+      screen.getByText("Removed from the list, form counts, and exports."),
+    ).toBeDefined();
+  });
+
+  it("emphasizes Your for owned submissions", () => {
+    const content = deleteSuccessToastContent("owned");
+    render(<div>{content.title}</div>);
+
+    expect(screen.getByText("Your")).toBeDefined();
+    expect(screen.getByText(/submission deleted/i)).toBeDefined();
+  });
+
+  it("emphasizes Respondent for respondent submissions", () => {
+    const content = deleteSuccessToastContent("respondent");
+    render(<div>{content.title}</div>);
+
+    expect(screen.getByText("Respondent")).toBeDefined();
+    expect(screen.getByText(/submission deleted/i)).toBeDefined();
+  });
+});

--- a/features/submissions/use-cases/delete-submission/delete-submission-risk.ts
+++ b/features/submissions/use-cases/delete-submission/delete-submission-risk.ts
@@ -1,0 +1,64 @@
+export type DeleteSubmissionKind = "test" | "owned" | "respondent";
+
+export type DeleteSubmissionRiskTier = "low" | "elevated";
+
+function normalizeId(value?: string | null): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  const trimmed = String(value).trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Hub "owned" means the current session user is the submitter identity shown in Hub.
+ * Prefer `submitterDisplayId` (grid "Submitter ID" column); also accept `submitterId`
+ * for legacy rows where the Hub user id was stored as the submitter PK.
+ */
+export function isOwnedByCurrentUser(args: {
+  submitterId?: string | null;
+  submitterDisplayId?: string | null;
+  currentUserId?: string | null;
+}): boolean {
+  const currentUserId = normalizeId(args.currentUserId);
+  if (!currentUserId) {
+    return false;
+  }
+
+  const submitterDisplayId = normalizeId(args.submitterDisplayId);
+  if (submitterDisplayId && submitterDisplayId === currentUserId) {
+    return true;
+  }
+
+  const submitterId = normalizeId(args.submitterId);
+  return Boolean(submitterId && submitterId === currentUserId);
+}
+
+export function resolveDeleteSubmissionKind(args: {
+  isTestSubmission?: boolean;
+  submitterId?: string | null;
+  submitterDisplayId?: string | null;
+  currentUserId?: string | null;
+}): DeleteSubmissionKind {
+  if (args.isTestSubmission) {
+    return "test";
+  }
+
+  if (isOwnedByCurrentUser(args)) {
+    return "owned";
+  }
+
+  return "respondent";
+}
+
+export function resolveDeleteSubmissionRisk(args: {
+  isTestSubmission?: boolean;
+  submitterId?: string | null;
+  submitterDisplayId?: string | null;
+  currentUserId?: string | null;
+}): DeleteSubmissionRiskTier {
+  return resolveDeleteSubmissionKind(args) === "respondent"
+    ? "elevated"
+    : "low";
+}

--- a/features/submissions/use-cases/delete-submission/delete-submission.action.ts
+++ b/features/submissions/use-cases/delete-submission/delete-submission.action.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { auth } from "@/auth";
+import { authorization } from "@/features/auth/authorization";
+import { EndatixApi } from "@/lib/endatix-api";
+import { Result } from "@/lib/result";
+import { mapToResult } from "@/lib/result/map-api-result-to-result";
+
+export type DeleteSubmissionResult = Result<string>;
+
+export async function deleteSubmissionAction(
+  formId: string,
+  submissionId: string,
+): Promise<DeleteSubmissionResult> {
+  const session = await auth();
+  const { requireHubAccess } = await authorization(session);
+  await requireHubAccess();
+
+  const api = new EndatixApi(session?.accessToken);
+  const apiResult = await api.submissions.delete(formId, submissionId);
+
+  if (!apiResult.success) {
+    return mapToResult(apiResult, {
+      fallbackMessage: "Failed to delete submission",
+      logMessage: "Failed to delete submission",
+      loggerName: "submissions.delete",
+    });
+  }
+
+  revalidatePath(`/(main)/forms/${formId}/submissions`);
+  revalidatePath(`/(main)/forms/${formId}/submissions/${submissionId}`);
+  revalidatePath(`/(main)/forms/${formId}`);
+
+  return Result.success(submissionId);
+}

--- a/features/submissions/use-cases/delete-submission/delete-submission.action.ts
+++ b/features/submissions/use-cases/delete-submission/delete-submission.action.ts
@@ -5,7 +5,7 @@ import { auth } from "@/auth";
 import { authorization } from "@/features/auth/authorization";
 import { EndatixApi } from "@/lib/endatix-api";
 import { Result } from "@/lib/result";
-import { mapToResult } from "@/lib/result/map-api-result-to-result";
+import { toResult } from "@/lib/result/map-api-result-to-result";
 
 export type DeleteSubmissionResult = Result<string>;
 
@@ -21,7 +21,7 @@ export async function deleteSubmissionAction(
   const apiResult = await api.submissions.delete(formId, submissionId);
 
   if (!apiResult.success) {
-    return mapToResult(apiResult, {
+    return toResult(apiResult, {
       fallbackMessage: "Failed to delete submission",
       logMessage: "Failed to delete submission",
       loggerName: "submissions.delete",

--- a/features/submissions/use-cases/delete-submission/index.ts
+++ b/features/submissions/use-cases/delete-submission/index.ts
@@ -1,0 +1,11 @@
+export { deleteSubmissionAction } from "./delete-submission.action";
+export type { DeleteSubmissionResult } from "./delete-submission.action";
+export {
+  resolveDeleteSubmissionKind,
+  resolveDeleteSubmissionRisk,
+  isOwnedByCurrentUser,
+  type DeleteSubmissionKind,
+  type DeleteSubmissionRiskTier,
+} from "./delete-submission-risk";
+export { DeleteSubmissionDialog } from "./ui/delete-submission-dialog";
+export { deleteSuccessToastContent } from "./ui/delete-success-toast-content";

--- a/features/submissions/use-cases/delete-submission/ui/delete-submission-dialog.tsx
+++ b/features/submissions/use-cases/delete-submission/ui/delete-submission-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import {
   AlertDialog,
@@ -12,6 +12,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Spinner } from "@/components/loaders/spinner";
 import { toast } from "@/components/ui/toast";
 import { useTrackEvent } from "@/features/analytics/posthog";
@@ -84,6 +85,7 @@ export function DeleteSubmissionDialog({
 }: Readonly<DeleteSubmissionDialogProps>) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const { trackFeatureUsage } = useTrackEvent();
   const kindArgs = {
     isTestSubmission,
@@ -95,15 +97,20 @@ export function DeleteSubmissionDialog({
   const risk = resolveDeleteSubmissionRisk(kindArgs);
   const copy = dialogCopy(kind, risk);
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setErrorMessage(null);
+    }
+    onOpenChange(nextOpen);
+  };
+
   const handleDelete = () => {
     startTransition(async () => {
+      setErrorMessage(null);
       const result = await deleteSubmissionAction(formId, submissionId);
 
       if (Result.isError(result)) {
-        toast.error({
-          title: "Delete failed",
-          description: result.message,
-        });
+        setErrorMessage(result.message);
         return;
       }
 
@@ -116,7 +123,7 @@ export function DeleteSubmissionDialog({
       });
 
       toast.success(deleteSuccessToastContent(kind));
-      onOpenChange(false);
+      handleOpenChange(false);
 
       if (redirectToList) {
         router.push(`/forms/${formId}/submissions`);
@@ -128,7 +135,7 @@ export function DeleteSubmissionDialog({
   };
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent onClick={(event) => event.stopPropagation()}>
         <AlertDialogHeader>
           <AlertDialogTitle>{copy.title}</AlertDialogTitle>
@@ -143,6 +150,11 @@ export function DeleteSubmissionDialog({
             )}
           </AlertDialogDescription>
         </AlertDialogHeader>
+        {errorMessage ? (
+          <Alert variant="destructive">
+            <AlertDescription>{errorMessage}</AlertDescription>
+          </Alert>
+        ) : null}
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
           <AlertDialogAction

--- a/features/submissions/use-cases/delete-submission/ui/delete-submission-dialog.tsx
+++ b/features/submissions/use-cases/delete-submission/ui/delete-submission-dialog.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Spinner } from "@/components/loaders/spinner";
+import { toast } from "@/components/ui/toast";
+import { useTrackEvent } from "@/features/analytics/posthog";
+import { Result } from "@/lib/result";
+import { AlertTriangle } from "lucide-react";
+import { deleteSubmissionAction } from "../delete-submission.action";
+import {
+  resolveDeleteSubmissionKind,
+  resolveDeleteSubmissionRisk,
+  type DeleteSubmissionKind,
+  type DeleteSubmissionRiskTier,
+} from "../delete-submission-risk";
+import { deleteSuccessToastContent } from "./delete-success-toast-content";
+
+export type DeleteSubmissionDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  formId: string;
+  submissionId: string;
+  isTestSubmission?: boolean;
+  submitterId?: string | null;
+  submitterDisplayId?: string | null;
+  currentUserId?: string | null;
+  /** When true, navigate to the submissions list after a successful delete. */
+  redirectToList?: boolean;
+};
+
+function dialogCopy(
+  kind: DeleteSubmissionKind,
+  risk: DeleteSubmissionRiskTier,
+): {
+  title: string;
+  description: string;
+} {
+  if (kind === "test") {
+    return {
+      title: "Delete this test submission?",
+      description:
+        "This will remove the test submission from the grid, form counts, and exports.",
+    };
+  }
+
+  if (kind === "owned") {
+    return {
+      title: "Delete your submission?",
+      description:
+        "This will remove your submission from the grid, form counts, and exports.",
+    };
+  }
+
+  return {
+    title: "Delete this respondent submission?",
+    description:
+      risk === "elevated"
+        ? "This will delete a real respondent's submission. It will be removed from the grid, form counts, and exports. This cannot be undone from Hub."
+        : "This will remove the submission from the grid, form counts, and exports.",
+  };
+}
+
+export function DeleteSubmissionDialog({
+  open,
+  onOpenChange,
+  formId,
+  submissionId,
+  isTestSubmission,
+  submitterId,
+  submitterDisplayId,
+  currentUserId,
+  redirectToList = false,
+}: Readonly<DeleteSubmissionDialogProps>) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const { trackFeatureUsage } = useTrackEvent();
+  const kindArgs = {
+    isTestSubmission,
+    submitterId,
+    submitterDisplayId,
+    currentUserId,
+  };
+  const kind = resolveDeleteSubmissionKind(kindArgs);
+  const risk = resolveDeleteSubmissionRisk(kindArgs);
+  const copy = dialogCopy(kind, risk);
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      const result = await deleteSubmissionAction(formId, submissionId);
+
+      if (Result.isError(result)) {
+        toast.error({
+          title: "Delete failed",
+          description: result.message,
+        });
+        return;
+      }
+
+      trackFeatureUsage("submissions", "delete", {
+        form_id: formId,
+        submission_id: submissionId,
+        is_test: Boolean(isTestSubmission),
+        kind,
+        risk,
+      });
+
+      toast.success(deleteSuccessToastContent(kind));
+      onOpenChange(false);
+
+      if (redirectToList) {
+        router.push(`/forms/${formId}/submissions`);
+        return;
+      }
+
+      router.refresh();
+    });
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent onClick={(event) => event.stopPropagation()}>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{copy.title}</AlertDialogTitle>
+          <AlertDialogDescription className="space-y-3">
+            {risk === "elevated" ? (
+              <span className="flex items-start gap-2 font-medium text-destructive">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>{copy.description}</span>
+              </span>
+            ) : (
+              <span className="block text-sm">{copy.description}</span>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isPending}
+            onClick={(event) => {
+              event.preventDefault();
+              handleDelete();
+            }}
+            className="bg-destructive hover:bg-destructive/90"
+          >
+            {isPending ? (
+              <>
+                <Spinner className="mr-2 h-4 w-4" />
+                Deleting...
+              </>
+            ) : (
+              "Delete"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/features/submissions/use-cases/delete-submission/ui/delete-success-toast-content.tsx
+++ b/features/submissions/use-cases/delete-submission/ui/delete-success-toast-content.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+import { FlaskConical, User, Users } from "lucide-react";
+import type { DeleteSubmissionKind } from "../delete-submission-risk";
+
+export type DeleteSuccessToastContent = {
+  title: ReactNode;
+  description: ReactNode;
+};
+
+/**
+ * Kind-specific success toast so operators can instantly confirm
+ * what they deleted (test vs own vs respondent).
+ */
+export function deleteSuccessToastContent(
+  kind: DeleteSubmissionKind,
+): DeleteSuccessToastContent {
+  switch (kind) {
+    case "test":
+      return {
+        title: (
+          <span className="inline-flex items-center gap-1.5">
+            <FlaskConical
+              className="h-4 w-4 shrink-0 text-amber-600"
+              aria-hidden
+            />
+            <span>
+              <span className="font-semibold">Test</span> submission deleted
+            </span>
+          </span>
+        ),
+        description: "Removed from the list, form counts, and exports.",
+      };
+    case "owned":
+      return {
+        title: (
+          <span className="inline-flex items-center gap-1.5">
+            <User className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+            <span>
+              <span className="font-semibold">Your</span> submission deleted
+            </span>
+          </span>
+        ),
+        description: "Removed from the list, form counts, and exports.",
+      };
+    case "respondent":
+      return {
+        title: (
+          <span className="inline-flex items-center gap-1.5">
+            <Users className="h-4 w-4 shrink-0 text-destructive" aria-hidden />
+            <span>
+              <span className="font-semibold">Respondent</span> submission
+              deleted
+            </span>
+          </span>
+        ),
+        description: "Removed from the list, form counts, and exports.",
+      };
+  }
+}

--- a/lib/endatix-api/submissions/__tests__/submissions-delete.test.ts
+++ b/lib/endatix-api/submissions/__tests__/submissions-delete.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import type { EndatixApi } from "../../endatix-api";
+import { ApiResult } from "../../shared/api-result";
+import { Submissions } from "../submissions";
+
+describe("Submissions.delete", () => {
+  it("calls DELETE forms/{formId}/submissions/{submissionId}", async () => {
+    const del = vi.fn().mockResolvedValue(ApiResult.success("ok"));
+    const endatix = { delete: del } as unknown as EndatixApi;
+    const submissions = new Submissions(endatix);
+
+    await submissions.delete("1525035735390879744", "1526934587983265792");
+
+    expect(del).toHaveBeenCalledWith(
+      "/forms/1525035735390879744/submissions/1526934587983265792",
+    );
+  });
+
+  it("returns validation error for invalid ids without calling API", async () => {
+    const del = vi.fn();
+    const endatix = { delete: del } as unknown as EndatixApi;
+    const submissions = new Submissions(endatix);
+
+    const result = await submissions.delete("bad", "1526934587983265792");
+
+    expect(del).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+  });
+});

--- a/lib/endatix-api/submissions/__tests__/submissions-delete.test.ts
+++ b/lib/endatix-api/submissions/__tests__/submissions-delete.test.ts
@@ -26,4 +26,15 @@ describe("Submissions.delete", () => {
     expect(del).not.toHaveBeenCalled();
     expect(result.success).toBe(false);
   });
+
+  it("returns validation error for invalid submissionId without calling API", async () => {
+    const del = vi.fn();
+    const endatix = { delete: del } as unknown as EndatixApi;
+    const submissions = new Submissions(endatix);
+
+    const result = await submissions.delete("1525035735390879744", "bad");
+
+    expect(del).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+  });
 });

--- a/lib/endatix-api/submissions/submissions.ts
+++ b/lib/endatix-api/submissions/submissions.ts
@@ -194,7 +194,7 @@ export class Submissions {
     if (exportFormatId) {
       const validateExportFormatIdResult = validateEndatixId(
         exportFormatId,
-        'exportFormatId',
+        "exportFormatId",
       );
       if (Result.isError(validateExportFormatIdResult)) {
         return ApiResult.validationError(validateExportFormatIdResult.message);
@@ -273,6 +273,31 @@ export class Submissions {
         expiryMinutes: request.expiryMinutes,
         permissions: request.permissions,
       },
+    );
+  }
+
+  /**
+   * Soft-deletes a submission for a form.
+   */
+  async delete(
+    formId: string,
+    submissionId: string,
+  ): Promise<ApiResult<string>> {
+    const validateFormIdResult = validateEndatixId(formId, "formId");
+    if (Result.isError(validateFormIdResult)) {
+      return ApiResult.validationError(validateFormIdResult.message);
+    }
+
+    const validateSubmissionIdResult = validateEndatixId(
+      submissionId,
+      "submissionId",
+    );
+    if (Result.isError(validateSubmissionIdResult)) {
+      return ApiResult.validationError(validateSubmissionIdResult.message);
+    }
+
+    return this.endatix.delete<string>(
+      `/forms/${validateFormIdResult.value}/submissions/${validateSubmissionIdResult.value}`,
     );
   }
 }


### PR DESCRIPTION
# feat(h108): Allow users to delete submissions (soft delete, grid + details)

## Description
- Allows deleting submissions in Submission grid
- Allows deleting submissions in Submission details
- Adds delete dialog experience with risk detection e.g. easy way to delete own and test submissions and warning for deleting respondent submissions
- Custom deletion toast notification based of submission type - owned, test or respondent

## Related Issues
- closes #108 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="534" height="223" alt="image" src="https://github.com/user-attachments/assets/49b6a2e0-5a24-4c34-9c9d-77848dc48c98" />
<img width="399" height="129" alt="image" src="https://github.com/user-attachments/assets/e59c53de-7cd8-441f-bec1-9c04c6252378" />
<img width="533" height="191" alt="image" src="https://github.com/user-attachments/assets/a9bda4a7-dbeb-4905-ae50-e642975d82d4" />
<img width="386" height="140" alt="image" src="https://github.com/user-attachments/assets/fc1beefe-e7d7-4c98-ba40-632ce65ec885" />
<img width="558" height="200" alt="image" src="https://github.com/user-attachments/assets/63d30d58-8f05-40ab-aae5-2543ebabe191" />
<img width="396" height="137" alt="image" src="https://github.com/user-attachments/assets/3407a610-3417-4661-b2df-87e9559bc3d7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added submission deletion from both submission details and list views.
  * Added confirmation messaging with additional warnings for higher-risk respondent deletions.
  * Added success and error feedback after deletion, with automatic page refresh or return to the submissions list.
  * Deletion actions now account for test submissions and submission ownership.

* **Tests**
  * Added coverage for deletion behavior, risk classification, confirmation messaging, API handling, navigation, and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->