### PR TITLE
fix(h742): Sanitize HTML-bearing survey properties to prevent stored XSS

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,4 @@
+// Runs before any application frontend code. Installing the survey HTML
+// sanitizer here makes the guarantee global: every SurveyModel created in the
+// browser is covered without each rendering site having to opt in.
+import "@/lib/survey-features/safe-html";

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,7 +1,11 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Server-side counterpart to instrumentation-client.ts: survey components
+    // are client components, but Next still renders them on the server, so the
+    // sanitizer has to be installed in both runtimes.
+    await import("@/lib/survey-features/safe-html");
     await import("@/lib/hosting/check-node-version");
     await import("@/lib/hosting/check-environment");
     await import("@/instrumentation.node");
   }
-};
+}

--- a/lib/survey-features/safe-html/__tests__/sanitize-survey-html.test.ts
+++ b/lib/survey-features/safe-html/__tests__/sanitize-survey-html.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { Model, SurveyModel } from "survey-core";
+import type { QuestionHtmlModel } from "survey-core";
+import { installSurveyHtmlSanitizer } from "../sanitize-survey-html";
+
+/**
+ * These tests drive the real survey-core rendering paths rather than mocking
+ * them: the value of the fix is precisely that the library's own getters (the
+ * ones survey-react-ui feeds to `dangerouslySetInnerHTML`) return sanitized
+ * markup. Mocking survey-core would assert nothing about that.
+ */
+beforeAll(() => {
+  installSurveyHtmlSanitizer();
+});
+
+const XSS = `<img src=x onerror="alert('XSS')">`;
+
+function htmlQuestionSurvey(html: string): Model {
+  return new Model({
+    pages: [{ name: "p1", elements: [{ type: "html", name: "h1", html }] }],
+  });
+}
+
+function renderedHtmlQuestion(survey: Model): string {
+  const question = survey.getQuestionByName("h1") as QuestionHtmlModel;
+  return question.processedHtml;
+}
+
+describe("survey HTML sanitizer", () => {
+  describe("blocks the HTML-bearing survey properties", () => {
+    it("strips event handlers from an html question", () => {
+      const rendered = renderedHtmlQuestion(htmlQuestionSurvey(XSS));
+
+      expect(rendered).not.toContain("onerror");
+      expect(rendered).not.toContain("alert");
+    });
+
+    it("strips event handlers from completedHtml", () => {
+      const survey = new Model({
+        completedHtml: XSS,
+        pages: [{ name: "p1", elements: [{ type: "text", name: "q1" }] }],
+      });
+
+      expect(survey.processedCompletedHtml).not.toContain("onerror");
+    });
+
+    it("strips event handlers from completedHtmlOnCondition", () => {
+      const survey = new Model({
+        completedHtml: "safe fallback",
+        completedHtmlOnCondition: [{ expression: "true", html: XSS }],
+        pages: [{ name: "p1", elements: [{ type: "text", name: "q1" }] }],
+      });
+
+      expect(survey.processedCompletedHtml).not.toContain("onerror");
+    });
+
+    it("strips event handlers from completedBeforeHtml", () => {
+      const survey = new Model({
+        completedBeforeHtml: XSS,
+        pages: [{ name: "p1", elements: [{ type: "text", name: "q1" }] }],
+      });
+
+      expect(survey.locCompletedBeforeHtml.renderedHtml).not.toContain(
+        "onerror",
+      );
+    });
+
+    it("strips event handlers from loadingHtml", () => {
+      const survey = new Model({
+        loadingHtml: XSS,
+        pages: [{ name: "p1", elements: [{ type: "text", name: "q1" }] }],
+      });
+
+      expect(survey.locLoadingHtml.renderedHtml).not.toContain("onerror");
+    });
+
+    it.each([
+      ["script tag", `<script>alert('XSS')</script>`, "alert"],
+      ["svg onload", `<svg/onload=alert('XSS')>`, "onload"],
+      ["iframe", `<iframe src="javascript:alert(1)"></iframe>`, "iframe"],
+      [
+        "javascript: href",
+        `<a href="javascript:alert(1)">x</a>`,
+        "javascript:",
+      ],
+    ])("strips %s", (_label, payload, forbidden) => {
+      const rendered = renderedHtmlQuestion(htmlQuestionSurvey(payload));
+
+      expect(rendered).not.toContain(forbidden);
+    });
+  });
+
+  describe("closes the text-piping bypass", () => {
+    it("sanitizes answer values piped into an html question", () => {
+      // Piping runs after onProcessHtml, so a sanitizer registered on that
+      // event would let this through. A respondent needs no edit rights.
+      const survey = htmlQuestionSurvey("Hello {q1}");
+      survey.setValue("q1", XSS);
+
+      const rendered = renderedHtmlQuestion(survey);
+
+      expect(rendered).toContain("Hello");
+      expect(rendered).not.toContain("onerror");
+    });
+
+    it("sanitizes answer values piped into completedHtml", () => {
+      const survey = new Model({
+        completedHtml: "Thanks {q1}",
+        pages: [{ name: "p1", elements: [{ type: "text", name: "q1" }] }],
+      });
+      survey.setValue("q1", XSS);
+
+      expect(survey.processedCompletedHtml).not.toContain("onerror");
+    });
+  });
+
+  describe("preserves legitimate authored content", () => {
+    it("keeps table cell content", () => {
+      const rendered = renderedHtmlQuestion(
+        htmlQuestionSurvey(
+          "<table><tbody><tr><td><strong>cell</strong></td></tr></tbody></table>",
+        ),
+      );
+
+      expect(rendered).toContain("<td>");
+      expect(rendered).toContain("<strong>cell</strong>");
+    });
+
+    it("keeps headings, lists and images", () => {
+      const rendered = renderedHtmlQuestion(
+        htmlQuestionSurvey(
+          `<h2>Title</h2><ul><li><p>item <strong>bold</strong></p></li></ul><img src="https://example.com/a.png" alt="a">`,
+        ),
+      );
+
+      expect(rendered).toContain("<h2>Title</h2>");
+      expect(rendered).toContain("<strong>bold</strong>");
+      expect(rendered).toContain('src="https://example.com/a.png"');
+    });
+
+    it("hardens external links instead of dropping them", () => {
+      const rendered = renderedHtmlQuestion(
+        htmlQuestionSurvey(`<a href="https://example.com">link</a>`),
+      );
+
+      expect(rendered).toContain('href="https://example.com"');
+      expect(rendered).toContain("noopener");
+      expect(rendered).toContain("noreferrer");
+    });
+
+    it("still pipes plain answer values", () => {
+      const survey = htmlQuestionSurvey("<p>Hello {q1}</p>");
+      survey.setValue("q1", "Ada");
+
+      expect(renderedHtmlQuestion(survey)).toContain("Hello Ada");
+    });
+  });
+
+  describe("installation", () => {
+    it("is idempotent, so wrappers never stack", () => {
+      const alreadyPatched = SurveyModel.prototype.processHtml;
+
+      installSurveyHtmlSanitizer();
+      installSurveyHtmlSanitizer();
+
+      expect(SurveyModel.prototype.processHtml).toBe(alreadyPatched);
+    });
+
+    it("leaves consumer onProcessHtml handlers working", () => {
+      const survey = htmlQuestionSurvey("<p>original</p>");
+      survey.onProcessHtml.add((_, options) => {
+        options.html = "<p>replaced</p>";
+      });
+
+      expect(renderedHtmlQuestion(survey)).toContain("replaced");
+    });
+  });
+});

