### PR TITLE
fix: route Auth.js logging into OpenTelemetry

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -2,6 +2,7 @@ import NextAuth from "next-auth";
 import { authRegistry } from "./features/auth/infrastructure/auth-provider-registry";
 import { createAuthConfig } from "./features/auth/infrastructure/config-factory";
 import { AuthPresentation } from "./features/auth/infrastructure";
+import { authTelemetryLogger } from "./features/auth/infrastructure/auth-telemetry-logger";
 
 // Example auth provider registration (uncomment to use)
 // import {
@@ -19,6 +20,10 @@ export const authPresentation: AuthPresentation[] = authConfig.authPresentation;
 
 export const { handlers, signIn, signOut, auth, unstable_update } = NextAuth({
   ...authConfig,
+  // After the spread, so this is authoritative. No provider config sets a logger today; if one
+  // ever needs to, it should compose with this rather than replace it, or auth failures stop
+  // reaching telemetry again.
+  logger: authTelemetryLogger,
 });
 
 export type SessionError =

--- a/features/auth/infrastructure/__tests__/auth-telemetry-logger.test.ts
+++ b/features/auth/infrastructure/__tests__/auth-telemetry-logger.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { authTelemetryLogger } from "../auth-telemetry-logger";
+import { TelemetryLogger } from "@/features/telemetry";
+
+describe("authTelemetryLogger", () => {
+  beforeEach(() => {
+    vi.spyOn(TelemetryLogger, "error").mockImplementation(() => {});
+    vi.spyOn(TelemetryLogger, "warn").mockImplementation(() => {});
+    vi.spyOn(TelemetryLogger, "debug").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("forwards auth errors to telemetry", () => {
+    // Arrange
+    // Auth.js logs through its own console-only logger, so authentication failures never
+    // reached an OTLP exporter before this bridge existed.
+    const error = new Error("Network");
+    error.name = "AuthError";
+
+    // Act
+    authTelemetryLogger.error?.(error);
+
+    // Assert
+    expect(TelemetryLogger.error).toHaveBeenCalledWith(
+      "Auth error: Network",
+      error,
+      { "auth.error.name": "AuthError" },
+      "auth",
+    );
+  });
+
+  it("keeps auth errors on the console as well as in telemetry", () => {
+    // Arrange
+    // TelemetryLogger suppresses its console fallback whenever an exporter is configured, so
+    // forwarding alone would remove [auth] lines from `docker logs` on exactly the
+    // deployments that enable telemetry.
+    const error = new Error("Network");
+
+    // Act
+    authTelemetryLogger.error?.(error);
+
+    // Assert
+    expect(console.error).toHaveBeenCalledWith("[auth][error] Network");
+  });
+
+  it("forwards auth warnings to telemetry", () => {
+    // Act
+    authTelemetryLogger.warn?.("debug-enabled");
+
+    // Assert
+    expect(TelemetryLogger.warn).toHaveBeenCalledWith(
+      "Auth warning: debug-enabled",
+      { "auth.warning.code": "debug-enabled" },
+      "auth",
+    );
+    expect(console.warn).toHaveBeenCalledWith("[auth][warn] debug-enabled");
+  });
+
+  it("emits auth debug at debug severity so backends drop it by default", () => {
+    // Arrange
+    // Auth.js debug output is extremely chatty and only fires when debug: true. Emitting it
+    // at a higher severity would mean paying to ingest it.
+
+    // Act
+    authTelemetryLogger.debug?.("callback invoked", { provider: "endatix" });
+
+    // Assert
+    expect(TelemetryLogger.debug).toHaveBeenCalled();
+    expect(TelemetryLogger.error).not.toHaveBeenCalled();
+    expect(TelemetryLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when Auth.js passes a malformed error", () => {
+    // Arrange
+    // A logger that throws inside the auth flow would turn a recoverable auth failure into a
+    // request crash, so this must degrade rather than propagate.
+
+    // Act
+    const act = () =>
+      authTelemetryLogger.error?.(undefined as unknown as Error);
+
+    // Assert
+    expect(act).not.toThrow();
+    expect(TelemetryLogger.error).toHaveBeenCalled();
+  });
+});

--- a/features/auth/infrastructure/auth-telemetry-logger.ts
+++ b/features/auth/infrastructure/auth-telemetry-logger.ts
@@ -1,0 +1,57 @@
+import type { LoggerInstance } from "@auth/core/types";
+import { TelemetryLogger } from "@/features/telemetry";
+
+/**
+ * Logger name applied to every record this bridge emits, so auth failures can be
+ * filtered as a group in a telemetry backend.
+ */
+const AUTH_LOGGER_NAME = "auth";
+
+/**
+ * Routes Auth.js's internal logging into OpenTelemetry.
+ *
+ * Auth.js logs through its own console-only logger, so without this bridge its output —
+ * including every authentication failure — never reaches an OTLP exporter. Those are among
+ * the most operationally important events the Hub produces, and they were invisible in the
+ * telemetry backend while being plainly visible in `docker logs`.
+ *
+ * Console output is mirrored deliberately. `TelemetryLogger` suppresses its own console
+ * fallback whenever an exporter is configured, so forwarding alone would *remove* `[auth]`
+ * lines from container logs on exactly the deployments that enable telemetry — trading one
+ * blind spot for another.
+ *
+ * Any method left undefined here falls back to the Auth.js default.
+ */
+export const authTelemetryLogger: Partial<LoggerInstance> = {
+  error(error: Error) {
+    console.error(`[auth][error] ${error?.message ?? error}`);
+
+    TelemetryLogger.error(
+      `Auth error: ${error?.message ?? "unknown"}`,
+      error,
+      { "auth.error.name": error?.name ?? "unknown" },
+      AUTH_LOGGER_NAME,
+    );
+  },
+
+  warn(code: string) {
+    console.warn(`[auth][warn] ${code}`);
+
+    TelemetryLogger.warn(
+      `Auth warning: ${code}`,
+      { "auth.warning.code": code },
+      AUTH_LOGGER_NAME,
+    );
+  },
+
+  debug(message: string, metadata?: unknown) {
+    // Auth.js only calls this when `debug: true`, and it is extremely chatty. Emitted at
+    // debug severity so a backend's level filter drops it by default rather than paying to
+    // ingest it.
+    TelemetryLogger.debug(
+      `Auth debug: ${message}`,
+      { "auth.debug.metadata": metadata === undefined ? "" : String(metadata) },
+      AUTH_LOGGER_NAME,
+    );
+  },
+};


### PR DESCRIPTION
## Description

Auth.js logs through **its own console-only logger**, and the Hub never passed it a `logger`. Every authentication failure therefore went to stdout and nowhere else — plainly visible in `docker logs`, entirely absent from the telemetry backend.

```
[auth][error] Network: Read more at https://errors.authjs.dev#network
    at Object.authorize (...)
```

That line, and everything like it, was invisible in Aspire.

### How this surfaced

While investigating why the Hub produced no records in the Aspire dashboard. The obvious suspicion — that the OTLP log pipeline was broken — turned out to be wrong, and it is worth recording that it was **measured, not assumed**:

| Test | Result |
|---|---|
| Hub's exact SDK config → dead OTLP port | errors from **both** the trace exporter and the **log** exporter |
| Same config → live dashboard | clean flush, no errors |
| `logs.getLogger()` after `sdk.start()` | returns a real `Logger`, not a no-op |

So the log path works and actively attempts delivery. Nothing was reaching it because nothing was calling `TelemetryLogger` — the failures were being logged by Auth.js instead.

## Why the console output is mirrored, not replaced

`TelemetryLogger` **suppresses its own console fallback whenever an exporter is configured** (`shouldUseConsoleFallback`). So simply forwarding to it would have *removed* `[auth]` lines from container logs on exactly the deployments that enable telemetry — trading one blind spot for another, and breaking the workflow of anyone currently debugging auth with `docker logs`.

The bridge therefore writes both.

## Notes

- **Debug is emitted at debug severity.** Auth.js only calls it when `debug: true` and it is extremely chatty; a backend's level filter should drop it rather than pay to ingest it.
- **`logger` is placed after the `...authConfig` spread**, so it is authoritative. No provider config sets a logger today; if one ever needs to, it should compose rather than replace, or auth failures stop reaching telemetry again.
- **Any method left undefined falls back to the Auth.js default**, so this is additive rather than a full logger replacement.

## Verification

- **164 tests pass** across `features/auth` and `features/telemetry` (23 files); `tsc --noEmit` reports no new errors in the changed files.
- **5 new tests, verified as real guards:** removing the console mirror or the warn forward fails two of them.

> [!NOTE]
> **This does not make the Hub log on success paths.** 41 of its 46 `TelemetryLogger` call sites are `error`/`critical`/`warn`, so a healthy request still produces no records. That is a separate, deliberate gap — worth its own discussion, since it means the Structured logs view cannot distinguish "running normally" from "not running".

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Refs endatix/endatix#476
