### PR TITLE
fix(h732): Unexpected randomization of choices

### DIFF
--- a/lib/questions/__tests__/group-randomization.test.ts
+++ b/lib/questions/__tests__/group-randomization.test.ts
@@ -220,6 +220,108 @@ describe("Group Randomization Feature", () => {
     });
   });
 
+  describe("Stable random seed", () => {
+    const NINE_CHOICES = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
+
+    const getVisibleOrder = (
+      survey: SurveyModel,
+      questionName: string,
+    ): string =>
+      (survey.getQuestionByName(questionName) as QuestionSelectBase).visibleChoices
+        .map((choice) => String(choice.value))
+        .join(",");
+
+    beforeEach(() => {
+      addRandomizeGroupFeature();
+    });
+
+    it("should keep the same order for the same survey randomSeed", () => {
+      // Arrange
+      const survey = new SurveyModel({
+        elements: [
+          {
+            type: "checkbox",
+            name: "question1",
+            choices: NINE_CHOICES,
+            choicesOrder: "random",
+          },
+        ],
+      });
+
+      // Act
+      survey.randomSeed = 12345;
+      const firstOrder = getVisibleOrder(survey, "question1");
+      survey.randomSeed = 123456;
+      const otherSeedOrder = getVisibleOrder(survey, "question1");
+      survey.randomSeed = 12345;
+      const replayedOrder = getVisibleOrder(survey, "question1");
+
+      // Assert
+      expect(replayedOrder).toEqual(firstOrder);
+      expect(otherSeedOrder).not.toEqual(firstOrder);
+    });
+
+    it("should keep the same order for the same randomSeed when items have groups", () => {
+      // Arrange
+      const groupedChoices = NINE_CHOICES.map((value, index) => ({
+        value,
+        text: `Option ${value}`,
+        group: index % 2 === 0 ? "A" : "B",
+      }));
+      const survey = new SurveyModel({
+        elements: [
+          {
+            type: "checkbox",
+            name: "question1",
+            choices: groupedChoices,
+            choicesOrder: "random",
+          },
+        ],
+      });
+
+      // Act
+      survey.randomSeed = 12345;
+      const firstOrder = getVisibleOrder(survey, "question1");
+      survey.randomSeed = 123456;
+      const otherSeedOrder = getVisibleOrder(survey, "question1");
+      survey.randomSeed = 12345;
+      const replayedOrder = getVisibleOrder(survey, "question1");
+
+      // Assert
+      expect(replayedOrder).toEqual(firstOrder);
+      expect(otherSeedOrder).not.toEqual(firstOrder);
+    });
+
+    it("should not reshuffle carried-forward choices when the target value changes", () => {
+      // Arrange
+      const survey = new SurveyModel({
+        elements: [
+          { type: "checkbox", name: "question1", choices: NINE_CHOICES },
+          {
+            type: "checkbox",
+            name: "question2",
+            choicesFromQuestion: "question1",
+            choicesFromQuestionMode: "selected",
+            choicesOrder: "random",
+          },
+        ],
+      });
+      survey.setValue("question1", ["1", "2", "3", "4", "5"]);
+      const orderAfterSourceSelection = getVisibleOrder(survey, "question2");
+
+      // Act
+      const ordersWhileToggling = [1, 2, 3, 4].map((iteration) => {
+        survey.setValue("question2", iteration % 2 === 0 ? ["2"] : []);
+        return getVisibleOrder(survey, "question2");
+      });
+
+      // Assert
+      expect(new Set(ordersWhileToggling)).toEqual(
+        new Set([orderAfterSourceSelection]),
+      );
+    });
+  });
+
   describe("Integration with Survey JS", () => {
     it("should work with actual SurveyModel", () => {
       // Arrange

--- a/lib/questions/features/group-randomization.ts
+++ b/lib/questions/features/group-randomization.ts
@@ -18,7 +18,14 @@ function addRandomizeGroupFeature() {
     return;
   }
 
-  Helpers.randomizeArray = function <T>(array: T[]): T[] {
+  /**
+   * `seed` must be forwarded: survey-core derives a stable per-question seed from
+   * `survey.randomSeed`, which keeps the shuffle identical every time
+   * `visibleChoices` is recalculated. Dropping it makes survey-core fall back to
+   * `Date.now()`, so questions whose choices are rebuilt on each value change
+   * (carry forward, data lists) get reshuffled on every interaction.
+   */
+  Helpers.randomizeArray = function <T>(array: T[], seed?: number): T[] {
     if (!array || array.length === 0) {
       return array;
     }
@@ -26,10 +33,10 @@ function addRandomizeGroupFeature() {
     const hasItemsWithGroups = array.some((c) => hasGroup(c));
 
     if (!hasItemsWithGroups) {
-      return originalRandomizeArray.call(this, array) as T[];
+      return originalRandomizeArray.call(this, array, seed) as T[];
     }
 
-    return groupRandomize(array);
+    return groupRandomize(array, seed);
   };
 
   Serializer.addProperties("itemvalue", [
@@ -60,7 +67,7 @@ function addRandomizeGroupFeature() {
   isInitialized = true;
 }
 
-function groupRandomize<T>(array: T[]): T[] {
+function groupRandomize<T>(array: T[], seed?: number): T[] {
   const groups = new Map<string, T[]>();
   array.forEach((c) => {
     const g = hasGroup(c) ? c.group : "__default__";
@@ -79,7 +86,7 @@ function groupRandomize<T>(array: T[]): T[] {
     let items = groups.get(g)!;
     const randomize = hasGroup(items[0]) ? items[0].randomize !== false : true;
     if (randomize) {
-      items = originalRandomizeArray([...items]);
+      items = originalRandomizeArray([...items], seed);
     }
     result.push(...items);
   });


### PR DESCRIPTION
## Description

Forward survey-core's stable `randomSeed` through the hub's `Helpers.randomizeArray` override so questions with `choicesOrder: "random"` and derived choices (carry forward, data lists) no longer reshuffle on every value change.

## Related Issues
#732 


## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above