--- a/lib/survey-features/safe-html/__tests__/sanitizer-wiring.test.ts
+++ b/lib/survey-features/safe-html/__tests__/sanitizer-wiring.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * The sanitizer only protects the app if it is actually installed at startup.
+ * Every other test in this folder installs it explicitly, so dropping the
+ * instrumentation wiring would silently reintroduce the vulnerability while
+ * leaving the suite green. This test fails loudly in that case.
+ */
+const SAFE_HTML_MODULE = "@/lib/survey-features/safe-html";
+
+const ENTRY_POINTS = [
+  ["client", "instrumentation-client.ts"],
+  ["server", "instrumentation.ts"],
+] as const;
+
+describe("survey HTML sanitizer wiring", () => {
+  it.each(ENTRY_POINTS)(
+    "is installed from the %s instrumentation entry point",
+    (_runtime, file) => {
+      const source = readFileSync(path.join(process.cwd(), file), "utf8");
+
+      expect(source).toContain(SAFE_HTML_MODULE);
+    },
+  );
+});

--- a/lib/survey-features/safe-html/index.ts
+++ b/lib/survey-features/safe-html/index.ts
@@ -1,0 +1,10 @@
+import { installSurveyHtmlSanitizer } from "./sanitize-survey-html";
+
+// Installed on import so that a single side-effect import anywhere in a survey
+// rendering path protects every SurveyModel instance in the bundle.
+installSurveyHtmlSanitizer();
+
+export {
+  installSurveyHtmlSanitizer,
+  sanitizeSurveyHtml,
+} from "./sanitize-survey-html";

