### PR TITLE
feat(h831): Refactoring survey localization into dedicated cross-cutting slice

### DIFF
--- a/features/pdf-export/submission/__tests__/prepare-pdf-model.use-case.test.ts
+++ b/features/pdf-export/submission/__tests__/prepare-pdf-model.use-case.test.ts
@@ -15,7 +15,7 @@ vi.mock(
   }),
 );
 
-vi.mock("@/features/submissions/submission-localization", () => ({
+vi.mock("@/lib/localization", () => ({
   getSubmissionLocale: vi.fn(),
 }));
 
@@ -34,7 +34,7 @@ vi.mock("@/lib/questions/drag-categorize/drag-categorize.registry", () => ({
 import { addViewTokensToModelUseCase } from "@/features/asset-storage/server";
 import { primeDataListDisplayValues } from "@/lib/survey-features/data-lists/infrastructure/prime-data-list-display-values";
 import { DATA_LIST_PROPERTY_NAME } from "@/lib/survey-features/data-lists/constants";
-import { getSubmissionLocale } from "@/features/submissions/submission-localization";
+import { getSubmissionLocale } from "@/lib/localization";
 import { initializeCustomQuestions } from "@/lib/questions";
 import { registerAudioQuestionModel } from "@/lib/questions/audio-recorder/audio-question-pdf";
 import { registerDragCategorizeModel } from "@/lib/questions/drag-categorize/drag-categorize.registry";

--- a/features/pdf-export/submission/prepare-pdf-model.use-case.ts
+++ b/features/pdf-export/submission/prepare-pdf-model.use-case.ts
@@ -1,7 +1,7 @@
 import { addViewTokensToModelUseCase } from "@/features/asset-storage/server";
 import { primeDataListDisplayValues } from "@/lib/survey-features/data-lists/infrastructure/prime-data-list-display-values";
 import { registerDataListGlobals } from "@/lib/survey-features/data-lists/infrastructure/registry";
-import { getSubmissionLocale } from "@/features/submissions/submission-localization";
+import { getSubmissionLocale } from "@/lib/localization";
 import { Submission } from "@/lib/endatix-api";
 import { initializeCustomQuestions } from "@/lib/questions";
 import { registerAudioQuestionModel } from "@/lib/questions/audio-recorder/audio-question-pdf";
@@ -18,7 +18,7 @@ interface PreparePdfModelOptions {
 /**
  * Orchestrates the creation and authorization of a SurveyJS Model for PDF export.
  * This centralizes logic to avoid duplication across different export routes.
- * 
+ *
  * @returns A fully prepared and authorized SurveyJS Model
  */
 export async function preparePdfModel({
@@ -26,7 +26,6 @@ export async function preparePdfModel({
   customQuestionsJsonData,
   useDefaultLocale = false,
 }: PreparePdfModelOptions): Promise<Model> {
-  
   // Add custom questions to the model
   registerAudioQuestionModel();
   registerDragCategorizeModel();

--- a/features/public-form/application/__tests__/use-language-selection.hook.test.ts
+++ b/features/public-form/application/__tests__/use-language-selection.hook.test.ts
@@ -59,6 +59,7 @@ describe("useLanguageSelection", () => {
       );
 
       expect(result.current.currentLocale).toBe("default");
+      expect(result.current.isDefaultLocale).toBe(true);
       expect(result.current.hasMultipleLocales).toBe(true);
     });
 
@@ -72,10 +73,7 @@ describe("useLanguageSelection", () => {
       );
 
       expect(result.current.currentLocale).toBe("sv");
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        "form-lang-preference",
-        "sv",
-      );
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
       expect(mockSurveyModel.locale).toBe("sv");
     });
 
@@ -90,6 +88,7 @@ describe("useLanguageSelection", () => {
       );
 
       expect(result.current.currentLocale).toBe("sv");
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
     });
 
     it("migrates legacy localStorage en to catalog default", () => {
@@ -104,10 +103,7 @@ describe("useLanguageSelection", () => {
 
       expect(result.current.currentLocale).toBe("default");
       expect(mockSurveyModel.locale).toBe("");
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
-        "form-lang-preference",
-        "default",
-      );
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
     });
 
     it("uses survey model locale when no saved preference", () => {
@@ -121,9 +117,10 @@ describe("useLanguageSelection", () => {
       );
 
       expect(result.current.currentLocale).toBe("es");
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
     });
 
-    it("falls back to catalog default when survey locale is unavailable", () => {
+    it("falls back via browser detection when survey locale is unavailable", () => {
       mockSurveyModel.locale = "fr";
       languagesSpy.mockReturnValue(["fr-FR"]);
       languageSpy.mockReturnValue("fr-FR");
@@ -136,6 +133,23 @@ describe("useLanguageSelection", () => {
       );
 
       expect(result.current.currentLocale).toBe("default");
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the first catalog locale when the default is unavailable", () => {
+      mockSurveyModel.locale = "";
+      languagesSpy.mockReturnValue(["fr-FR"]);
+      languageSpy.mockReturnValue("fr-FR");
+
+      const { result } = renderHook(() =>
+        useLanguageSelection({
+          availableLocales: ["sv", "bg"],
+          surveyModel: mockSurveyModel,
+        }),
+      );
+
+      expect(result.current.currentLocale).toBe("sv");
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
     });
   });
 
@@ -243,7 +257,11 @@ describe("useLanguageSelection", () => {
       });
 
       expect(result.current.currentLocale).toBe(initialLocale);
-      expect(mockSurveyModel.locale).not.toBe("fr");
+      expect(mockSurveyModel.locale).toBe("");
+      expect(mockLocalStorage.setItem).not.toHaveBeenCalledWith(
+        "form-lang-preference",
+        "fr",
+      );
     });
   });
 
@@ -310,6 +328,20 @@ describe("useLanguageSelection", () => {
       );
 
       expect(result.current.hasMultipleLocales).toBe(false);
+    });
+
+    it("reports no multiple locales and no current option for an empty catalog", () => {
+      const { result } = renderHook(() =>
+        useLanguageSelection({
+          availableLocales: [],
+          surveyModel: mockSurveyModel,
+        }),
+      );
+
+      expect(result.current.currentLocale).toBe("default");
+      expect(result.current.hasMultipleLocales).toBe(false);
+      expect(result.current.languageOptions).toEqual([]);
+      expect(result.current.currentOption).toBeUndefined();
     });
   });
 });

--- a/features/public-form/application/__tests__/use-language-selection.hook.test.ts
+++ b/features/public-form/application/__tests__/use-language-selection.hook.test.ts
@@ -1,10 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { SurveyModel } from "survey-core";
-import { surveyLocalization } from "survey-core";
 import { useLanguageSelection } from "../use-language-selection.hook";
 
