### PR TITLE
chore(ci): add Dependabot config and pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
@@ -13,8 +16,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -44,10 +44,10 @@ jobs:
 
     steps:
       - name: 🔍 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10.33.0
           run_install: false
@@ -77,7 +77,7 @@ jobs:
           file: .coverage/endatix-hub/cobertura-coverage.xml
 
       - name: 📊 Endatix Hub Coverage
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@8b157684c6a6b259b97d45e72b44242865c0f6a5 # v2.12.2
         with:
           name: "Endatix Hub"
           json-summary-path: ".coverage/endatix-hub/coverage-summary.json"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🔍 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: 📦 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10.15
           run_install: false
@@ -31,7 +31,7 @@ jobs:
         run: pnpm exec playwright test
 
       - name: 📊 Upload Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -19,11 +19,11 @@ jobs:
     name: Validate Pull Request Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         # Adding sticky message when the previous steps fails
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
@@ -42,7 +42,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: pr-title-lint-error
           delete: true


### PR DESCRIPTION
## Description
Two supply-chain hardening changes for CI:

1. **Add `.github/dependabot.yml`** — weekly Dependabot **version updates** for:
   - **npm/pnpm** (reads `pnpm-lock.yaml`) — direct deps only, minor+patch grouped into one PR, 10-PR cap
   - **github-actions**
   - **docker** (`Dockerfile`)

   Uses a `chore` / `chore(deps)` commit prefix so Dependabot PR titles pass the Conventional-Commits check in `validate-pr-title.yml`. Scoped to **direct** dependencies by default, so it does not collide with the manual pnpm `overrides` + `comments.overrides` workflow used for transitive CVEs.

2. **Pin GitHub Actions to full commit SHAs** — all remaining tag-referenced third-party actions are pinned to a commit SHA with a `# vX.Y.Z` comment, matching the style already used for `coverallsapp/github-action` and the `endatix/release-workflows` reusable workflows:
   - `actions/checkout` → `# v4.4.0`
   - `pnpm/action-setup` → `# v4.3.0`
   - `actions/upload-artifact` → `# v4.6.2`
   - `davelosert/vitest-coverage-report-action` → `# v2.12.2`
   - `amannn/action-semantic-pull-request` → `# v5`
   - `marocchino/sticky-pull-request-comment` → `# v2.9.4`

   (`actions/setup-node` is already SHA-pinned at v7 via #774.) Once pinned this way, Dependabot maintains the SHA and bumps the `# vX` comment automatically.

> Note: enabling **Dependabot alerts / security updates** is a repo/org **Settings** toggle and is not part of this PR.

## Related Issues
_None._

## Type of Change
- [x] Dependency update
- [x] Other (CI / supply-chain hardening)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

🤖 Generated with [Claude Code](https://claude.com/claude-code)