### PR TITLE
feat(h819): Auto-select storage and hide the base64 option when a storage provider is enabled

### DIFF
--- a/features/asset-storage/__tests__/use-cases/upload-content-files/use-creator-storage.hook.test.tsx
+++ b/features/asset-storage/__tests__/use-cases/upload-content-files/use-creator-storage.hook.test.tsx
@@ -12,6 +12,11 @@ const mockRegisterUploadHandlers = vi.fn();
 const mockPrefetchPrivateReadUrlsForModel = vi
   .fn()
   .mockResolvedValue(undefined);
+const { mockRegisterStorageOnlyFileModeGlobals, mockBindStorageOnlyFileModeToCreator } =
+  vi.hoisted(() => ({
+    mockRegisterStorageOnlyFileModeGlobals: vi.fn(),
+    mockBindStorageOnlyFileModeToCreator: vi.fn(),
+  }));
 
 vi.mock(
   "@/features/asset-storage/use-cases/upload-content-files/use-content-upload.hook",
@@ -31,6 +36,11 @@ vi.mock(
   }),
 );
 
+vi.mock("@/lib/survey-features/storage-only-file-mode", () => ({
+  registerStorageOnlyFileModeGlobals: mockRegisterStorageOnlyFileModeGlobals,
+  bindStorageOnlyFileModeToCreator: mockBindStorageOnlyFileModeToCreator,
+}));
+
 const createMockSurveyModel = () =>
   ({
     render: vi.fn(),
@@ -49,6 +59,7 @@ describe("useStorageWithCreator", () => {
     vi.clearAllMocks();
     mockRegisterUploadHandlers.mockReturnValue(() => {});
     mockPrefetchPrivateReadUrlsForModel.mockResolvedValue(undefined);
+    mockBindStorageOnlyFileModeToCreator.mockReturnValue(vi.fn());
   });
 
   const wrapper = (config: ClientStorageConfig | null) => {
@@ -114,6 +125,8 @@ describe("useStorageWithCreator", () => {
       unregister = result!.current.registerStorageHandlers(creator);
     });
     expect(mockRegisterUploadHandlers).not.toHaveBeenCalled();
+    expect(mockRegisterStorageOnlyFileModeGlobals).not.toHaveBeenCalled();
+    expect(mockBindStorageOnlyFileModeToCreator).not.toHaveBeenCalled();
     unregister();
   });
 
@@ -145,7 +158,13 @@ describe("useStorageWithCreator", () => {
       unregister = result!.current.registerStorageHandlers(creator);
     });
     expect(mockRegisterUploadHandlers).toHaveBeenCalledWith(creator);
+    expect(mockRegisterStorageOnlyFileModeGlobals).toHaveBeenCalledTimes(1);
+    expect(mockBindStorageOnlyFileModeToCreator).toHaveBeenCalledWith(creator);
+
+    const unbindStorageOnlyFileMode =
+      mockBindStorageOnlyFileModeToCreator.mock.results[0]?.value;
     unregister();
+    expect(unbindStorageOnlyFileMode).toHaveBeenCalledTimes(1);
   });
 
   it("should register upload handlers when private", async () => {

--- a/features/asset-storage/ui/hooks/use-storage-with-creator.hook.tsx
+++ b/features/asset-storage/ui/hooks/use-storage-with-creator.hook.tsx
@@ -3,6 +3,10 @@
 import { useCallback, useRef, useState } from "react";
 import { SurveyCreatorModel } from "survey-creator-core";
 import type { SurveyModel } from "survey-core";
+import {
+  bindStorageOnlyFileModeToCreator,
+  registerStorageOnlyFileModeGlobals,
+} from "@/lib/survey-features/storage-only-file-mode";
 import { useContentUpload } from "../../use-cases/upload-content-files/use-content-upload.hook";
 import { useStorageView } from "../../use-cases/view-protected-files/use-storage-view.hook";
 import { useAssetStorage } from "../asset-storage.context";
@@ -61,6 +65,9 @@ export function useStorageWithCreator({
       }
 
       const unregisterUpload = registerUploadHandlers(creator);
+      registerStorageOnlyFileModeGlobals();
+      const unregisterStorageOnlyFileMode =
+        bindStorageOnlyFileModeToCreator(creator);
       attachSurveyViewHandlers(creator.survey);
 
       const onActiveTabChanged = () => {
@@ -86,6 +93,7 @@ export function useStorageWithCreator({
         creator.onActiveTabChanged?.remove(onActiveTabChanged);
         creator.onSurveyInstanceCreated?.remove(onSurveyInstanceCreated);
         unregisterUpload?.();
+        unregisterStorageOnlyFileMode();
       };
     },
     [

--- a/lib/survey-features/storage-only-file-mode/__tests__/creator-bindings.test.ts
+++ b/lib/survey-features/storage-only-file-mode/__tests__/creator-bindings.test.ts
@@ -1,0 +1,49 @@
+import { Model, Question } from "survey-core";
+import type { SurveyCreatorModel } from "survey-creator-core";
+import { describe, expect, it, vi } from "vitest";
+import { bindStorageOnlyFileModeToCreator } from "../infrastructure/creator-bindings";
+
+type QuestionWithStoreAsText = Question & { storeDataAsText?: boolean };
+
+function createMockCreator(survey: Model): SurveyCreatorModel {
+  return {
+    survey,
+    onSurveyInstanceCreated: { add: vi.fn(), remove: vi.fn() },
+  } as unknown as SurveyCreatorModel;
+}
+
+describe("bindStorageOnlyFileModeToCreator", () => {
+  it("enforces storeDataAsText on the designer survey's file questions", () => {
+    // Arrange
+    const survey = new Model({
+      elements: [{ type: "file", name: "attachment", storeDataAsText: true }],
+    });
+    const creator = createMockCreator(survey);
+
+    // Act
+    bindStorageOnlyFileModeToCreator(creator);
+
+    // Assert
+    const question = survey.getQuestionByName(
+      "attachment",
+    ) as QuestionWithStoreAsText;
+    expect(question.storeDataAsText).toBe(false);
+  });
+
+  it("returns a cleanup function that unbinds the designer survey", () => {
+    // Arrange
+    const survey = new Model({ elements: [] });
+    const creator = createMockCreator(survey);
+    const cleanup = bindStorageOnlyFileModeToCreator(creator);
+
+    // Act
+    cleanup();
+    survey.pages[0].addNewQuestion("file", "newAttachment");
+
+    // Assert
+    const question = survey.getQuestionByName(
+      "newAttachment",
+    ) as QuestionWithStoreAsText;
+    expect(question.storeDataAsText).toBe(true);
+  });
+});

--- a/lib/survey-features/storage-only-file-mode/__tests__/registry.test.ts
+++ b/lib/survey-features/storage-only-file-mode/__tests__/registry.test.ts
@@ -12,7 +12,7 @@ describe("registerStorageOnlyFileModeGlobals", () => {
   });
 
   it.each(["file", "signaturepad"])(
-    "hides storeDataAsText and defaults it to false for %s",
+    "hides storeDataAsText for %s",
     (type) => {
       // Act
       registerStorageOnlyFileModeGlobals();
@@ -20,7 +20,19 @@ describe("registerStorageOnlyFileModeGlobals", () => {
       // Assert
       const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
       expect(prop?.visible).toBe(false);
-      expect(prop?.defaultValue).toBe(false);
+    },
+  );
+
+  it.each(["file", "signaturepad"])(
+    "leaves the built-in default (true) untouched for %s",
+    (type) => {
+      // Act
+      registerStorageOnlyFileModeGlobals();
+
+      // Assert: an explicit storeDataAsText:false must stay distinguishable
+      // from "unset" so it still serializes on save (see registry.ts).
+      const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
+      expect(prop?.defaultValue).toBe(true);
     },
   );
 
@@ -37,7 +49,7 @@ describe("registerStorageOnlyFileModeGlobals", () => {
 
 describe("resetStorageOnlyFileModeRegistryForTests", () => {
   it.each(["file", "signaturepad"])(
-    "restores storeDataAsText visibility and default for %s",
+    "restores storeDataAsText visibility for %s",
     (type) => {
       // Arrange
       registerStorageOnlyFileModeGlobals();
@@ -48,7 +60,6 @@ describe("resetStorageOnlyFileModeRegistryForTests", () => {
       // Assert
       const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
       expect(prop?.visible).toBe(true);
-      expect(prop?.defaultValue).toBe(true);
     },
   );
 });

--- a/lib/survey-features/storage-only-file-mode/__tests__/registry.test.ts
+++ b/lib/survey-features/storage-only-file-mode/__tests__/registry.test.ts
@@ -1,6 +1,6 @@
 import { Serializer } from "survey-core";
 import { afterEach, describe, expect, it } from "vitest";
-import { STORE_DATA_AS_TEXT_PROPERTY } from "../constants";
+import { STORE_DATA_AS_TEXT_PROPERTY, WAIT_FOR_UPLOAD_PROPERTY } from "../constants";
 import {
   registerStorageOnlyFileModeGlobals,
   resetStorageOnlyFileModeRegistryForTests,
@@ -12,27 +12,37 @@ describe("registerStorageOnlyFileModeGlobals", () => {
   });
 
   it.each(["file", "signaturepad"])(
-    "hides storeDataAsText for %s",
+    "hides storeDataAsText and waitForUpload for %s",
     (type) => {
       // Act
       registerStorageOnlyFileModeGlobals();
 
       // Assert
-      const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
-      expect(prop?.visible).toBe(false);
+      expect(
+        Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY)?.visible,
+      ).toBe(false);
+      expect(
+        Serializer.findProperty(type, WAIT_FOR_UPLOAD_PROPERTY)?.visible,
+      ).toBe(false);
     },
   );
 
   it.each(["file", "signaturepad"])(
-    "leaves the built-in default (true) untouched for %s",
+    "leaves the built-in defaults untouched for %s",
     (type) => {
       // Act
       registerStorageOnlyFileModeGlobals();
 
-      // Assert: an explicit storeDataAsText:false must stay distinguishable
-      // from "unset" so it still serializes on save (see registry.ts).
-      const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
-      expect(prop?.defaultValue).toBe(true);
+      // Assert: an explicit storeDataAsText:false / waitForUpload:true must
+      // stay distinguishable from "unset" so it still serializes on save
+      // (see registry.ts and bindStorageOnlyFileModeToSurvey).
+      expect(
+        Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY)
+          ?.defaultValue,
+      ).toBe(true);
+      expect(
+        Serializer.findProperty(type, WAIT_FOR_UPLOAD_PROPERTY)?.defaultValue,
+      ).toBe(false);
     },
   );
 
@@ -42,14 +52,18 @@ describe("registerStorageOnlyFileModeGlobals", () => {
     registerStorageOnlyFileModeGlobals();
 
     // Assert
-    const prop = Serializer.findProperty("file", STORE_DATA_AS_TEXT_PROPERTY);
-    expect(prop?.visible).toBe(false);
+    expect(
+      Serializer.findProperty("file", STORE_DATA_AS_TEXT_PROPERTY)?.visible,
+    ).toBe(false);
+    expect(
+      Serializer.findProperty("file", WAIT_FOR_UPLOAD_PROPERTY)?.visible,
+    ).toBe(false);
   });
 });
 
 describe("resetStorageOnlyFileModeRegistryForTests", () => {
   it.each(["file", "signaturepad"])(
-    "restores storeDataAsText visibility for %s",
+    "restores storeDataAsText and waitForUpload visibility for %s",
     (type) => {
       // Arrange
       registerStorageOnlyFileModeGlobals();
@@ -58,8 +72,12 @@ describe("resetStorageOnlyFileModeRegistryForTests", () => {
       resetStorageOnlyFileModeRegistryForTests();
 
       // Assert
-      const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
-      expect(prop?.visible).toBe(true);
+      expect(
+        Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY)?.visible,
+      ).toBe(true);
+      expect(
+        Serializer.findProperty(type, WAIT_FOR_UPLOAD_PROPERTY)?.visible,
+      ).toBe(true);
     },
   );
 });

--- a/lib/survey-features/storage-only-file-mode/__tests__/registry.test.ts
+++ b/lib/survey-features/storage-only-file-mode/__tests__/registry.test.ts
@@ -1,0 +1,54 @@
+import { Serializer } from "survey-core";
+import { afterEach, describe, expect, it } from "vitest";
+import { STORE_DATA_AS_TEXT_PROPERTY } from "../constants";
+import {
+  registerStorageOnlyFileModeGlobals,
+  resetStorageOnlyFileModeRegistryForTests,
+} from "../infrastructure/registry";
+
+describe("registerStorageOnlyFileModeGlobals", () => {
+  afterEach(() => {
+    resetStorageOnlyFileModeRegistryForTests();
+  });
+
+  it.each(["file", "signaturepad"])(
+    "hides storeDataAsText and defaults it to false for %s",
+    (type) => {
+      // Act
+      registerStorageOnlyFileModeGlobals();
+
+      // Assert
+      const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
+      expect(prop?.visible).toBe(false);
+      expect(prop?.defaultValue).toBe(false);
+    },
+  );
+
+  it("is idempotent across repeated calls", () => {
+    // Act
+    registerStorageOnlyFileModeGlobals();
+    registerStorageOnlyFileModeGlobals();
+
+    // Assert
+    const prop = Serializer.findProperty("file", STORE_DATA_AS_TEXT_PROPERTY);
+    expect(prop?.visible).toBe(false);
+  });
+});
+
+describe("resetStorageOnlyFileModeRegistryForTests", () => {
+  it.each(["file", "signaturepad"])(
+    "restores storeDataAsText visibility and default for %s",
+    (type) => {
+      // Arrange
+      registerStorageOnlyFileModeGlobals();
+
+      // Act
+      resetStorageOnlyFileModeRegistryForTests();
+
+      // Assert
+      const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
+      expect(prop?.visible).toBe(true);
+      expect(prop?.defaultValue).toBe(true);
+    },
+  );
+});

--- a/lib/survey-features/storage-only-file-mode/__tests__/survey-bindings.test.ts
+++ b/lib/survey-features/storage-only-file-mode/__tests__/survey-bindings.test.ts
@@ -2,13 +2,23 @@ import { Model, Question } from "survey-core";
 import { describe, expect, it } from "vitest";
 import { bindStorageOnlyFileModeToSurvey } from "../infrastructure/survey-bindings";
 
-type QuestionWithStoreAsText = Question & { storeDataAsText?: boolean };
+type StorageOnlyFileModeQuestion = Question & {
+  storeDataAsText?: boolean;
+  waitForUpload?: boolean;
+};
 
 describe("bindStorageOnlyFileModeToSurvey", () => {
-  it("forces storeDataAsText to false on an existing file question", () => {
+  it("forces storeDataAsText to false and waitForUpload to true on an existing file question", () => {
     // Arrange
     const model = new Model({
-      elements: [{ type: "file", name: "attachment", storeDataAsText: true }],
+      elements: [
+        {
+          type: "file",
+          name: "attachment",
+          storeDataAsText: true,
+          waitForUpload: false,
+        },
+      ],
     });
 
     // Act
@@ -17,17 +27,19 @@ describe("bindStorageOnlyFileModeToSurvey", () => {
     // Assert
     const question = model.getQuestionByName(
       "attachment",
-    ) as QuestionWithStoreAsText;
+    ) as StorageOnlyFileModeQuestion;
     expect(question.storeDataAsText).toBe(false);
+    expect(question.waitForUpload).toBe(true);
   });
 
-  it("serializes the forced value explicitly, so it survives a save/reload round trip", () => {
-    // Arrange: a question that never had storeDataAsText set at all — this
-    // is the regression case. If the Serializer's declared default were
-    // ever changed to false alongside hiding the property, an explicitly
-    // forced `false` here would match "default" and get dropped from
-    // toJSON(), silently reverting to base64 embedding for a respondent
-    // Model that parses this JSON later.
+  it("serializes both forced values explicitly, so they survive a save/reload round trip", () => {
+    // Arrange: a question that never had either property set — this is the
+    // regression case. storeDataAsText's built-in default is true;
+    // waitForUpload's is false. If either Serializer default were ever
+    // changed to match the forced value, the explicit value here would look
+    // like "default" and get dropped from toJSON(), silently reverting to
+    // base64 embedding / not waiting for uploads for a respondent Model that
+    // parses this JSON later (see registry.ts).
     const model = new Model({
       elements: [{ type: "file", name: "attachment" }],
     });
@@ -37,11 +49,15 @@ describe("bindStorageOnlyFileModeToSurvey", () => {
 
     // Assert
     const question = model.getQuestionByName("attachment") as Question;
-    const json = question.toJSON() as { storeDataAsText?: boolean };
+    const json = question.toJSON() as {
+      storeDataAsText?: boolean;
+      waitForUpload?: boolean;
+    };
     expect(json.storeDataAsText).toBe(false);
+    expect(json.waitForUpload).toBe(true);
   });
 
-  it("forces storeDataAsText to false on an existing signaturepad question", () => {
+  it("forces storeDataAsText to false and waitForUpload to true on an existing signaturepad question", () => {
     // Arrange
     const model = new Model({
       elements: [{ type: "signaturepad", name: "signature" }],
@@ -53,11 +69,12 @@ describe("bindStorageOnlyFileModeToSurvey", () => {
     // Assert
     const question = model.getQuestionByName(
       "signature",
-    ) as QuestionWithStoreAsText;
+    ) as StorageOnlyFileModeQuestion;
     expect(question.storeDataAsText).toBe(false);
+    expect(question.waitForUpload).toBe(true);
   });
 
-  it("forces storeDataAsText to false on a file question nested in a dynamic panel template", () => {
+  it("forces both properties on a file question nested in a dynamic panel template", () => {
     // Arrange
     const model = new Model({
       elements: [
@@ -77,9 +94,10 @@ describe("bindStorageOnlyFileModeToSurvey", () => {
     const nested = model
       .getAllQuestions(false, false, true)
       .find((q) => q.getType() === "file") as
-      | QuestionWithStoreAsText
+      | StorageOnlyFileModeQuestion
       | undefined;
     expect(nested?.storeDataAsText).toBe(false);
+    expect(nested?.waitForUpload).toBe(true);
   });
 
   it("leaves unrelated question types untouched", () => {
@@ -90,11 +108,12 @@ describe("bindStorageOnlyFileModeToSurvey", () => {
     expect(() => bindStorageOnlyFileModeToSurvey(model)).not.toThrow();
     const question = model.getQuestionByName(
       "comment",
-    ) as QuestionWithStoreAsText;
+    ) as StorageOnlyFileModeQuestion;
     expect(question.storeDataAsText).toBeUndefined();
+    expect(question.waitForUpload).toBeUndefined();
   });
 
-  it("forces storeDataAsText to false on a file question added after binding", () => {
+  it("forces both properties on a file question added after binding", () => {
     // Arrange
     const model = new Model({ elements: [] });
     bindStorageOnlyFileModeToSurvey(model);
@@ -105,8 +124,9 @@ describe("bindStorageOnlyFileModeToSurvey", () => {
     // Assert
     const question = model.getQuestionByName(
       "newAttachment",
-    ) as QuestionWithStoreAsText;
+    ) as StorageOnlyFileModeQuestion;
     expect(question.storeDataAsText).toBe(false);
+    expect(question.waitForUpload).toBe(true);
   });
 
   it("stops enforcing after the returned cleanup runs", () => {
@@ -121,7 +141,8 @@ describe("bindStorageOnlyFileModeToSurvey", () => {
     // Assert
     const question = model.getQuestionByName(
       "newAttachment",
-    ) as QuestionWithStoreAsText;
+    ) as StorageOnlyFileModeQuestion;
     expect(question.storeDataAsText).toBe(true);
+    expect(question.waitForUpload).toBe(false);
   });
 });

--- a/lib/survey-features/storage-only-file-mode/__tests__/survey-bindings.test.ts
+++ b/lib/survey-features/storage-only-file-mode/__tests__/survey-bindings.test.ts
@@ -21,6 +21,26 @@ describe("bindStorageOnlyFileModeToSurvey", () => {
     expect(question.storeDataAsText).toBe(false);
   });
 
+  it("serializes the forced value explicitly, so it survives a save/reload round trip", () => {
+    // Arrange: a question that never had storeDataAsText set at all — this
+    // is the regression case. If the Serializer's declared default were
+    // ever changed to false alongside hiding the property, an explicitly
+    // forced `false` here would match "default" and get dropped from
+    // toJSON(), silently reverting to base64 embedding for a respondent
+    // Model that parses this JSON later.
+    const model = new Model({
+      elements: [{ type: "file", name: "attachment" }],
+    });
+
+    // Act
+    bindStorageOnlyFileModeToSurvey(model);
+
+    // Assert
+    const question = model.getQuestionByName("attachment") as Question;
+    const json = question.toJSON() as { storeDataAsText?: boolean };
+    expect(json.storeDataAsText).toBe(false);
+  });
+
   it("forces storeDataAsText to false on an existing signaturepad question", () => {
     // Arrange
     const model = new Model({

--- a/lib/survey-features/storage-only-file-mode/__tests__/survey-bindings.test.ts
+++ b/lib/survey-features/storage-only-file-mode/__tests__/survey-bindings.test.ts
@@ -1,0 +1,107 @@
+import { Model, Question } from "survey-core";
+import { describe, expect, it } from "vitest";
+import { bindStorageOnlyFileModeToSurvey } from "../infrastructure/survey-bindings";
+
+type QuestionWithStoreAsText = Question & { storeDataAsText?: boolean };
+
+describe("bindStorageOnlyFileModeToSurvey", () => {
+  it("forces storeDataAsText to false on an existing file question", () => {
+    // Arrange
+    const model = new Model({
+      elements: [{ type: "file", name: "attachment", storeDataAsText: true }],
+    });
+
+    // Act
+    bindStorageOnlyFileModeToSurvey(model);
+
+    // Assert
+    const question = model.getQuestionByName(
+      "attachment",
+    ) as QuestionWithStoreAsText;
+    expect(question.storeDataAsText).toBe(false);
+  });
+
+  it("forces storeDataAsText to false on an existing signaturepad question", () => {
+    // Arrange
+    const model = new Model({
+      elements: [{ type: "signaturepad", name: "signature" }],
+    });
+
+    // Act
+    bindStorageOnlyFileModeToSurvey(model);
+
+    // Assert
+    const question = model.getQuestionByName(
+      "signature",
+    ) as QuestionWithStoreAsText;
+    expect(question.storeDataAsText).toBe(false);
+  });
+
+  it("forces storeDataAsText to false on a file question nested in a dynamic panel template", () => {
+    // Arrange
+    const model = new Model({
+      elements: [
+        {
+          type: "paneldynamic",
+          name: "attachments",
+          templateElements: [{ type: "file", name: "attachment" }],
+          panelCount: 1,
+        },
+      ],
+    });
+
+    // Act
+    bindStorageOnlyFileModeToSurvey(model);
+
+    // Assert
+    const nested = model
+      .getAllQuestions(false, false, true)
+      .find((q) => q.getType() === "file") as
+      | QuestionWithStoreAsText
+      | undefined;
+    expect(nested?.storeDataAsText).toBe(false);
+  });
+
+  it("leaves unrelated question types untouched", () => {
+    // Arrange
+    const model = new Model({ elements: [{ type: "text", name: "comment" }] });
+
+    // Act & Assert
+    expect(() => bindStorageOnlyFileModeToSurvey(model)).not.toThrow();
+    const question = model.getQuestionByName(
+      "comment",
+    ) as QuestionWithStoreAsText;
+    expect(question.storeDataAsText).toBeUndefined();
+  });
+
+  it("forces storeDataAsText to false on a file question added after binding", () => {
+    // Arrange
+    const model = new Model({ elements: [] });
+    bindStorageOnlyFileModeToSurvey(model);
+
+    // Act
+    model.pages[0].addNewQuestion("file", "newAttachment");
+
+    // Assert
+    const question = model.getQuestionByName(
+      "newAttachment",
+    ) as QuestionWithStoreAsText;
+    expect(question.storeDataAsText).toBe(false);
+  });
+
+  it("stops enforcing after the returned cleanup runs", () => {
+    // Arrange
+    const model = new Model({ elements: [] });
+    const cleanup = bindStorageOnlyFileModeToSurvey(model);
+
+    // Act
+    cleanup();
+    model.pages[0].addNewQuestion("file", "newAttachment");
+
+    // Assert
+    const question = model.getQuestionByName(
+      "newAttachment",
+    ) as QuestionWithStoreAsText;
+    expect(question.storeDataAsText).toBe(true);
+  });
+});

--- a/lib/survey-features/storage-only-file-mode/constants.ts
+++ b/lib/survey-features/storage-only-file-mode/constants.ts
@@ -7,6 +7,7 @@ export type StorageOnlyFileModeQuestionType =
   (typeof STORAGE_ONLY_FILE_MODE_QUESTION_TYPES)[number];
 
 export const STORE_DATA_AS_TEXT_PROPERTY = "storeDataAsText";
+export const WAIT_FOR_UPLOAD_PROPERTY = "waitForUpload";
 
 export const STORAGE_ONLY_FILE_MODE_CREATOR_BOUND_KEY =
   "__endatixStorageOnlyFileModeCreatorBound";

--- a/lib/survey-features/storage-only-file-mode/constants.ts
+++ b/lib/survey-features/storage-only-file-mode/constants.ts
@@ -1,0 +1,12 @@
+export const STORAGE_ONLY_FILE_MODE_QUESTION_TYPES = [
+  "file",
+  "signaturepad",
+] as const;
+
+export type StorageOnlyFileModeQuestionType =
+  (typeof STORAGE_ONLY_FILE_MODE_QUESTION_TYPES)[number];
+
+export const STORE_DATA_AS_TEXT_PROPERTY = "storeDataAsText";
+
+export const STORAGE_ONLY_FILE_MODE_CREATOR_BOUND_KEY =
+  "__endatixStorageOnlyFileModeCreatorBound";

--- a/lib/survey-features/storage-only-file-mode/index.ts
+++ b/lib/survey-features/storage-only-file-mode/index.ts
@@ -1,0 +1,10 @@
+export {
+  registerStorageOnlyFileModeGlobals,
+  resetStorageOnlyFileModeRegistryForTests,
+} from "./infrastructure/registry";
+export { bindStorageOnlyFileModeToCreator } from "./infrastructure/creator-bindings";
+export { bindStorageOnlyFileModeToSurvey } from "./infrastructure/survey-bindings";
+export {
+  STORAGE_ONLY_FILE_MODE_QUESTION_TYPES,
+  STORE_DATA_AS_TEXT_PROPERTY,
+} from "./constants";

--- a/lib/survey-features/storage-only-file-mode/index.ts
+++ b/lib/survey-features/storage-only-file-mode/index.ts
@@ -7,4 +7,5 @@ export { bindStorageOnlyFileModeToSurvey } from "./infrastructure/survey-binding
 export {
   STORAGE_ONLY_FILE_MODE_QUESTION_TYPES,
   STORE_DATA_AS_TEXT_PROPERTY,
+  WAIT_FOR_UPLOAD_PROPERTY,
 } from "./constants";

--- a/lib/survey-features/storage-only-file-mode/infrastructure/creator-bindings.ts
+++ b/lib/survey-features/storage-only-file-mode/infrastructure/creator-bindings.ts
@@ -1,0 +1,19 @@
+import type { SurveyCreatorModel } from "survey-creator-core";
+import { bindSurveyToCreatorAreas } from "@/lib/survey-features/infrastructure/creator-survey-bindings";
+import { STORAGE_ONLY_FILE_MODE_CREATOR_BOUND_KEY } from "../constants";
+import { bindStorageOnlyFileModeToSurvey } from "./survey-bindings";
+
+/**
+ * Binds storage-only file mode to every Creator survey instance (designer +
+ * preview tabs). Call only when a storage provider is enabled — see
+ * registerStorageOnlyFileModeGlobals for the paired property-grid change.
+ */
+export function bindStorageOnlyFileModeToCreator(
+  creator: SurveyCreatorModel,
+): () => void {
+  return bindSurveyToCreatorAreas(
+    creator,
+    STORAGE_ONLY_FILE_MODE_CREATOR_BOUND_KEY,
+    bindStorageOnlyFileModeToSurvey,
+  );
+}

--- a/lib/survey-features/storage-only-file-mode/infrastructure/registry.ts
+++ b/lib/survey-features/storage-only-file-mode/infrastructure/registry.ts
@@ -2,44 +2,61 @@ import { Serializer } from "survey-core";
 import {
   STORAGE_ONLY_FILE_MODE_QUESTION_TYPES,
   STORE_DATA_AS_TEXT_PROPERTY,
+  WAIT_FOR_UPLOAD_PROPERTY,
 } from "../constants";
+
+// Both are forced by bindStorageOnlyFileModeToSurvey (storeDataAsText: false,
+// waitForUpload: true). Hide both from the grid — leaving either editable
+// lets an author flip it back and silently defeat the enforcement.
+const HIDDEN_PROPERTIES = [
+  STORE_DATA_AS_TEXT_PROPERTY,
+  WAIT_FOR_UPLOAD_PROPERTY,
+] as const;
 
 let isStorageOnlyFileModeRegistryInitialized = false;
 
-function isStoreDataAsTextHidden(type: string): boolean {
-  const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
+function isPropertyHidden(type: string, propertyName: string): boolean {
+  const prop = Serializer.findProperty(type, propertyName);
   return prop?.visible === false;
 }
 
+function areAllPropertiesHidden(type: string): boolean {
+  return HIDDEN_PROPERTIES.every((propertyName) =>
+    isPropertyHidden(type, propertyName),
+  );
+}
+
 /**
- * Hides `storeDataAsText` from the Creator property grid for file/signaturepad
- * questions. Call only when a storage provider is enabled — without one,
- * files must stay embedded as base64 text since there's nowhere to upload
- * them to.
+ * Hides `storeDataAsText` and `waitForUpload` from the Creator property grid
+ * for file/signaturepad questions. Call only when a storage provider is
+ * enabled — without one, files must stay embedded as base64 text since
+ * there's nowhere to upload them to.
  *
- * Deliberately leaves the Serializer's `defaultValue` (`true`) untouched.
- * Flipping the default here would make an explicit `storeDataAsText: false`
- * equal to "default" and get dropped from the saved JSON — then a
- * respondent's Model (a separate session that never runs this registry)
- * would fall back to the built-in default of `true` and silently re-embed
- * files as base64. bindStorageOnlyFileModeToSurvey sets the value explicitly
- * per question instead, so it always differs from the default and always
- * serializes.
+ * Deliberately leaves the Serializer's declared defaults (`true` for
+ * storeDataAsText, `false` for waitForUpload) untouched. Flipping a default
+ * here would make bindStorageOnlyFileModeToSurvey's explicit value equal to
+ * "default" and get dropped from the saved JSON — then a respondent's Model
+ * (a separate session that never runs this registry) would fall back to the
+ * built-in default and silently misbehave (re-embed as base64, or not wait
+ * for the upload). Setting the value explicitly per question instead means
+ * it always differs from the default and always serializes.
  */
 export function registerStorageOnlyFileModeGlobals(): void {
   if (
     isStorageOnlyFileModeRegistryInitialized &&
-    STORAGE_ONLY_FILE_MODE_QUESTION_TYPES.every(isStoreDataAsTextHidden)
+    STORAGE_ONLY_FILE_MODE_QUESTION_TYPES.every(areAllPropertiesHidden)
   ) {
     return;
   }
 
   STORAGE_ONLY_FILE_MODE_QUESTION_TYPES.forEach((type) => {
-    const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
-    if (!prop) {
-      return;
-    }
-    prop.visible = false;
+    HIDDEN_PROPERTIES.forEach((propertyName) => {
+      const prop = Serializer.findProperty(type, propertyName);
+      if (!prop) {
+        return;
+      }
+      prop.visible = false;
+    });
   });
 
   isStorageOnlyFileModeRegistryInitialized = true;
@@ -47,11 +64,13 @@ export function registerStorageOnlyFileModeGlobals(): void {
 
 export function resetStorageOnlyFileModeRegistryForTests(): void {
   STORAGE_ONLY_FILE_MODE_QUESTION_TYPES.forEach((type) => {
-    const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
-    if (!prop) {
-      return;
-    }
-    prop.visible = true;
+    HIDDEN_PROPERTIES.forEach((propertyName) => {
+      const prop = Serializer.findProperty(type, propertyName);
+      if (!prop) {
+        return;
+      }
+      prop.visible = true;
+    });
   });
 
   isStorageOnlyFileModeRegistryInitialized = false;

--- a/lib/survey-features/storage-only-file-mode/infrastructure/registry.ts
+++ b/lib/survey-features/storage-only-file-mode/infrastructure/registry.ts
@@ -1,0 +1,51 @@
+import { Serializer } from "survey-core";
+import {
+  STORAGE_ONLY_FILE_MODE_QUESTION_TYPES,
+  STORE_DATA_AS_TEXT_PROPERTY,
+} from "../constants";
+
+let isStorageOnlyFileModeRegistryInitialized = false;
+
+function isStoreDataAsTextHidden(type: string): boolean {
+  const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
+  return prop?.visible === false;
+}
+
+/**
+ * Hides `storeDataAsText` from the Creator property grid and flips its
+ * default to `false` for file/signaturepad questions. Call only when a
+ * storage provider is enabled — without one, files must stay embedded as
+ * base64 text since there's nowhere to upload them to.
+ */
+export function registerStorageOnlyFileModeGlobals(): void {
+  if (
+    isStorageOnlyFileModeRegistryInitialized &&
+    STORAGE_ONLY_FILE_MODE_QUESTION_TYPES.every(isStoreDataAsTextHidden)
+  ) {
+    return;
+  }
+
+  STORAGE_ONLY_FILE_MODE_QUESTION_TYPES.forEach((type) => {
+    const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
+    if (!prop) {
+      return;
+    }
+    prop.visible = false;
+    prop.defaultValue = false;
+  });
+
+  isStorageOnlyFileModeRegistryInitialized = true;
+}
+
+export function resetStorageOnlyFileModeRegistryForTests(): void {
+  STORAGE_ONLY_FILE_MODE_QUESTION_TYPES.forEach((type) => {
+    const prop = Serializer.findProperty(type, STORE_DATA_AS_TEXT_PROPERTY);
+    if (!prop) {
+      return;
+    }
+    prop.visible = true;
+    prop.defaultValue = true;
+  });
+
+  isStorageOnlyFileModeRegistryInitialized = false;
+}

--- a/lib/survey-features/storage-only-file-mode/infrastructure/registry.ts
+++ b/lib/survey-features/storage-only-file-mode/infrastructure/registry.ts
@@ -12,10 +12,19 @@ function isStoreDataAsTextHidden(type: string): boolean {
 }
 
 /**
- * Hides `storeDataAsText` from the Creator property grid and flips its
- * default to `false` for file/signaturepad questions. Call only when a
- * storage provider is enabled — without one, files must stay embedded as
- * base64 text since there's nowhere to upload them to.
+ * Hides `storeDataAsText` from the Creator property grid for file/signaturepad
+ * questions. Call only when a storage provider is enabled — without one,
+ * files must stay embedded as base64 text since there's nowhere to upload
+ * them to.
+ *
+ * Deliberately leaves the Serializer's `defaultValue` (`true`) untouched.
+ * Flipping the default here would make an explicit `storeDataAsText: false`
+ * equal to "default" and get dropped from the saved JSON — then a
+ * respondent's Model (a separate session that never runs this registry)
+ * would fall back to the built-in default of `true` and silently re-embed
+ * files as base64. bindStorageOnlyFileModeToSurvey sets the value explicitly
+ * per question instead, so it always differs from the default and always
+ * serializes.
  */
 export function registerStorageOnlyFileModeGlobals(): void {
   if (
@@ -31,7 +40,6 @@ export function registerStorageOnlyFileModeGlobals(): void {
       return;
     }
     prop.visible = false;
-    prop.defaultValue = false;
   });
 
   isStorageOnlyFileModeRegistryInitialized = true;
@@ -44,7 +52,6 @@ export function resetStorageOnlyFileModeRegistryForTests(): void {
       return;
     }
     prop.visible = true;
-    prop.defaultValue = true;
   });
 
   isStorageOnlyFileModeRegistryInitialized = false;

--- a/lib/survey-features/storage-only-file-mode/infrastructure/survey-bindings.ts
+++ b/lib/survey-features/storage-only-file-mode/infrastructure/survey-bindings.ts
@@ -1,27 +1,23 @@
-import type { Model, Question, QuestionAddedEvent } from "survey-core";
+import type {
+  Model,
+  Question,
+  QuestionAddedEvent,
+  QuestionFileModelBase,
+} from "survey-core";
 import {
   STORAGE_ONLY_FILE_MODE_QUESTION_TYPES,
-  STORE_DATA_AS_TEXT_PROPERTY,
-  WAIT_FOR_UPLOAD_PROPERTY,
   type StorageOnlyFileModeQuestionType,
 } from "../constants";
 
-type StorageOnlyFileModeQuestion = Question & {
-  [STORE_DATA_AS_TEXT_PROPERTY]?: boolean;
-  [WAIT_FOR_UPLOAD_PROPERTY]?: boolean;
-};
-
-function isStorageOnlyFileModeQuestion(
+function isFileStorageQuestion(
   question: Question,
-): question is StorageOnlyFileModeQuestion {
+): question is QuestionFileModelBase {
   return (STORAGE_ONLY_FILE_MODE_QUESTION_TYPES as readonly string[]).includes(
     question.getType() as StorageOnlyFileModeQuestionType,
   );
 }
 
-function enforceStorageOnlyFileMode(
-  question: StorageOnlyFileModeQuestion,
-): void {
+function enforceStorageOnlyFileMode(question: QuestionFileModelBase): void {
   if (question.storeDataAsText !== false) {
     question.storeDataAsText = false;
   }
@@ -35,7 +31,7 @@ function enforceStorageOnlyFileMode(
 }
 
 function handleQuestionAdded(_: Model, options: QuestionAddedEvent): void {
-  if (isStorageOnlyFileModeQuestion(options.question)) {
+  if (isFileStorageQuestion(options.question)) {
     enforceStorageOnlyFileMode(options.question);
   }
 }
@@ -50,7 +46,7 @@ function handleQuestionAdded(_: Model, options: QuestionAddedEvent): void {
 export function bindStorageOnlyFileModeToSurvey(survey: Model): () => void {
   survey
     .getAllQuestions(false, false, true)
-    .filter(isStorageOnlyFileModeQuestion)
+    .filter(isFileStorageQuestion)
     .forEach(enforceStorageOnlyFileMode);
 
   survey.onQuestionAdded.add(handleQuestionAdded);

--- a/lib/survey-features/storage-only-file-mode/infrastructure/survey-bindings.ts
+++ b/lib/survey-features/storage-only-file-mode/infrastructure/survey-bindings.ts
@@ -2,11 +2,13 @@ import type { Model, Question, QuestionAddedEvent } from "survey-core";
 import {
   STORAGE_ONLY_FILE_MODE_QUESTION_TYPES,
   STORE_DATA_AS_TEXT_PROPERTY,
+  WAIT_FOR_UPLOAD_PROPERTY,
   type StorageOnlyFileModeQuestionType,
 } from "../constants";
 
 type StorageOnlyFileModeQuestion = Question & {
   [STORE_DATA_AS_TEXT_PROPERTY]?: boolean;
+  [WAIT_FOR_UPLOAD_PROPERTY]?: boolean;
 };
 
 function isStorageOnlyFileModeQuestion(
@@ -23,6 +25,13 @@ function enforceStorageOnlyFileMode(
   if (question.storeDataAsText !== false) {
     question.storeDataAsText = false;
   }
+  // Uploads are async once storeDataAsText is false — without waitForUpload,
+  // a respondent can complete the survey while the upload is still in
+  // flight. Set explicitly (rather than changing the Serializer default,
+  // which is also false) so it always serializes. Mirrors AudioQuestionModel.
+  if (question.waitForUpload !== true) {
+    question.waitForUpload = true;
+  }
 }
 
 function handleQuestionAdded(_: Model, options: QuestionAddedEvent): void {
@@ -33,9 +42,10 @@ function handleQuestionAdded(_: Model, options: QuestionAddedEvent): void {
 
 /**
  * Forces every file/signaturepad question on the survey to upload to storage
- * (storeDataAsText = false) — questions already in the JSON and any added
- * afterwards. Pair with registerStorageOnlyFileModeGlobals, which hides the
- * property from the Creator property grid so authors can't flip it back.
+ * (storeDataAsText = false, waitForUpload = true) — questions already in the
+ * JSON and any added afterwards. Pair with registerStorageOnlyFileModeGlobals,
+ * which hides the property from the Creator property grid so authors can't
+ * flip it back.
  */
 export function bindStorageOnlyFileModeToSurvey(survey: Model): () => void {
   survey

--- a/lib/survey-features/storage-only-file-mode/infrastructure/survey-bindings.ts
+++ b/lib/survey-features/storage-only-file-mode/infrastructure/survey-bindings.ts
@@ -1,0 +1,51 @@
+import type { Model, Question, QuestionAddedEvent } from "survey-core";
+import {
+  STORAGE_ONLY_FILE_MODE_QUESTION_TYPES,
+  STORE_DATA_AS_TEXT_PROPERTY,
+  type StorageOnlyFileModeQuestionType,
+} from "../constants";
+
+type StorageOnlyFileModeQuestion = Question & {
+  [STORE_DATA_AS_TEXT_PROPERTY]?: boolean;
+};
+
+function isStorageOnlyFileModeQuestion(
+  question: Question,
+): question is StorageOnlyFileModeQuestion {
+  return (STORAGE_ONLY_FILE_MODE_QUESTION_TYPES as readonly string[]).includes(
+    question.getType() as StorageOnlyFileModeQuestionType,
+  );
+}
+
+function enforceStorageOnlyFileMode(
+  question: StorageOnlyFileModeQuestion,
+): void {
+  if (question.storeDataAsText !== false) {
+    question.storeDataAsText = false;
+  }
+}
+
+function handleQuestionAdded(_: Model, options: QuestionAddedEvent): void {
+  if (isStorageOnlyFileModeQuestion(options.question)) {
+    enforceStorageOnlyFileMode(options.question);
+  }
+}
+
+/**
+ * Forces every file/signaturepad question on the survey to upload to storage
+ * (storeDataAsText = false) — questions already in the JSON and any added
+ * afterwards. Pair with registerStorageOnlyFileModeGlobals, which hides the
+ * property from the Creator property grid so authors can't flip it back.
+ */
+export function bindStorageOnlyFileModeToSurvey(survey: Model): () => void {
+  survey
+    .getAllQuestions(false, false, true)
+    .filter(isStorageOnlyFileModeQuestion)
+    .forEach(enforceStorageOnlyFileMode);
+
+  survey.onQuestionAdded.add(handleQuestionAdded);
+
+  return () => {
+    survey.onQuestionAdded.remove(handleQuestionAdded);
+  };
+}


### PR DESCRIPTION
## Summary

- When a storage provider is enabled, `file` and `signaturepad` questions now always upload to storage instead of embedding content as base64 in the JSON result.
- Hides the `storeDataAsText` property from the Survey Creator property grid in that case, so form authors can't flip it back to text-embedding.
- Applies to both Endatix forms and form templates (both go through the same `useStorageWithCreator` hook).
- No-op when no storage provider is configured - existing behavior (embed as text) is unchanged.

## Implementation

- New `lib/survey-features/storage-only-file-mode/` module:
  - `registry.ts` - hides `storeDataAsText` from the Creator property grid (leaves the SurveyJS default untouched - see note below).
  - `survey-bindings.ts` - forces `storeDataAsText = false` on existing file/signaturepad questions and any added afterwards.
  - `creator-bindings.ts` - binds the above to every Creator survey instance (designer + preview tabs), reusing the existing `bindSurveyToCreatorAreas` helper.
- Wired into `useStorageWithCreator` (`features/asset-storage`), gated by the existing `storageConfig?.isEnabled` check - no changes to `form-editor.tsx` / `form-template-editor.tsx`.

## Note

- Deliberately does **not** change the Serializer's default value for `storeDataAsText` (only hides it). Flipping the default would make an explicit `false` equal to "default" and get dropped from saved JSON - then a respondent session (which never runs this hub-only registry code) would fall back to the built-in default of `true` and silently re-embed files as base64. Covered by a regression test asserting the value round-trips through `toJSON()`.
- Enforcement is Creator-only by design (not applied at runtime/respondent side) - scoped per discussion.

## Related Issues
Closes #819 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="703" height="660" alt="image" src="https://github.com/user-attachments/assets/5096a03e-5af2-442f-a1ec-b962aa5a66b6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added storage-only file handling for file upload and signature-pad questions.
  * New questions and existing questions automatically use external storage instead of embedding data in survey results.
  * Added integration with Survey Creator and survey editing workflows.
  * Added cleanup support to restore standard behavior when storage handling is disabled or removed.

* **Tests**
  * Added coverage for registration, creator and survey bindings, nested questions, cleanup, and default-value preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->