--- a/lib/survey-features/safe-html/sanitize-survey-html.ts
+++ b/lib/survey-features/safe-html/sanitize-survey-html.ts
@@ -1,0 +1,72 @@
+import { SurveyModel } from "survey-core";
+import { htmlSanitizer } from "@/lib/utils/html-sanitizer";
+
+/**
+ * Marker kept on the prototype so repeated imports/installs never stack wrappers.
+ */
+const INSTALLED_FLAG = "__endatixSurveyHtmlSanitizerInstalled";
+
+type ProcessHtmlFn = (
+  this: SurveyModel,
+  html: string,
+  reason?: string,
+) => string;
+
+type PatchablePrototype = Record<string, unknown>;
+
+/**
+ * Sanitizes HTML that survey-core is about to hand to `dangerouslySetInnerHTML`.
+ */
+export function sanitizeSurveyHtml(html: string): string {
+  return htmlSanitizer.sanitize(html, htmlSanitizer.presets.surveyHtml);
+}
+
+/**
+ * Routes every HTML-bearing survey property through the sanitizer.
+ *
+ * survey-core renders `html` questions, `completedHtml`,
+ * `completedHtmlOnCondition[].html`, `completedBeforeHtml` and `loadingHtml`
+ * with `dangerouslySetInnerHTML` and performs no sanitization of its own -
+ * the library documents this and expects the host application to sanitize.
+ * All five properties funnel through `SurveyModel.processHtml`.
+ *
+ * This wraps that method rather than subscribing to the documented
+ * `onProcessHtml` event on purpose: `processHtml` fires `onProcessHtml` first
+ * and only then runs text piping, which substitutes answer values into the
+ * markup without encoding them. Sanitizing from the event would therefore be
+ * undone by any `{question}` placeholder, letting a respondent's answer reach
+ * the DOM as live markup. Wrapping the method sanitizes the final string.
+ *
+ * Patching the prototype (rather than each instance) keeps the guarantee
+ * independent of how a survey is constructed, so ad-hoc models built for
+ * dialogs are covered too.
+ */
+export function installSurveyHtmlSanitizer(): void {
+  const prototype = SurveyModel.prototype as unknown as PatchablePrototype;
+
+  if (prototype[INSTALLED_FLAG]) {
+    return;
+  }
+
+  const originalProcessHtml = prototype.processHtml as
+    | ProcessHtmlFn
+    | undefined;
+
+  if (typeof originalProcessHtml !== "function") {
+    throw new Error(
+      "[safe-html] SurveyModel.prototype.processHtml is missing - survey-core changed its HTML rendering path. " +
+        "Survey HTML would render unsanitized; update lib/survey-features/safe-html before upgrading.",
+    );
+  }
+
+  prototype.processHtml = function patchedProcessHtml(
+    this: SurveyModel,
+    html: string,
+    reason?: string,
+  ): string {
+    const processed = originalProcessHtml.call(this, html, reason);
+    return sanitizeSurveyHtml(processed);
+  } as ProcessHtmlFn;
+
+  prototype[INSTALLED_FLAG] = true;
+}

