### PR TITLE
docs: Adding security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ Security fixes are published for the latest supported release line. Customers on
 
 Use GitHub’s private vulnerability reporting so the report stays confidential until a fix is available:
 
-1. Open the repository **Security's** tab, or go directly to [Report a vulnerability](https://github.com/endatix/endatix-hub/security/advisories/new)
+1. Open the repository's **Security** tab, or go directly to [Report a vulnerability](https://github.com/endatix/endatix-hub/security/advisories/new)
 2. Provide as much detail as you can (see below)
 3. Submit the report and wait for our acknowledgment
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,90 @@
+# Security Policy
+
+Endatix Hub is **commercial, source-available** software maintained by Endatix, Ltd.
+
+We take the security of Endatix Hub seriously. If you believe you have found a vulnerability, please report it to us privately so we can investigate and remediate it before any public disclosure.
+
+## Supported Versions
+
+| Version | Supported |
+| :--- | :--- |
+| `>= 0.7.0` (Latest release on `main`) | ✅ |
+| `< 0.7.0` (Older releases) | ❌ *(Please upgrade; critical fixes may be backported at our discretion)* |
+
+Security fixes are published for the latest supported release line. Customers on licensed deployments should apply updates promptly.
+
+## Reporting a Vulnerability
+
+**Do not** open a public GitHub issue, discussion, or pull request for security vulnerabilities.
+
+### Preferred channel: GitHub Private Vulnerability Reporting (PVR)
+
+Use GitHub’s private vulnerability reporting so the report stays confidential until a fix is available:
+
+1. Open the repository **Security** tab, or go directly to [Report a vulnerability](https://github.com/endatix/endatix-hub/security/advisories/new)
+2. Provide as much detail as you can (see below)
+3. Submit the report and wait for our acknowledgment
+
+This is the **preferred** way for customers, partners, and researchers to disclose potential security issues in Endatix Hub.
+
+### What to include
+
+Helpful reports typically include:
+
+*   A clear description of the issue and its security impact.
+*   Affected product, version, and deployment context (self-hosted, SaaS, etc.) when known.
+*   **Privilege Boundary Details:** Explicitly state the required trust level to exploit the vulnerability (e.g., requires authenticated "Creator" role, or affects unauthenticated respondents).
+*   Steps to reproduce, or a proof of concept.
+*   Any logs, screenshots, or request/response samples (redact secrets and personal data).
+*   Your assessment of severity *(optional; we will triage independently)*.
+
+### Response expectations
+
+We aim to:
+
+*   **Acknowledge** valid reports within **3 business days**.
+*   **Triage** and share an initial assessment within **10 business days**.
+*   Keep you informed of remediation progress when appropriate.
+*   Credit reporters in advisories when a fix is published (unless you prefer to remain anonymous).
+
+Complex issues may take longer; we will communicate timelines as we learn more.
+
+## Coordinated Disclosure
+
+Please give us a reasonable opportunity to investigate and ship a fix before any public disclosure.
+
+We ask that you:
+
+*   Do not exploit the issue beyond what is needed to demonstrate it.
+*   Do not access, modify, or delete data that is not yours.
+*   Do not publicly share exploit details, advisories, or blog posts until we confirm a fix is available (or we agree otherwise in writing).
+
+We will work with you on a coordinated disclosure timeline once remediation is planned.
+
+<details>
+<summary><strong>Out of Scope</strong></summary>
+
+The following are generally **out of scope** unless they demonstrate a practical security impact on Endatix Hub:
+
+*   Issues in third-party dependencies with no demonstrated exploitability in this product (report upstream when appropriate).
+*   Social engineering, phishing, or physical attacks.
+*   Denial-of-service from excessive legitimate traffic without a specific application flaw.
+*   Reports based solely on automated scanner output without a validated reproduction path.
+*   Missing security headers or best-practice recommendations without a concrete vulnerability.
+*   Vulnerabilities only present in unsupported or heavily customized forks.
+</details>
+
+<details>
+<summary><strong>Safe Harbor</strong></summary>
+
+If you research and report vulnerabilities in good faith, following this policy, we will not pursue legal action related to that research. Good faith means staying within the guidelines above and avoiding privacy violations, service disruption, or data destruction.
+</details>
+
+---
+
+## Contact
+
+*   **Preferred:** [GitHub Private Vulnerability Reporting](https://github.com/endatix/endatix-hub/security/advisories/new)
+*   **General inquiries:** [tech@endatix.com](mailto:tech@endatix.com) *(not for confidential vulnerability details when PVR is available)*
+
+Thank you for helping keep Endatix Hub and our customers secure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ Security fixes are published for the latest supported release line. Customers on
 
 Use GitHub’s private vulnerability reporting so the report stays confidential until a fix is available:
 
-1. Open the repository **Security** tab, or go directly to [Report a vulnerability](https://github.com/endatix/endatix-hub/security/advisories/new)
+1. Open the repository **Security's** tab, or go directly to [Report a vulnerability](https://github.com/endatix/endatix-hub/security/advisories/new)
 2. Provide as much detail as you can (see below)
 3. Submit the report and wait for our acknowledgment
 


### PR DESCRIPTION
# docs: Adding security policy

## Description
Added security policy to help security researchers, software engineered and agents to submit security advisories with preference over [GitHub Private Vulnerability Reporting](https://github.com/endatix/endatix-hub/security/advisories/new)

## Related Issues
N/A

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.