-// Mock SurveyJS localization
 vi.mock("survey-core", async () => {
   const actual = await vi.importActual("survey-core");
   return {
@@ -15,13 +13,13 @@ vi.mock("survey-core", async () => {
         en: "English",
         sv: "Svenska",
         es: "Español",
+        bg: "български",
         fr: "Français",
       },
     },
   };
 });
 
-// Mock localStorage
 const mockLocalStorage = {
   getItem: vi.fn(),
   setItem: vi.fn(),
@@ -31,7 +29,7 @@ const mockLocalStorage = {
 
 describe("useLanguageSelection", () => {
   const mockSurveyModel = {
-    locale: "en",
+    locale: "",
   } as SurveyModel;
 
   let languagesSpy: ReturnType<typeof vi.spyOn>;
@@ -39,14 +37,11 @@ describe("useLanguageSelection", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset survey model locale
-    mockSurveyModel.locale = "en";
-    // Mock localStorage
+    mockSurveyModel.locale = "";
     vi.stubGlobal("localStorage", mockLocalStorage);
-
-    // Setup navigator spies
     languagesSpy = vi.spyOn(navigator, "languages", "get");
     languageSpy = vi.spyOn(navigator, "language", "get");
+    mockLocalStorage.getItem.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -55,8 +50,7 @@ describe("useLanguageSelection", () => {
   });
 
   describe("initialization", () => {
-    it("should initialize with default locale when no survey model", () => {
-      // Arrange & Act
+    it("uses catalog default when no survey model", () => {
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en", "sv"],
@@ -64,13 +58,11 @@ describe("useLanguageSelection", () => {
         }),
       );
 
-      // Assert
-      expect(result.current.currentLocale).toBe("en");
+      expect(result.current.currentLocale).toBe("default");
       expect(result.current.hasMultipleLocales).toBe(true);
     });
 
-    it("should prioritize preselected locale", () => {
-      // Arrange & Act
+    it("prioritizes preselected locale", () => {
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en", "sv", "es"],
@@ -79,19 +71,17 @@ describe("useLanguageSelection", () => {
         }),
       );
 
-      // Assert
       expect(result.current.currentLocale).toBe("sv");
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
         "form-lang-preference",
         "sv",
       );
+      expect(mockSurveyModel.locale).toBe("sv");
     });
 
-    it("should use saved locale from localStorage when no preselected", () => {
-      // Arrange
+    it("uses saved catalog locale from localStorage", () => {
       mockLocalStorage.getItem.mockReturnValue("sv");
 
-      // Act
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en", "sv", "es"],
@@ -99,17 +89,30 @@ describe("useLanguageSelection", () => {
         }),
       );
 
-      // Assert
       expect(result.current.currentLocale).toBe("sv");
-      expect(mockLocalStorage.getItem).toHaveBeenCalledWith("form-lang-preference");
     });
 
-    it("should use survey model locale when no saved preference", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
+    it("migrates legacy localStorage en to catalog default", () => {
+      mockLocalStorage.getItem.mockReturnValue("en");
+
+      const { result } = renderHook(() =>
+        useLanguageSelection({
+          availableLocales: ["en", "bg"],
+          surveyModel: mockSurveyModel,
+        }),
+      );
+
+      expect(result.current.currentLocale).toBe("default");
+      expect(mockSurveyModel.locale).toBe("");
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        "form-lang-preference",
+        "default",
+      );
+    });
+
+    it("uses survey model locale when no saved preference", () => {
       mockSurveyModel.locale = "es";
 
-      // Act
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en", "sv", "es"],
@@ -117,16 +120,14 @@ describe("useLanguageSelection", () => {
         }),
       );
 
-      // Assert
       expect(result.current.currentLocale).toBe("es");
     });
 
-    it("should fall back to default locale when no other preferences", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
+    it("falls back to catalog default when survey locale is unavailable", () => {
+      mockSurveyModel.locale = "fr";
+      languagesSpy.mockReturnValue(["fr-FR"]);
+      languageSpy.mockReturnValue("fr-FR");
 
-      // Act
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en", "sv"],
@@ -134,37 +135,16 @@ describe("useLanguageSelection", () => {
         }),
       );
 
-      // Assert
-      expect(result.current.currentLocale).toBe("en");
-    });
-
-    it("should use first available locale when default not available", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["sv", "es"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("sv");
+      expect(result.current.currentLocale).toBe("default");
     });
   });
 
   describe("browser preferred locale detection", () => {
-    it("should match exact browser language", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
+    it("matches browser language codes to catalog locales", () => {
+      mockSurveyModel.locale = "fr";
       languagesSpy.mockReturnValue(["sv-SE", "en-US"]);
       languageSpy.mockReturnValue("sv-SE");
 
-      // Act
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en", "sv"],
@@ -172,151 +152,14 @@ describe("useLanguageSelection", () => {
         }),
       );
 
-      // Assert
       expect(result.current.currentLocale).toBe("sv");
     });
 
-    it("should match language code when exact match not available", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-      languagesSpy.mockReturnValue(["sv-SE", "en-US"]);
-      languageSpy.mockReturnValue("sv-SE");
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("sv");
-    });
-
-    it("should match first available language from navigator.languages", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-      languagesSpy.mockReturnValue(["fr-FR", "sv-SE", "en-US"]);
-      languageSpy.mockReturnValue("fr-FR");
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("sv");
-    });
-
-    it("should fall back to default locale when no browser match", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-      languagesSpy.mockReturnValue(["fr-FR", "de-DE"]);
-      languageSpy.mockReturnValue("fr-FR");
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("en");
-    });
-
-    it("should use first available locale when default not available", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-      languagesSpy.mockReturnValue(["fr-FR", "de-DE"]);
-      languageSpy.mockReturnValue("fr-FR");
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["sv", "es"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("sv");
-    });
-
-    it("should handle navigator.languages being undefined", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-      languagesSpy.mockReturnValue(undefined);
-      languageSpy.mockReturnValue("sv-SE");
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("sv");
-    });
-
-    it("should handle navigator.language being undefined", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-      languagesSpy.mockReturnValue(["sv-SE", "en-US"]);
-      languageSpy.mockReturnValue(undefined);
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("sv");
-    });
-
-    it("should handle both navigator.languages and navigator.language being undefined", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-      languagesSpy.mockReturnValue(undefined);
-      languageSpy.mockReturnValue(undefined);
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("en");
-    });
-
-    it("should match 'en' from 'en-US'", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-      languagesSpy.mockReturnValue(["en-US", "sv-SE"]);
+    it("maps browser en-US to catalog default", () => {
+      mockSurveyModel.locale = "fr";
+      languagesSpy.mockReturnValue(["en-US"]);
       languageSpy.mockReturnValue("en-US");
 
-      // Act
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en", "sv"],
@@ -324,71 +167,12 @@ describe("useLanguageSelection", () => {
         }),
       );
 
-      // Assert
-      expect(result.current.currentLocale).toBe("en");
-    });
-
-    it("should match 'sv' from 'sv-SE'", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-      languagesSpy.mockReturnValue(["sv-SE", "en-US"]);
-      languageSpy.mockReturnValue("sv-SE");
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("sv");
-    });
-
-    it("should match 'es' from 'es-ES'", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-      languagesSpy.mockReturnValue(["es-ES", "en-US"]);
-      languageSpy.mockReturnValue("es-ES");
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "es"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("es");
-    });
-
-    it("should check navigator.languages in order", () => {
-      // Arrange
-      mockLocalStorage.getItem.mockReturnValue(null);
-      mockSurveyModel.locale = "fr"; // Not in available locales
-      languagesSpy.mockReturnValue(["fr-FR", "sv-SE", "en-US"]);
-      languageSpy.mockReturnValue("fr-FR");
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("sv"); // Should match sv-SE, not fall back to en
+      expect(result.current.currentLocale).toBe("default");
     });
   });
 
   describe("changeLocale", () => {
-    it("should update locale and persist to localStorage", () => {
-      // Arrange
+    it("updates catalog locale, survey model, and localStorage", () => {
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en", "sv"],
@@ -396,12 +180,10 @@ describe("useLanguageSelection", () => {
         }),
       );
 
-      // Act
       act(() => {
         result.current.changeLocale("sv");
       });
 
-      // Assert
       expect(result.current.currentLocale).toBe("sv");
       expect(mockSurveyModel.locale).toBe("sv");
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
@@ -410,8 +192,43 @@ describe("useLanguageSelection", () => {
       );
     });
 
-    it("should not update locale if not in available locales", () => {
-      // Arrange
+    it("sets survey locale to empty string for catalog default", () => {
+      const { result } = renderHook(() =>
+        useLanguageSelection({
+          availableLocales: ["en", "bg"],
+          surveyModel: mockSurveyModel,
+          preselectedLocale: "bg",
+        }),
+      );
+
+      expect(result.current.currentLocale).toBe("bg");
+
+      act(() => {
+        result.current.changeLocale("default");
+      });
+
+      expect(result.current.currentLocale).toBe("default");
+      expect(mockSurveyModel.locale).toBe("");
+    });
+
+    it("accepts legacy en and normalizes to catalog default", () => {
+      const { result } = renderHook(() =>
+        useLanguageSelection({
+          availableLocales: ["en", "bg"],
+          surveyModel: mockSurveyModel,
+          preselectedLocale: "bg",
+        }),
+      );
+
+      act(() => {
+        result.current.changeLocale("en");
+      });
+
+      expect(result.current.currentLocale).toBe("default");
+      expect(mockSurveyModel.locale).toBe("");
+    });
+
+    it("does not update locale if not in available locales", () => {
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en", "sv"],
@@ -421,40 +238,17 @@ describe("useLanguageSelection", () => {
 
       const initialLocale = result.current.currentLocale;
 
-      // Act
       act(() => {
         result.current.changeLocale("fr");
       });
 
-      // Assert
       expect(result.current.currentLocale).toBe(initialLocale);
       expect(mockSurveyModel.locale).not.toBe("fr");
-    });
-
-    it("should not update locale if no survey model", () => {
-      // Arrange
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: null,
-        }),
-      );
-
-      const initialLocale = result.current.currentLocale;
-
-      // Act
-      act(() => {
-        result.current.changeLocale("sv");
-      });
-
-      // Assert
-      expect(result.current.currentLocale).toBe(initialLocale);
     });
   });
 
   describe("languageOptions", () => {
-    it("should return formatted language options", () => {
-      // Arrange & Act
+    it("exposes catalog codes with SurveyJS display names", () => {
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en", "sv", "es"],
@@ -462,37 +256,16 @@ describe("useLanguageSelection", () => {
         }),
       );
 
-      // Assert
       expect(result.current.languageOptions).toEqual([
-        { value: "en", label: "English" },
+        { value: "default", label: "English" },
         { value: "sv", label: "Svenska" },
         { value: "es", label: "Español" },
-      ]);
-    });
-
-    it("should fall back to locale code when name not available", () => {
-      // Arrange
-      vi.mocked(surveyLocalization.localeNames).fr = undefined;
-
-      // Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "fr"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.languageOptions).toEqual([
-        { value: "en", label: "English" },
-        { value: "fr", label: "fr" },
       ]);
     });
   });
 
   describe("currentOption", () => {
-    it("should return current language option", () => {
-      // Arrange & Act
+    it("tracks the selected catalog option", () => {
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en", "sv"],
@@ -500,28 +273,15 @@ describe("useLanguageSelection", () => {
         }),
       );
 
-      // Assert
       expect(result.current.currentOption).toEqual({
-        value: "en",
+        value: "default",
         label: "English",
       });
-    });
 
-    it("should update current option when locale changes", () => {
-      // Arrange
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Act
       act(() => {
         result.current.changeLocale("sv");
       });
 
-      // Assert
       expect(result.current.currentOption).toEqual({
         value: "sv",
         label: "Svenska",
@@ -530,21 +290,18 @@ describe("useLanguageSelection", () => {
   });
 
   describe("hasMultipleLocales", () => {
-    it("should return true when multiple locales available", () => {
-      // Arrange & Act
+    it("is true when multiple catalog locales are available", () => {
       const { result } = renderHook(() =>
         useLanguageSelection({
-          availableLocales: ["en", "sv", "es"],
+          availableLocales: ["en", "sv"],
           surveyModel: mockSurveyModel,
         }),
       );
 
-      // Assert
       expect(result.current.hasMultipleLocales).toBe(true);
     });
 
-    it("should return false when only one locale available", () => {
-      // Arrange & Act
+    it("is false for a single locale", () => {
       const { result } = renderHook(() =>
         useLanguageSelection({
           availableLocales: ["en"],
@@ -552,67 +309,7 @@ describe("useLanguageSelection", () => {
         }),
       );
 
-      // Assert
       expect(result.current.hasMultipleLocales).toBe(false);
-    });
-
-    it("should return false when no locales available", () => {
-      // Arrange & Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: [],
-          surveyModel: mockSurveyModel,
-        }),
-      );
-
-      // Assert
-      expect(result.current.hasMultipleLocales).toBe(false);
-    });
-  });
-
-  describe("edge cases", () => {
-    it("should handle empty available locales", () => {
-      // Arrange & Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: [],
-          surveyModel: null,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("en");
-      expect(result.current.hasMultipleLocales).toBe(false);
-      expect(result.current.languageOptions).toEqual([]);
-      expect(result.current.currentOption).toBeUndefined();
-    });
-
-    it("should handle null survey model", () => {
-      // Arrange & Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: null,
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("en");
-      expect(result.current.hasMultipleLocales).toBe(true);
-    });
-
-    it("should handle invalid preselected locale", () => {
-      // Arrange & Act
-      const { result } = renderHook(() =>
-        useLanguageSelection({
-          availableLocales: ["en", "sv"],
-          surveyModel: mockSurveyModel,
-          preselectedLocale: "invalid",
-        }),
-      );
-
-      // Assert
-      expect(result.current.currentLocale).toBe("en");
     });
   });
 });

--- a/features/public-form/application/use-language-selection.hook.ts
+++ b/features/public-form/application/use-language-selection.hook.ts
@@ -45,11 +45,10 @@ export function useLanguageSelection({
   const [currentLocale, setCurrentLocale] = useState<string>(
     DEFAULT_CATALOG_LOCALE,
   );
-  const didInitializeRef = useRef(false);
   const initializedForModelRef = useRef<SurveyModel | null>(null);
 
-  const changeLocale = useCallback(
-    (newLocale: string) => {
+  const applyCatalogLocale = useCallback(
+    (newLocale: string, persist: boolean) => {
       const catalogLocale = fromSurveyModelLocale(newLocale);
       if (!surveyModel || !catalogLocales.includes(catalogLocale)) {
         return;
@@ -57,9 +56,18 @@ export function useLanguageSelection({
 
       setCurrentLocale(catalogLocale);
       surveyModel.locale = toSurveyModelLocale(catalogLocale);
-      localStorage.setItem(STORAGE_KEY, catalogLocale);
+      if (persist) {
+        localStorage.setItem(STORAGE_KEY, catalogLocale);
+      }
     },
     [surveyModel, catalogLocales],
+  );
+
+  const changeLocale = useCallback(
+    (newLocale: string) => {
+      applyCatalogLocale(newLocale, true);
+    },
+    [applyCatalogLocale],
   );
 
   useEffect(() => {
@@ -67,15 +75,10 @@ export function useLanguageSelection({
       return;
     }
 
-    if (initializedForModelRef.current !== surveyModel) {
-      initializedForModelRef.current = surveyModel;
-      didInitializeRef.current = false;
-    }
-
-    if (didInitializeRef.current) {
+    if (initializedForModelRef.current === surveyModel) {
       return;
     }
-    didInitializeRef.current = true;
+    initializedForModelRef.current = surveyModel;
 
     const localeToSelect = resolveInitialCatalogLocale(catalogLocales, {
       preselectedLocale,
@@ -83,8 +86,8 @@ export function useLanguageSelection({
       surveyLocale: surveyModel.locale,
     });
 
-    changeLocale(localeToSelect);
-  }, [surveyModel, catalogLocales, preselectedLocale, changeLocale]);
+    applyCatalogLocale(localeToSelect, false);
+  }, [surveyModel, catalogLocales, preselectedLocale, applyCatalogLocale]);
 
   const languageOptions = useMemo(
     () =>
@@ -114,7 +117,7 @@ function pickAvailableCatalogLocale(
   candidate: string | null | undefined,
   catalogLocales: readonly string[],
 ): string | undefined {
-  if (!candidate) {
+  if (candidate == null) {
     return undefined;
   }
 
@@ -167,7 +170,9 @@ function getBrowserPreferredLocale(catalogLocales: string[]): string {
     return DEFAULT_CATALOG_LOCALE;
   }
 
-  const browserLanguages = navigator.languages || [navigator.language] || [];
+  const browserLanguages = (navigator.languages ?? [navigator.language]).filter(
+    (tag): tag is string => Boolean(tag),
+  );
 
   for (const browserLang of browserLanguages) {
     const catalog = fromSurveyModelLocale(browserLang);
@@ -175,7 +180,7 @@ function getBrowserPreferredLocale(catalogLocales: string[]): string {
       return catalog;
     }
 
-    const languageCode = browserLang?.split("-")[0];
+    const languageCode = browserLang.split("-")[0];
     if (languageCode) {
       const catalogLang = fromSurveyModelLocale(languageCode);
       if (catalogLocales.includes(catalogLang)) {

--- a/features/public-form/application/use-language-selection.hook.ts
+++ b/features/public-form/application/use-language-selection.hook.ts
@@ -1,9 +1,15 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SurveyModel } from "survey-core";
-import { surveyLocalization } from "survey-core";
+import {
+  DEFAULT_CATALOG_LOCALE,
+  catalogLocaleDisplayName,
+  fromSurveyModelLocale,
+  isDefaultCatalogLocale,
+  toCatalogLocales,
+  toSurveyModelLocale,
+} from "@/lib/localization";
 
 const STORAGE_KEY = "form-lang-preference";
-const DEFAULT_LOCALE = "en";
 
 interface UseLanguageSelectionProps {
   availableLocales: string[];
@@ -14,84 +20,80 @@ interface UseLanguageSelectionProps {
 /**
  * React hook for managing language selection in a survey context.
  *
- * @param availableLocales - List of supported locale codes (e.g., ['en', 'sv']).
- * @param surveyModel - The SurveyModel instance to synchronize locale with.
- * @param preselectedLocale - (Optional) Locale code to prioritize as initial selection.
- * @returns {
- *   currentLocale: string, // The currently selected locale code.
- *   changeLocale: (locale: string) => void // Function to update the locale.
- *   languageOptions: LanguageOption[] // List of available language options.
- *   currentOption: LanguageOption | undefined // The currently selected language option.
- *   hasMultipleLocales: boolean // Whether there are multiple locales available.
- * }
+ * Locales use the owned catalog vocabulary (`default`, `bg`, …). SurveyJS
+ * `model.locale` stays `""` for the default language.
  *
- * Usage:
- *   const { currentLocale, changeLocale } = useLanguageSelection({ ... });
+ * Initial selection priority:
+ *  1. Server-provided initial locale
+ *  2. Saved locale (localStorage; migrate legacy "en" → "default")
+ *  3. Survey model locale
+ *  4. Browser detection (fallback)
+ *
+ * Note: if a saved preference exists but is not in the catalog, we skip the
+ * survey model locale and fall through to browser detection.
  */
-
 export function useLanguageSelection({
   availableLocales,
   surveyModel,
   preselectedLocale,
 }: UseLanguageSelectionProps) {
-  const [currentLocale, setCurrentLocale] = useState<string>(
-    surveyLocalization.defaultLocale || DEFAULT_LOCALE,
+  const catalogLocales = useMemo(
+    () => toCatalogLocales(availableLocales),
+    [availableLocales],
   );
+
+  const [currentLocale, setCurrentLocale] = useState<string>(
+    DEFAULT_CATALOG_LOCALE,
+  );
+  const didInitializeRef = useRef(false);
+  const initializedForModelRef = useRef<SurveyModel | null>(null);
 
   const changeLocale = useCallback(
     (newLocale: string) => {
-      if (!surveyModel || !availableLocales.includes(newLocale)) {
+      const catalogLocale = fromSurveyModelLocale(newLocale);
+      if (!surveyModel || !catalogLocales.includes(catalogLocale)) {
         return;
       }
 
-      setCurrentLocale(newLocale);
-      surveyModel.locale = newLocale;
-      localStorage.setItem(STORAGE_KEY, newLocale);
+      setCurrentLocale(catalogLocale);
+      surveyModel.locale = toSurveyModelLocale(catalogLocale);
+      localStorage.setItem(STORAGE_KEY, catalogLocale);
     },
-    [surveyModel, availableLocales],
+    [surveyModel, catalogLocales],
   );
 
   useEffect(() => {
-    if (!surveyModel || availableLocales.length === 0) {
+    if (!surveyModel || catalogLocales.length === 0) {
       return;
     }
 
-    // Priority: order of preference:
-    //  1. Server-provided initial locale
-    //  2. Saved locale (in localStorage)
-    //  3. Survey model locale
-    //  4. Browser detection (fallback)
-    let localeToSelect = DEFAULT_LOCALE;
-
-    // 1. Server-provided initial locale. Requires server-side processing. TODO: Implement.
-    if (preselectedLocale && availableLocales.includes(preselectedLocale)) {
-      localeToSelect = preselectedLocale;
-    } else {
-      const preferredLocale = localStorage.getItem(STORAGE_KEY);
-      if (preferredLocale && availableLocales.includes(preferredLocale)) {
-        localeToSelect = preferredLocale;
-      } else if (
-        surveyModel.locale &&
-        availableLocales.includes(surveyModel.locale)
-      ) {
-        localeToSelect = surveyModel.locale;
-      } else {
-        localeToSelect = getBrowserPreferredLocale(availableLocales);
-      }
+    if (initializedForModelRef.current !== surveyModel) {
+      initializedForModelRef.current = surveyModel;
+      didInitializeRef.current = false;
     }
 
-    // Use changeLocale to maintain consistency and avoid code duplication
-    changeLocale(localeToSelect);
-  }, [surveyModel, availableLocales, preselectedLocale, changeLocale]);
+    if (didInitializeRef.current) {
+      return;
+    }
+    didInitializeRef.current = true;
 
-  // Language options
-  const languageOptions = useMemo(() => {
-    const localeNames = surveyLocalization.localeNames;
-    return availableLocales.map((localeCode) => ({
-      value: localeCode,
-      label: localeNames[localeCode] || localeCode,
-    }));
-  }, [availableLocales]);
+    const localeToSelect = resolveInitialCatalogLocale(catalogLocales, {
+      preselectedLocale,
+      savedLocale: localStorage.getItem(STORAGE_KEY),
+      surveyLocale: surveyModel.locale,
+    });
+
+    changeLocale(localeToSelect);
+  }, [surveyModel, catalogLocales, preselectedLocale, changeLocale]);
+
+  const languageOptions = useMemo(
+    () =>
+      catalogLocales.map((localeCode) => ({
+        value: localeCode,
+        label: catalogLocaleDisplayName(localeCode),
+      })),
+    [catalogLocales],
+  );
 
   const currentOption = useMemo(() => {
     return languageOptions.find((option) => option.value === currentLocale);
@@ -103,28 +105,86 @@ export function useLanguageSelection({
     languageOptions,
     changeLocale,
     hasMultipleLocales: languageOptions.length > 1,
+    isDefaultLocale: isDefaultCatalogLocale(currentLocale),
   };
 }
 
-function getBrowserPreferredLocale(availableLocales: string[]): string {
-  if (typeof window === "undefined" || availableLocales.length === 0) {
-    return DEFAULT_LOCALE;
+/** Returns the catalog form of `candidate` when it is available; otherwise undefined. */
+function pickAvailableCatalogLocale(
+  candidate: string | null | undefined,
+  catalogLocales: readonly string[],
+): string | undefined {
+  if (!candidate) {
+    return undefined;
+  }
+
+  const catalogLocale = fromSurveyModelLocale(candidate);
+  return catalogLocales.includes(catalogLocale) ? catalogLocale : undefined;
+}
+
+/**
+ * Pure initial-locale resolver for the public form language picker.
+ * Kept in the feature: selection policy is UX, not shared catalog vocabulary.
+ */
+function resolveInitialCatalogLocale(
+  catalogLocales: string[],
+  sources: {
+    preselectedLocale?: string;
+    savedLocale: string | null;
+    surveyLocale: string;
+  },
+): string {
+  const fromPreselected = pickAvailableCatalogLocale(
+    sources.preselectedLocale,
+    catalogLocales,
+  );
+  if (fromPreselected) {
+    return fromPreselected;
+  }
+
+  if (sources.savedLocale) {
+    return (
+      pickAvailableCatalogLocale(sources.savedLocale, catalogLocales) ??
+      getBrowserPreferredLocale(catalogLocales)
+    );
+  }
+
+  if (sources.surveyLocale) {
+    return (
+      pickAvailableCatalogLocale(sources.surveyLocale, catalogLocales) ??
+      getBrowserPreferredLocale(catalogLocales)
+    );
+  }
+
+  return (
+    pickAvailableCatalogLocale(DEFAULT_CATALOG_LOCALE, catalogLocales) ??
+    getBrowserPreferredLocale(catalogLocales)
+  );
+}
+
+function getBrowserPreferredLocale(catalogLocales: string[]): string {
+  if (typeof window === "undefined" || catalogLocales.length === 0) {
+    return DEFAULT_CATALOG_LOCALE;
   }
 
   const browserLanguages = navigator.languages || [navigator.language] || [];
 
   for (const browserLang of browserLanguages) {
-    if (availableLocales.includes(browserLang)) {
-      return browserLang;
+    const catalog = fromSurveyModelLocale(browserLang);
+    if (catalogLocales.includes(catalog)) {
+      return catalog;
     }
 
     const languageCode = browserLang?.split("-")[0];
-    if (availableLocales.includes(languageCode)) {
-      return languageCode;
+    if (languageCode) {
+      const catalogLang = fromSurveyModelLocale(languageCode);
+      if (catalogLocales.includes(catalogLang)) {
+        return catalogLang;
+      }
     }
   }
 
-  return availableLocales.includes(DEFAULT_LOCALE)
-    ? DEFAULT_LOCALE
-    : availableLocales[0];
+  return catalogLocales.includes(DEFAULT_CATALOG_LOCALE)
+    ? DEFAULT_CATALOG_LOCALE
+    : catalogLocales[0];
 }

--- a/features/public-form/ui/use-survey-model.hook.ts
+++ b/features/public-form/ui/use-survey-model.hook.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Model, SurveyModel } from "survey-core";
 import { Submission } from "@/lib/endatix-api";
+import { resolveSurveyModelLocaleForSubmission } from "@/lib/localization";
 import { initializeCustomQuestions } from "@/lib/questions";
 import { registerAudioQuestion } from "@/lib/questions/audio-recorder";
 import addRandomizeGroupFeature from "@/lib/questions/features/group-randomization";
@@ -21,6 +22,11 @@ interface UseSurveyModelProps {
   customQuestions?: string[];
   onModelCreated?: (model: Model) => void;
   formRuntime?: FormRuntimeContextValue;
+  /**
+   * When set (submission details), drives `model.locale` from submission
+   * metadata vs catalog default. Omit on public-form runtime.
+   */
+  useSubmissionLanguage?: boolean;
 }
 
 export function useSurveyModel({
@@ -30,6 +36,7 @@ export function useSurveyModel({
   submission,
   onModelCreated,
   formRuntime,
+  useSubmissionLanguage,
 }: UseSurveyModelProps) {
   const [error, setError] = useState<string | null>(null);
   const [surveyModel, setSurveyModel] = useState<Model | null>(null);
@@ -43,6 +50,8 @@ export function useSurveyModel({
   const isInitializedRef = useRef(false);
   const identityRef = useRef<string | null>(null);
   const submissionRef = useInitOnly(submission);
+  const useSubmissionLanguageRef = useRef(useSubmissionLanguage);
+  useSubmissionLanguageRef.current = useSubmissionLanguage;
 
   useEffect(() => {
     const loadCustomQuestions = async () => {
@@ -99,6 +108,14 @@ export function useSurveyModel({
       });
       model.currentPageNo = initialSubmission.currentPage ?? 0;
       applyVariablesToModel(model, initialSubmission.metadata);
+
+      if (useSubmissionLanguageRef.current !== undefined) {
+        model.locale = resolveSurveyModelLocaleForSubmission(
+          initialSubmission,
+          model,
+          useSubmissionLanguageRef.current === true,
+        );
+      }
     }
 
     const unbindQuestionLoops = bindQuestionLoops(model);
@@ -130,6 +147,19 @@ export function useSurveyModel({
     bindQuestionLoops,
     formRuntime,
   ]);
+
+  // Keep locale in sync when View → submission language is toggled after construction.
+  useEffect(() => {
+    if (!surveyModel || !submission || useSubmissionLanguage === undefined) {
+      return;
+    }
+
+    surveyModel.locale = resolveSurveyModelLocaleForSubmission(
+      submission,
+      surveyModel,
+      useSubmissionLanguage === true,
+    );
+  }, [surveyModel, submission, useSubmissionLanguage]);
 
   return {
     error,

--- a/features/submissions/ui/details/metadata-card.tsx
+++ b/features/submissions/ui/details/metadata-card.tsx
@@ -17,7 +17,7 @@ import { useMemo, type ReactNode } from "react";
 import {
   getLanguageDisplayName,
   getSubmissionLocale,
-} from "../../submission-localization";
+} from "@/lib/localization";
 import { CellStatusDropdown } from "../table/cell-status-dropdown";
 import {
   useSubmissionDetails,

--- a/features/submissions/ui/details/submission-answers.tsx
+++ b/features/submissions/ui/details/submission-answers.tsx
@@ -13,7 +13,6 @@ import { CustomQuestion } from "@/services/api";
 import { EyeOff } from "lucide-react";
 import { useCallback, useEffect } from "react";
 import { Question } from "survey-core";
-import { resolveSurveyModelLocaleForSubmission } from "@/lib/localization";
 import { getQuestionNumber } from "../../submission-utils";
 import AnswerViewer from "../answers/answer-viewer";
 import {
@@ -43,17 +42,18 @@ export function SubmissionAnswers({
       getRuntimeState,
     },
   });
+  const { viewOptions } = useSubmissionDetailsViewOptions();
   const { surveyModel, error } = useSurveyModel({
     formId,
     definition: formDefinition,
     submission,
     customQuestions: customQuestions.map((q: CustomQuestion) => q.jsonData),
     onModelCreated,
+    useSubmissionLanguage: viewOptions.useSubmissionLanguage === true,
   });
 
   const getReadRuntime = useStorageReadRuntime({ formId });
   const { setSurveyModel } = useSubmissionDetails();
-  const { viewOptions } = useSubmissionDetailsViewOptions();
   const { prefetchPrivateReadUrlsForModel } = useStorageView({
     getReadRuntime,
   });
@@ -74,14 +74,8 @@ export function SubmissionAnswers({
       return;
     }
 
-    surveyModel.locale = resolveSurveyModelLocaleForSubmission(
-      submission,
-      surveyModel,
-      viewOptions.useSubmissionLanguage === true,
-    );
-
     surveyModel.showQuestionNumbers = true;
-  }, [surveyModel, viewOptions.useSubmissionLanguage, submission]);
+  }, [surveyModel]);
 
   if (!isExtensionsReady) {
     return <div>Loading...</div>;

--- a/features/submissions/ui/details/submission-answers.tsx
+++ b/features/submissions/ui/details/submission-answers.tsx
@@ -12,11 +12,8 @@ import { useSurveyExtensions } from "@/lib/survey-extensions/ui/use-survey-exten
 import { CustomQuestion } from "@/services/api";
 import { EyeOff } from "lucide-react";
 import { useCallback, useEffect } from "react";
-import { Question, surveyLocalization } from "survey-core";
-import {
-  getSubmissionLocale,
-  isLocaleValid,
-} from "../../submission-localization";
+import { Question } from "survey-core";
+import { resolveSurveyModelLocaleForSubmission } from "@/lib/localization";
 import { getQuestionNumber } from "../../submission-utils";
 import AnswerViewer from "../answers/answer-viewer";
 import {
@@ -77,15 +74,11 @@ export function SubmissionAnswers({
       return;
     }
 
-    const submissionLocale = getSubmissionLocale(submission);
-    if (
-      viewOptions.useSubmissionLanguage &&
-      isLocaleValid(submissionLocale, surveyModel)
-    ) {
-      surveyModel.locale = submissionLocale!;
-    } else {
-      surveyModel.locale = surveyLocalization.defaultLocale;
-    }
+    surveyModel.locale = resolveSurveyModelLocaleForSubmission(
+      submission,
+      surveyModel,
+      viewOptions.useSubmissionLanguage === true,
+    );
 
     surveyModel.showQuestionNumbers = true;
   }, [surveyModel, viewOptions.useSubmissionLanguage, submission]);

--- a/features/submissions/ui/details/submission-details-content.tsx
+++ b/features/submissions/ui/details/submission-details-content.tsx
@@ -3,7 +3,7 @@
 import { cn } from "@/lib/utils";
 import { CustomQuestion } from "@/services/api";
 import { useEffect, useState, type ReactNode } from "react";
-import { getSubmissionLocale } from "../../submission-localization";
+import { getSubmissionLocale } from "@/lib/localization";
 import CalculatedValuesList from "./calculated-values-list";
 import DynamicVariablesList from "./dynamic-variables-list";
 import { QuestionFinder } from "./question-finder";

--- a/features/submissions/ui/shared/use-survey-model.hook.ts
+++ b/features/submissions/ui/shared/use-survey-model.hook.ts
@@ -10,7 +10,11 @@ import { useAnyAnswered } from "@/lib/survey-features/any-answered";
 import { useEndatixSurveyTheme } from "@/lib/themes/use-endatix-themes";
 import { useEffect, useRef, useState } from "react";
 import { Model } from "survey-core";
-import { getSubmissionLocale, isLocaleValid } from "@/lib/localization";
+import {
+  getSubmissionLocale,
+  isLocaleValid,
+  toSurveyModelLocale,
+} from "@/lib/localization";
 
 export function useSurveyModel(
   submission: Submission,
@@ -76,7 +80,7 @@ export function useSurveyModel(
 
         const submissionLocale = getSubmissionLocale(submission);
         if (submissionLocale && isLocaleValid(submissionLocale, model)) {
-          model.locale = submissionLocale;
+          model.locale = toSurveyModelLocale(submissionLocale);
         }
 
         model.showCompletedPage = false;

--- a/features/submissions/ui/shared/use-survey-model.hook.ts
+++ b/features/submissions/ui/shared/use-survey-model.hook.ts
@@ -10,10 +10,7 @@ import { useAnyAnswered } from "@/lib/survey-features/any-answered";
 import { useEndatixSurveyTheme } from "@/lib/themes/use-endatix-themes";
 import { useEffect, useRef, useState } from "react";
 import { Model } from "survey-core";
-import {
-  getSubmissionLocale,
-  isLocaleValid,
-} from "../../submission-localization";
+import { getSubmissionLocale, isLocaleValid } from "@/lib/localization";
 
 export function useSurveyModel(
   submission: Submission,

--- a/lib/localization/catalog/__tests__/catalog-locale.test.ts
+++ b/lib/localization/catalog/__tests__/catalog-locale.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CATALOG_LOCALE,
+  fromSurveyModelLocale,
+  isDefaultCatalogLocale,
+  toCatalogLocales,
+  toSurveyModelLocale,
+} from "../catalog-locale";
+
+describe("catalog-locale", () => {
+  it("maps catalog default to empty survey model locale and back", () => {
+    expect(toSurveyModelLocale(DEFAULT_CATALOG_LOCALE)).toBe("");
+    expect(toSurveyModelLocale("en")).toBe("");
+    expect(toSurveyModelLocale("")).toBe("");
+    expect(fromSurveyModelLocale("")).toBe(DEFAULT_CATALOG_LOCALE);
+    expect(fromSurveyModelLocale("en")).toBe(DEFAULT_CATALOG_LOCALE);
+    expect(fromSurveyModelLocale("default")).toBe(DEFAULT_CATALOG_LOCALE);
+  });
+
+  it("preserves non-default cultures", () => {
+    expect(toSurveyModelLocale("bg")).toBe("bg");
+    expect(fromSurveyModelLocale("bg")).toBe("bg");
+    expect(isDefaultCatalogLocale("bg")).toBe(false);
+  });
+
+  it("normalizes getUsedLocales-style lists to catalog codes", () => {
+    expect(toCatalogLocales(["en", "bg", "en"])).toEqual(["default", "bg"]);
+    expect(toCatalogLocales(["bg", "default"])).toEqual(["bg", "default"]);
+  });
+});

--- a/lib/localization/catalog/catalog-locale.ts
+++ b/lib/localization/catalog/catalog-locale.ts
@@ -1,0 +1,86 @@
+import { surveyLocalization } from "survey-core";
+
+/** Catalog / LocalizableString key for the survey default language. */
+export const DEFAULT_CATALOG_LOCALE = "default";
+
+/**
+ * SurveyJS runtime code that {@link SurveyModel.getUsedLocales} substitutes for
+ * JSON <c>default</c> (usually <c>en</c>).
+ */
+export function surveyJsDefaultLocaleCode(): string {
+  return surveyLocalization.defaultLocale || "en";
+}
+
+/** True when the code means the survey / data-list default language. */
+export function isDefaultCatalogLocale(
+  code: string | undefined | null,
+): boolean {
+  if (code == null) {
+    return true;
+  }
+
+  const trimmed = code.trim();
+  if (trimmed.length === 0 || trimmed === DEFAULT_CATALOG_LOCALE) {
+    return true;
+  }
+
+  return trimmed.toLowerCase() === surveyJsDefaultLocaleCode().toLowerCase();
+}
+
+/**
+ * Maps an owned catalog locale to SurveyJS <c>model.locale</c>.
+ * Default language is the empty string.
+ */
+export function toSurveyModelLocale(catalogLocale: string): string {
+  return isDefaultCatalogLocale(catalogLocale)
+    ? ""
+    : catalogLocale.trim().toLowerCase();
+}
+
+/**
+ * Maps SurveyJS <c>model.locale</c> (or a getUsedLocales entry) to an owned
+ * catalog locale code.
+ */
+export function fromSurveyModelLocale(
+  modelLocale: string | undefined | null,
+): string {
+  if (isDefaultCatalogLocale(modelLocale)) {
+    return DEFAULT_CATALOG_LOCALE;
+  }
+
+  return String(modelLocale).trim().toLowerCase();
+}
+
+/**
+ * Normalizes SurveyJS <c>getUsedLocales()</c> (which rewrites JSON
+ * <c>default</c> → defaultLocale code) into catalog codes for UI / APIs.
+ */
+export function toCatalogLocales(usedLocales: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const locale of usedLocales) {
+    const catalog = fromSurveyModelLocale(locale);
+    if (seen.has(catalog)) {
+      continue;
+    }
+    seen.add(catalog);
+    result.push(catalog);
+  }
+
+  return result;
+}
+
+/**
+ * Display label for a catalog locale (uses SurveyJS localeNames for the
+ * runtime defaultLocale code when the catalog key is <c>default</c>).
+ */
+export function catalogLocaleDisplayName(catalogLocale: string): string {
+  if (isDefaultCatalogLocale(catalogLocale)) {
+    const code = surveyJsDefaultLocaleCode();
+    return surveyLocalization.localeNames[code] || code;
+  }
+
+  const code = catalogLocale.trim().toLowerCase();
+  return surveyLocalization.localeNames[code] || code;
+}

--- a/lib/localization/catalog/index.ts
+++ b/lib/localization/catalog/index.ts
@@ -1,0 +1,9 @@
+export {
+  DEFAULT_CATALOG_LOCALE,
+  catalogLocaleDisplayName,
+  fromSurveyModelLocale,
+  isDefaultCatalogLocale,
+  surveyJsDefaultLocaleCode,
+  toCatalogLocales,
+  toSurveyModelLocale,
+} from "./catalog-locale";

--- a/lib/localization/index.ts
+++ b/lib/localization/index.ts
@@ -1,0 +1,16 @@
+export {
+  DEFAULT_CATALOG_LOCALE,
+  catalogLocaleDisplayName,
+  fromSurveyModelLocale,
+  isDefaultCatalogLocale,
+  surveyJsDefaultLocaleCode,
+  toCatalogLocales,
+  toSurveyModelLocale,
+} from "./catalog";
+
+export {
+  getLanguageDisplayName,
+  getSubmissionLocale,
+  isLocaleValid,
+  resolveSurveyModelLocaleForSubmission,
+} from "./submission-locale";

--- a/lib/localization/submission-locale/__tests__/submission-locale.test.ts
+++ b/lib/localization/submission-locale/__tests__/submission-locale.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { Submission } from "@/lib/endatix-api";
+import type { SurveyModel } from "survey-core";
+import { resolveSurveyModelLocaleForSubmission } from "../submission-locale";
+
+describe("resolveSurveyModelLocaleForSubmission", () => {
+  const surveyModel = {
+    getUsedLocales: () => ["en", "bg"],
+  } as unknown as SurveyModel;
+
+  function submissionWithLanguage(language: string): Submission {
+    return {
+      metadata: JSON.stringify({ language }),
+    } as Submission;
+  }
+
+  it("returns catalog default when submission language is disabled", () => {
+    expect(
+      resolveSurveyModelLocaleForSubmission(
+        submissionWithLanguage("bg"),
+        surveyModel,
+        false,
+      ),
+    ).toBe("");
+  });
+
+  it("returns submission SurveyJS locale when enabled and valid", () => {
+    expect(
+      resolveSurveyModelLocaleForSubmission(
+        submissionWithLanguage("bg"),
+        surveyModel,
+        true,
+      ),
+    ).toBe("bg");
+  });
+
+  it("falls back to catalog default when submission locale is invalid", () => {
+    expect(
+      resolveSurveyModelLocaleForSubmission(
+        submissionWithLanguage("fr"),
+        surveyModel,
+        true,
+      ),
+    ).toBe("");
+  });
+});

--- a/lib/localization/submission-locale/index.ts
+++ b/lib/localization/submission-locale/index.ts
@@ -1,0 +1,6 @@
+export {
+  getLanguageDisplayName,
+  getSubmissionLocale,
+  isLocaleValid,
+  resolveSurveyModelLocaleForSubmission,
+} from "./submission-locale";

--- a/lib/localization/submission-locale/submission-locale.ts
+++ b/lib/localization/submission-locale/submission-locale.ts
@@ -1,8 +1,14 @@
 import { Submission } from "@/lib/endatix-api";
 import { tryParseJson } from "@/lib/utils/type-parsers";
-import { Metadata, MetadataSchema } from "../public-form/types";
+import { Metadata, MetadataSchema } from "@/features/public-form/types";
 import { Result } from "@/lib/result";
 import { SurveyModel } from "survey-core";
+import {
+  DEFAULT_CATALOG_LOCALE,
+  fromSurveyModelLocale,
+  toCatalogLocales,
+  toSurveyModelLocale,
+} from "@/lib/localization/catalog";
 
 /**
  * Get the Submission locale according to the view preference
@@ -37,16 +43,17 @@ function isLocaleValid(
   locale: string | undefined,
   surveyModel: SurveyModel,
 ): boolean {
-  if (!locale || !surveyModel) {
+  if (locale == null || !surveyModel) {
     return false;
   }
 
-  if (typeof locale !== "string" || locale.length === 0) {
+  if (typeof locale !== "string") {
     return false;
   }
 
-  const usedLocales = surveyModel.getUsedLocales() || [];
-  return usedLocales.includes(locale);
+  const catalogLocale = fromSurveyModelLocale(locale);
+  const usedLocales = toCatalogLocales(surveyModel.getUsedLocales() || []);
+  return usedLocales.includes(catalogLocale);
 }
 
 /**
@@ -67,4 +74,28 @@ function getLanguageDisplayName(locale: string | undefined) {
   }
 }
 
-export { getSubmissionLocale, isLocaleValid, getLanguageDisplayName };
+/**
+ * SurveyJS `model.locale` for a submission view: preferred metadata language
+ * when enabled and valid, otherwise the catalog default (`""`).
+ */
+function resolveSurveyModelLocaleForSubmission(
+  submission: Submission,
+  surveyModel: SurveyModel,
+  useSubmissionLanguage: boolean,
+): string {
+  if (useSubmissionLanguage) {
+    const submissionLocale = getSubmissionLocale(submission);
+    if (isLocaleValid(submissionLocale, surveyModel)) {
+      return toSurveyModelLocale(submissionLocale!);
+    }
+  }
+
+  return toSurveyModelLocale(DEFAULT_CATALOG_LOCALE);
+}
+
+export {
+  getSubmissionLocale,
+  isLocaleValid,
+  getLanguageDisplayName,
+  resolveSurveyModelLocaleForSubmission,
+};

--- a/project-structure.md
+++ b/project-structure.md
@@ -365,6 +365,7 @@ app/
 hub/
 ├── lib/                    # Internal utilities
 │   ├── endatix-api/       # API client (internal)
+│   ├── localization/      # Multi-lingual domain (catalog, submission locale, future i18n)
 │   └── utils/             # Shared utilities
 ├── features/              # App-specific features
 │   ├── config/            # App configuration
@@ -372,6 +373,21 @@ hub/
 │   └── forms/             # Form management
 └── packages/              # Future workspace packages
 ```
+
+### `lib/localization` domain
+
+Use `lib/localization` for **cross-feature multi-lingual infrastructure**, organized as slices:
+
+| Slice | Responsibility |
+| --- | --- |
+| `catalog/` | SurveyJS ↔ owned catalog vocabulary (`default` ↔ `""` / runtime default code), `toCatalogLocales`, display names |
+| `submission-locale/` | Submission metadata language helpers shared by submissions UI and pdf-export |
+| `routing/` (future) | Locale-prefixed Hub routes / middleware |
+| `messages/` (future) | Hub UI copy catalogs (e.g. next-intl) |
+
+Keep **selection policy** in the owning feature (e.g. public-form language picker priority: preselected → localStorage → survey model → browser). Do not move feature-specific preference storage or init order into `lib/`.
+
+Import from `@/lib/localization` (root barrel) or a slice path such as `@/lib/localization/catalog`.
 
 ### Target Monorepo Structure
 


### PR DESCRIPTION
# feat(h831): Refactoring survey localization into dedicated cross-cutting slice

## Description
- Refactoring survey localization into dedicated cross-cutting slice
- Consolidates localization logic used by the language selector and other multi-lingual parts of the application like the data lists to allow for seamless and consistent multi-lingual experience
- Updates tests

## Related Issues
- relates to #831 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [x] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved language selection with consistent default-locale handling across catalog and survey languages.
  - Added migration and mapping for saved preferences, browser languages, and legacy locale values.
  - Added clearer language display names and an indicator for the default language.
  - Submission details now apply the appropriate submission language, with reliable fallback behavior.

- **Bug Fixes**
  - Prevented invalid or unsupported locales from being selected.
  - Improved synchronization between selected languages and survey translations.

- **Documentation**
  - Documented the shared multilingual infrastructure and supported localization usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->