--- a/lib/survey-features/safe-html/sanitize-survey-html.ts
+++ b/lib/survey-features/safe-html/sanitize-survey-html.ts
@@ -53,7 +53,7 @@ export function installSurveyHtmlSanitizer(): void {
     | undefined;
 
   if (typeof originalProcessHtml !== "function") {
-    throw new Error(
+    throw new TypeError(
       "[safe-html] SurveyModel.prototype.processHtml is missing - survey-core changed its HTML rendering path. " +
         "Survey HTML would render unsanitized; update lib/survey-features/safe-html before upgrading.",
     );

--- a/lib/utils/html-sanitizer.ts
+++ b/lib/utils/html-sanitizer.ts
@@ -183,6 +183,41 @@ const moderateSanitizationOptions: IOptions = {
 };
 
 /**
+ * Survey HTML sanitization preset - for the HTML-bearing survey properties
+ * (`html` questions, `completedHtml`, `completedHtmlOnCondition[].html`,
+ * `completedBeforeHtml`, `loadingHtml`).
+ *
+ * Same security posture as the moderate preset (identical schemes, attribute
+ * allow-list and link hardening), but authors use these properties to lay out
+ * whole blocks of content, so it additionally allows structural tags and a
+ * deeper nesting limit. The moderate preset's `nestingLimit: 3` is tuned for
+ * inline markdown output and would silently drop table cells and any emphasis
+ * nested more than three levels deep.
+ */
+const SURVEY_HTML_EXTRA_TAGS = [
+  "b",
+  "br",
+  "caption",
+  "col",
+  "colgroup",
+  "dd",
+  "div",
+  "dl",
+  "dt",
+  "figcaption",
+  "figure",
+  "hr",
+  "i",
+  "small",
+] as const;
+
+const surveyHtmlSanitizationOptions: IOptions = {
+  ...moderateSanitizationOptions,
+  allowedTags: [...ALLOWED_TAGS, ...SURVEY_HTML_EXTRA_TAGS],
+  nestingLimit: 12,
+};
+
+/**
  * Default sanitization options - uses moderate preset.
  * @internal This configuration is security-critical. Changes should be reviewed carefully.
  */
@@ -209,12 +244,14 @@ function sanitizeHtmlInline(dirtyHtml: string): string {
  * - `strict`: Minimal tags, maximum security (for untrusted input)
  * - `inline`: Phrasing content only, safe inside &lt;label&gt; (for titles, labels)
  * - `moderate`: Block + inline content (for descriptions, rich text)
+ * - `surveyHtml`: Moderate + structural tags, for HTML-bearing survey properties
  * - `pdf`: No tags, plain text only (for PDF export and non-DOM contexts)
  */
 export const sanitizationPresets = {
   strict: strictSanitizationOptions,
   inline: inlineSanitizationOptions,
   moderate: moderateSanitizationOptions,
+  surveyHtml: surveyHtmlSanitizationOptions,
   pdf: pdfSanitizationOptions,
 } as const;
 


### PR DESCRIPTION
# Sanitize HTML-bearing survey properties to prevent stored XSS

## Description
survey-core renders `html` questions, `completedHtml`, `completedHtmlOnCondition[].html`, `completedBeforeHtml` and `loadingHtml` through `dangerouslySetInnerHTML` and performs no sanitization of its own, leaving it to the host application. Our sanitizer was only wired to `onTextMarkdown`, which by design never fires for these properties, so authored markup reached the DOM as live content.

All five properties funnel through `SurveyModel.processHtml`, which is now wrapped so its result is sanitized. Wrapping the method rather than subscribing to the documented `onProcessHtml` event is deliberate: `processHtml` fires that event first and only then runs text piping, which substitutes answer values into the markup without encoding. Sanitizing from the event would be undone by any `{question}` placeholder, so a respondent's answer could reach the DOM as markup without any edit rights at all.

The patch is applied to the prototype and installed from both instrumentation entry points, so the guarantee holds regardless of how a survey is constructed - including the ad-hoc models built for dialogs - across all 20 construction sites.

Adds a `surveyHtml` sanitizer preset: same schemes, attribute allow-list and link hardening as `moderate`, plus structural tags and a deeper nesting limit. The `moderate` preset is tuned for inline markdown and its `nestingLimit: 3` would have silently dropped table cells and nested emphasis from authored content.

Tests drive the real survey-core getters that survey-react-ui feeds to `dangerouslySetInnerHTML` rather than mocking them, and cover the piping bypass, preservation of legitimate content, and the instrumentation wiring.

## Related Issues
List any related issues  #742

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Survey content is now sanitized automatically across client and server rendering.
  * Dangerous HTML, scripts, event handlers, unsafe URLs, and embedded payloads are blocked.
  * Safe authored formatting, images, tables, lists, and headings remain supported.
  * External links are hardened with additional security protections.

* **Bug Fixes**
  * Prevented user-provided answers and completed-survey content from reintroducing unsafe HTML.
  * Preserved custom HTML processing while ensuring sanitizer installation remains safe and repeatable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->