### PR TITLE
feat(h831): Multilingual support for public data lists API/UI

### DIFF
--- a/features/data-lists/add-items/__tests__/validation.test.ts
+++ b/features/data-lists/add-items/__tests__/validation.test.ts
@@ -39,7 +39,10 @@ describe("validateJsonInput", () => {
     );
 
     expect(result.validItems).toHaveLength(1);
-    expect(result.validItems[0]).toEqual({ label: "Option 1", value: "opt1" });
+    expect(result.validItems[0]).toEqual({
+      value: "opt1",
+      labels: { default: "Option 1" },
+    });
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain("label is required");
 
@@ -63,8 +66,8 @@ describe("validateJsonInput", () => {
       `[{"label": "${longLabel}", "value": "a"}]`,
     );
 
-    expect(result.errors.some((e) => e.includes("exceeds 255"))).toBe(true);
-    expect(result.annotations.some((a) => a.text.includes("exceeds 255"))).toBe(
+    expect(result.errors.some((e) => e.includes("exceeds 100"))).toBe(true);
+    expect(result.annotations.some((a) => a.text.includes("exceeds 100"))).toBe(
       true,
     );
   });

--- a/features/data-lists/add-items/__tests__/validation.test.ts
+++ b/features/data-lists/add-items/__tests__/validation.test.ts
@@ -163,13 +163,17 @@ describe("validateJsonInput", () => {
     );
 
     expect(result.validItems).toHaveLength(2);
-    expect(result.validItems[0].label).toBe("foo");
-    expect(result.validItems[1].label).toBe("bar");
+    expect(result.validItems[0].labels.default).toBe("foo");
+    expect(result.validItems[1].labels.default).toBe("bar");
 
     expect(result.errors).toHaveLength(6);
     expect(result.errors.some((e) => e.includes("cannot be null"))).toBe(true);
-    expect(result.errors.some((e) => e.includes("label is required"))).toBe(true);
-    expect(result.errors.some((e) => e.includes("value is required"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("label is required"))).toBe(
+      true,
+    );
+    expect(result.errors.some((e) => e.includes("value is required"))).toBe(
+      true,
+    );
     expect(result.errors.some((e) => e.includes("must be unique"))).toBe(true);
   });
 });

--- a/features/data-lists/convert-inline-choices/__tests__/convert-choices-to-data-list.action.test.ts
+++ b/features/data-lists/convert-inline-choices/__tests__/convert-choices-to-data-list.action.test.ts
@@ -31,7 +31,7 @@ describe("convertChoicesToDataListAction", () => {
 
     const result = await convertChoicesToDataListAction({
       name: "List",
-      items: [{ label: "A", value: "a" }],
+      items: [{ value: "a", labels: { default: "A" } }],
     });
 
     expect(Result.isError(result)).toBe(true);
@@ -55,7 +55,7 @@ describe("convertChoicesToDataListAction", () => {
 
     const result = await convertChoicesToDataListAction({
       name: "List",
-      items: [{ label: "A", value: "a" }],
+      items: [{ value: "a", labels: { default: "A" } }],
     });
 
     expect(Result.isError(result)).toBe(true);
@@ -77,7 +77,7 @@ describe("convertChoicesToDataListAction", () => {
 
     const result = await convertChoicesToDataListAction({
       name: "List",
-      items: [{ label: "A", value: "a" }],
+      items: [{ value: "a", labels: { default: "A" } }],
     });
 
     expect(Result.isSuccess(result)).toBe(true);
@@ -85,7 +85,7 @@ describe("convertChoicesToDataListAction", () => {
       expect(result.value.dataList.id).toBe("dl-1");
     }
     expect(mockReplace).toHaveBeenCalledWith("dl-1", [
-      { label: "A", value: "a" },
+      { value: "a", labels: { default: "A" } },
     ]);
     expect(mockDelete).not.toHaveBeenCalled();
   });

--- a/features/data-lists/utils.ts
+++ b/features/data-lists/utils.ts
@@ -141,7 +141,7 @@ export function validateJsonInput(value: string): ParsedValidation {
 
     // Add valid item if no errors for this item
     if (label && valueField && !hasError(`Choice item ${index + 1}`)) {
-      validItems.push({ label, value: valueField });
+      validItems.push({ value: valueField, labels: { default: label } });
     }
   });
 

--- a/lib/endatix-api/data-lists/types.ts
+++ b/lib/endatix-api/data-lists/types.ts
@@ -13,8 +13,8 @@ export interface DataListDetails extends DataList {
 }
 
 export interface DataListChoiceItem {
-  label: string;
   value: string;
+  labels: Record<string, string>;
 }
 
 export interface DataListItem {

--- a/lib/endatix-api/public/data-lists/__tests__/public-data-lists.client.test.ts
+++ b/lib/endatix-api/public/data-lists/__tests__/public-data-lists.client.test.ts
@@ -80,12 +80,76 @@ describe("PublicDataListsClient", () => {
     );
   });
 
+  it("sends includeLocales as repeated query params", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          page: 1,
+          pageSize: 25,
+          totalRecords: 0,
+          totalPages: 0,
+          items: [],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createPublicDataListsClient({
+      baseUrl: "https://api.example.com",
+    });
+    const result = await client.search({
+      formId: "101",
+      dataListId: "12",
+      includeLocales: ["default", "es"],
+      formAccessJwt: "form-access-jwt",
+    });
+
+    expect(result.success).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/public/forms/101/data-lists/12/search?skip=0&take=25&includeLocales=default&includeLocales=es",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("sends includeLocales on display-values", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            value: "apple",
+            labels: { default: "Apple", es: "Manzana" },
+          },
+        ]),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createPublicDataListsClient({
+      baseUrl: "https://api.example.com",
+    });
+    const result = await client.getDisplayValues({
+      formId: "101",
+      dataListId: "12",
+      values: ["apple"],
+      includeLocales: ["default", "es"],
+      formAccessJwt: "jwt-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/public/forms/101/data-lists/12/display-values?values=apple&includeLocales=default&includeLocales=es",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
   it("builds display-values request with repeated values and Bearer JWT", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify([
-          { label: "Bulgaria", value: "BG" },
-          { label: "United States", value: "US" },
+          { value: "BG", labels: { default: "Bulgaria" } },
+          { value: "US", labels: { default: "United States" } },
         ]),
         { status: 200, headers: { "content-type": "application/json" } },
       ),

--- a/lib/endatix-api/public/data-lists/public-data-lists.client.ts
+++ b/lib/endatix-api/public/data-lists/public-data-lists.client.ts
@@ -9,6 +9,8 @@ import {
   PublicDataListSearchRequest,
 } from "./types";
 
+const INCLUDE_LOCALES_QUERY_PARAM = "includeLocales";
+
 export interface PublicDataListsClientOptions {
   baseUrl?: string;
   /** Optional default bearer token used for all requests unless overridden per call. */
@@ -54,6 +56,12 @@ export class PublicDataListsClient {
     if (request.locale) {
       query.set("locale", request.locale);
     }
+    for (const locale of request.includeLocales ?? []) {
+      const trimmed = locale.trim();
+      if (trimmed.length > 0) {
+        query.append(INCLUDE_LOCALES_QUERY_PARAM, trimmed);
+      }
+    }
 
     const endpoint = `/public/forms/${request.formId}/data-lists/${request.dataListId}/search?${query.toString()}`;
     return this.get<DataListPublicSearchResult>(endpoint, bearerToken);
@@ -83,6 +91,15 @@ export class PublicDataListsClient {
 
     const query = new URLSearchParams();
     request.values.forEach((value) => query.append("values", value));
+    if (request.locale) {
+      query.set("locale", request.locale);
+    }
+    for (const locale of request.includeLocales ?? []) {
+      const trimmed = locale.trim();
+      if (trimmed.length > 0) {
+        query.append(INCLUDE_LOCALES_QUERY_PARAM, trimmed);
+      }
+    }
 
     const endpoint = `/public/forms/${request.formId}/data-lists/${request.dataListId}/display-values?${query.toString()}`;
     return this.get<DataListChoiceItem[]>(endpoint, bearerToken);

--- a/lib/endatix-api/public/data-lists/types.ts
+++ b/lib/endatix-api/public/data-lists/types.ts
@@ -1,6 +1,7 @@
 export interface DataListChoiceItem {
-  label: string;
   value: string;
+  /** Localized labels map (always includes `default`). Mapped to SurveyJS `text` in Hub. */
+  labels: Record<string, string>;
 }
 
 export interface DataListPublicSearchResult {
@@ -24,15 +25,19 @@ export interface PublicDataListSearchRequest {
   formAccessJwt?: string;
   query?: string;
   /**
-   * Comparison used for query against the resolved label key (not Value).
+   * Comparison used for query against Value and label keys.
    * Omit for API default (Contains).
    */
   matchMode?: DataListSearchMatchMode;
   /**
-   * Optional locale for which label key to search.
-   * Omitted / default / list default culture → Labels.default; catalog locale (e.g. es) → that key.
+   * Optional locale for which single label key to prefer when includeLocales is omitted.
    */
   locale?: string;
+  /**
+   * Locales to include in labels projection and multi-key search.
+   * Sent as repeated includeLocales query params.
+   */
+  includeLocales?: string[];
   skip?: number;
   take?: number;
 }
@@ -46,4 +51,7 @@ export interface PublicDataListDisplayValuesRequest {
   formAccessJwt?: string;
   /** The values to get display values for. */
   values: string[];
+  /** Optional locales for labels projection on display-values. */
+  includeLocales?: string[];
+  locale?: string;
 }

--- a/lib/survey-features/data-lists/constants.ts
+++ b/lib/survey-features/data-lists/constants.ts
@@ -10,7 +10,7 @@ export const PROPERTY_GRID_LAZY_REFRESH_PROPERTY_NAMES = [
 ] as const;
 
 /** API max length for data list item label and value. */
-export const DATA_LIST_ITEM_MAX_LENGTH = 255;
+export const DATA_LIST_ITEM_MAX_LENGTH = 100;
 
 /** API max length for data list name. */
 export const DATA_LIST_NAME_MAX_LENGTH = 100;

--- a/lib/survey-features/data-lists/infrastructure/__tests__/apply-multilingual-choice-display-values.test.ts
+++ b/lib/survey-features/data-lists/infrastructure/__tests__/apply-multilingual-choice-display-values.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { Model, QuestionDropdownModel } from "survey-core";
+import { applyMultilingualChoiceDisplayValues } from "../apply-multilingual-choice-display-values";
+
+type SelectedChoiceItem = {
+  text: string;
+  value?: unknown;
+  locText: { getJson: () => Record<string, string> };
+};
+
+/** SurveyJS keeps `selectedItemValues` protected; tests need the same access path as production. */
+type SelectBaseQuestion = QuestionDropdownModel & {
+  selectedItemValues: SelectedChoiceItem[];
+};
+
+describe("applyMultilingualChoiceDisplayValues", () => {
+  it("passes flat labels to setItems then stamps full locale maps on selected items", () => {
+    const model = new Model({
+      locale: "bg",
+      pages: [
+        {
+          elements: [
+            {
+              type: "tagbox",
+              name: "cities",
+              choicesLazyLoadEnabled: true,
+            },
+          ],
+        },
+      ],
+    });
+    model.locale = "bg";
+
+    const question = model.getQuestionByName("cities") as SelectBaseQuestion;
+    const setItems = vi.fn((displayValues: string[]) => {
+      question.selectedItemValues = displayValues.map((text, index) =>
+        question.createItemValue(["728193", "727011"][index], text),
+      ) as SelectedChoiceItem[];
+    });
+
+    applyMultilingualChoiceDisplayValues(
+      question,
+      ["728193", "727011"],
+      new Map([
+        ["728193", { default: "Plovdiv", bg: "Пловдив" }],
+        ["727011", { default: "Sofia", bg: "София" }],
+      ]),
+      setItems,
+      "bg",
+    );
+
+    expect(setItems).toHaveBeenCalledWith(["Пловдив", "София"]);
+
+    const selected = question.selectedItemValues;
+
+    expect(selected[0].locText.getJson()).toEqual({
+      default: "Plovdiv",
+      bg: "Пловдив",
+    });
+    expect(selected[1].locText.getJson()).toEqual({
+      default: "Sofia",
+      bg: "София",
+    });
+
+    model.locale = "";
+    expect(selected.map((item: SelectedChoiceItem) => item.text)).toEqual([
+      "Plovdiv",
+      "Sofia",
+    ]);
+
+    model.locale = "bg";
+    expect(selected.map((item: SelectedChoiceItem) => item.text)).toEqual([
+      "Пловдив",
+      "София",
+    ]);
+  });
+});

--- a/lib/survey-features/data-lists/infrastructure/__tests__/prime-data-list-display-values.test.ts
+++ b/lib/survey-features/data-lists/infrastructure/__tests__/prime-data-list-display-values.test.ts
@@ -5,6 +5,7 @@ import {
   formatChoiceDisplay,
   resolveChoiceLabelForQuestion,
 } from "@/features/pdf-export/submission/format-choice-display";
+import { clearDataListDisplayValuesCacheForTests } from "../../use-cases/resolve-data-list-display-values";
 
 const { mockAuth, mockCreateFormAccessToken } = vi.hoisted(() => ({
   mockAuth: vi.fn(),
@@ -45,6 +46,7 @@ import { primeDataListDisplayValues } from "../prime-data-list-display-values";
 describe("primeDataListDisplayValues", () => {
   beforeEach(() => {
     registerDataListGlobals();
+    clearDataListDisplayValuesCacheForTests();
     vi.clearAllMocks();
     mockAuth.mockResolvedValue({ accessToken: "hub-token" });
     mockCreateFormAccessToken.mockResolvedValue({
@@ -53,7 +55,7 @@ describe("primeDataListDisplayValues", () => {
     });
     mockGetDisplayValues.mockResolvedValue({
       success: true,
-      data: [{ value: "us", label: "United States" }],
+      data: [{ value: "us", labels: { default: "United States" } }],
     });
   });
 
@@ -84,6 +86,7 @@ describe("primeDataListDisplayValues", () => {
       dataListId: "42",
       formAccessJwt: "form-jwt",
       values: ["us"],
+      includeLocales: ["default"],
     });
     expect(question.choicesLazyLoadEnabled).toBe(false);
     expect(resolveChoiceLabelForQuestion(question)).toBe("United States");
@@ -98,7 +101,7 @@ describe("primeDataListDisplayValues", () => {
   it("resolves lazy-load dropdown with numeric stored values", async () => {
     mockGetDisplayValues.mockResolvedValue({
       success: true,
-      data: [{ value: "18", label: "Option Eighteen" }],
+      data: [{ value: "18", labels: { default: "Option Eighteen" } }],
     });
 
     const model = new Model({

--- a/lib/survey-features/data-lists/infrastructure/__tests__/resolve-survey-locales-for-data-list.test.ts
+++ b/lib/survey-features/data-lists/infrastructure/__tests__/resolve-survey-locales-for-data-list.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { resolveSurveyLocalesForDataList } from "../resolve-survey-locales-for-data-list";
+
+describe("resolveSurveyLocalesForDataList", () => {
+  it("includes default and catalog locales, normalizing SurveyJS en", () => {
+    const result = resolveSurveyLocalesForDataList(
+      {
+        locale: "bg",
+        getUsedLocales: () => ["bg", "en"],
+      },
+      { getLocale: () => "bg" },
+    );
+
+    expect(result.locale).toBe("bg");
+    expect(result.includeLocales).toEqual(["default", "bg"]);
+  });
+
+  it("treats active en as survey default (no API locale)", () => {
+    const result = resolveSurveyLocalesForDataList(
+      {
+        locale: "en",
+        getUsedLocales: () => ["en", "bg"],
+      },
+      { getLocale: () => "en" },
+    );
+
+    expect(result.locale).toBeUndefined();
+    expect(result.includeLocales).toEqual(["default", "bg"]);
+  });
+
+  it("falls back to model.locale when question locale is empty", () => {
+    const result = resolveSurveyLocalesForDataList(
+      {
+        locale: "es",
+        getUsedLocales: () => ["es", "fr"],
+      },
+      { getLocale: () => "" },
+    );
+
+    expect(result.locale).toBe("es");
+    expect(result.includeLocales).toEqual(["default", "es", "fr"]);
+  });
+
+  it("still projects used locales when no active locale is set", () => {
+    const result = resolveSurveyLocalesForDataList(
+      {
+        locale: "",
+        getUsedLocales: () => ["bg"],
+      },
+      { getLocale: () => "default" },
+    );
+
+    expect(result.locale).toBeUndefined();
+    expect(result.includeLocales).toEqual(["default", "bg"]);
+  });
+});

--- a/lib/survey-features/data-lists/infrastructure/__tests__/survey-bindings.test.ts
+++ b/lib/survey-features/data-lists/infrastructure/__tests__/survey-bindings.test.ts
@@ -52,9 +52,8 @@ describe("bindDataListsToSurvey", () => {
     registerDataListGlobals();
   });
 
-<<<<<<< Updated upstream
   it.each(["dropdown", "tagbox"] as const)(
-    "passes StartsWith and locale es from %s to the public search request",
+    "passes StartsWith, locale es, and includeLocales from %s to the public search request",
     async (questionType) => {
       const model = new Model({
         pages: [
@@ -68,48 +67,13 @@ describe("bindDataListsToSurvey", () => {
             ],
           },
         ],
-=======
-  it("passes StartsWith and all survey locales from the question to the public search request", async () => {
-    const model = new Model({
-      locale: "es",
-      pages: [
-        {
-          elements: [
-            {
-              type: "dropdown",
-              name: "fruit",
-              choicesLazyLoadEnabled: true,
-            },
-          ],
-        },
-      ],
-    });
-    model.locale = "es";
-    vi.spyOn(model, "getUsedLocales").mockReturnValue(["es", "fr"]);
-
-    const question = model.getQuestionByName("fruit") as QuestionDropdownModel;
-    question.setPropertyValue(DATA_LIST_PROPERTY_NAME, "42");
-    question.searchMode = "startsWith";
-
-    bindDataListsToSurvey(model, {
-      deps: {
-        getRuntimeState: () => ({ formId: "101" }),
-      },
-    });
-
-    await new Promise<void>((resolve) => {
-      model.onChoicesLazyLoad.fire(model, {
-        question,
-        filter: "Manz",
-        skip: 0,
-        take: 25,
-        setItems: () => resolve(),
->>>>>>> Stashed changes
       });
       model.locale = "es";
+      vi.spyOn(model, "getUsedLocales").mockReturnValue(["es", "fr"]);
 
-<<<<<<< Updated upstream
-      const question = model.getQuestionByName("fruit") as QuestionDropdownModel;
+      const question = model.getQuestionByName(
+        "fruit",
+      ) as QuestionDropdownModel;
       question.setPropertyValue(DATA_LIST_PROPERTY_NAME, "42");
       question.searchMode = "startsWith";
 
@@ -136,26 +100,13 @@ describe("bindDataListsToSurvey", () => {
           query: "Manz",
           matchMode: "StartsWith",
           locale: "es",
+          includeLocales: ["default", "es", "fr"],
           skip: 0,
           take: 25,
         }),
       );
     },
   );
-=======
-    expect(searchMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        formId: "101",
-        dataListId: "42",
-        query: "Manz",
-        matchMode: "StartsWith",
-        locale: "es",
-        includeLocales: ["default", "es", "fr"],
-        skip: 0,
-        take: 25,
-      }),
-    );
-  });
 
   it("stamps full locale maps on selectedItemValues so locale switches stay labeled", async () => {
     const model = new Model({
@@ -221,5 +172,4 @@ describe("bindDataListsToSurvey", () => {
     model.locale = "bg";
     expect(selected[0].text).toBe("Пловдив");
   });
->>>>>>> Stashed changes
 });

--- a/lib/survey-features/data-lists/infrastructure/__tests__/survey-bindings.test.ts
+++ b/lib/survey-features/data-lists/infrastructure/__tests__/survey-bindings.test.ts
@@ -3,17 +3,20 @@ import { Model, QuestionDropdownModel } from "survey-core";
 import { ApiResult } from "@/lib/endatix-api/shared/api-result";
 import { clearChoicesLazyLoadGuardsForTests } from "@/lib/survey-features/infrastructure/choices-lazy-load-guards";
 import { DATA_LIST_PROPERTY_NAME } from "../../constants";
+import { clearDataListDisplayValuesCacheForTests } from "../../use-cases/resolve-data-list-display-values";
 import { registerDataListGlobals } from "../registry";
 import { bindDataListsToSurvey } from "../survey-bindings";
 
-const { searchMock } = vi.hoisted(() => ({
+const { searchMock, getDisplayValuesMock } = vi.hoisted(() => ({
   searchMock: vi.fn(),
+  getDisplayValuesMock: vi.fn(),
 }));
 
 vi.mock("@/lib/endatix-api/public", () => ({
   createEndatixPublicApi: () => ({
     dataLists: {
       search: searchMock,
+      getDisplayValues: getDisplayValuesMock,
     },
   }),
 }));
@@ -23,10 +26,12 @@ vi.mock("@/lib/form-runtime/form-access-jwt-orchestrator", () => ({
   invalidateRuntimeFormAccessJwt: vi.fn(),
 }));
 
-describe("bindDataListsToSurvey onChoicesLazyLoad", () => {
+describe("bindDataListsToSurvey", () => {
   beforeEach(() => {
     clearChoicesLazyLoadGuardsForTests();
+    clearDataListDisplayValuesCacheForTests();
     searchMock.mockReset();
+    getDisplayValuesMock.mockReset();
     searchMock.mockResolvedValue(
       ApiResult.success({
         page: 1,
@@ -36,9 +41,18 @@ describe("bindDataListsToSurvey onChoicesLazyLoad", () => {
         items: [],
       }),
     );
+    getDisplayValuesMock.mockResolvedValue(
+      ApiResult.success([
+        {
+          value: "728193",
+          labels: { default: "Plovdiv", bg: "Пловдив" },
+        },
+      ]),
+    );
     registerDataListGlobals();
   });
 
+<<<<<<< Updated upstream
   it.each(["dropdown", "tagbox"] as const)(
     "passes StartsWith and locale es from %s to the public search request",
     async (questionType) => {
@@ -54,9 +68,47 @@ describe("bindDataListsToSurvey onChoicesLazyLoad", () => {
             ],
           },
         ],
+=======
+  it("passes StartsWith and all survey locales from the question to the public search request", async () => {
+    const model = new Model({
+      locale: "es",
+      pages: [
+        {
+          elements: [
+            {
+              type: "dropdown",
+              name: "fruit",
+              choicesLazyLoadEnabled: true,
+            },
+          ],
+        },
+      ],
+    });
+    model.locale = "es";
+    vi.spyOn(model, "getUsedLocales").mockReturnValue(["es", "fr"]);
+
+    const question = model.getQuestionByName("fruit") as QuestionDropdownModel;
+    question.setPropertyValue(DATA_LIST_PROPERTY_NAME, "42");
+    question.searchMode = "startsWith";
+
+    bindDataListsToSurvey(model, {
+      deps: {
+        getRuntimeState: () => ({ formId: "101" }),
+      },
+    });
+
+    await new Promise<void>((resolve) => {
+      model.onChoicesLazyLoad.fire(model, {
+        question,
+        filter: "Manz",
+        skip: 0,
+        take: 25,
+        setItems: () => resolve(),
+>>>>>>> Stashed changes
       });
       model.locale = "es";
 
+<<<<<<< Updated upstream
       const question = model.getQuestionByName("fruit") as QuestionDropdownModel;
       question.setPropertyValue(DATA_LIST_PROPERTY_NAME, "42");
       question.searchMode = "startsWith";
@@ -90,4 +142,84 @@ describe("bindDataListsToSurvey onChoicesLazyLoad", () => {
       );
     },
   );
+=======
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        formId: "101",
+        dataListId: "42",
+        query: "Manz",
+        matchMode: "StartsWith",
+        locale: "es",
+        includeLocales: ["default", "es", "fr"],
+        skip: 0,
+        take: 25,
+      }),
+    );
+  });
+
+  it("stamps full locale maps on selectedItemValues so locale switches stay labeled", async () => {
+    const model = new Model({
+      pages: [
+        {
+          elements: [
+            {
+              type: "tagbox",
+              name: "cities",
+              choicesLazyLoadEnabled: true,
+              defaultValue: ["728193"],
+            },
+          ],
+        },
+      ],
+    });
+    model.locale = "bg";
+    vi.spyOn(model, "getUsedLocales").mockReturnValue(["bg", "en"]);
+
+    const question = model.getQuestionByName("cities") as QuestionDropdownModel;
+    question.setPropertyValue(DATA_LIST_PROPERTY_NAME, "42");
+
+    bindDataListsToSurvey(model, {
+      deps: {
+        getRuntimeState: () => ({ formId: "101" }),
+      },
+    });
+
+    await new Promise<void>((resolve) => {
+      model.onGetChoiceDisplayValue.fire(model, {
+        question,
+        values: ["728193"],
+        setItems: (items: string[]) => {
+          // Mirror SurveyJS: create selected ItemValues from flat display strings.
+          question.selectedItemValues = items.map((text, index) =>
+            question.createItemValue(["728193"][index], text),
+          );
+          resolve();
+        },
+      });
+    });
+
+    expect(getDisplayValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeLocales: ["default", "bg"],
+        values: ["728193"],
+      }),
+    );
+
+    const selected = question.selectedItemValues as Array<{
+      text: string;
+      locText: { getJson: () => Record<string, string> };
+    }>;
+    expect(selected[0].locText.getJson()).toEqual({
+      default: "Plovdiv",
+      bg: "Пловдив",
+    });
+    expect(selected[0].text).toBe("Пловдив");
+
+    model.locale = "";
+    expect(selected[0].text).toBe("Plovdiv");
+
+    model.locale = "bg";
+    expect(selected[0].text).toBe("Пловдив");
+  });
+>>>>>>> Stashed changes
 });

--- a/lib/survey-features/data-lists/infrastructure/apply-multilingual-choice-display-values.ts
+++ b/lib/survey-features/data-lists/infrastructure/apply-multilingual-choice-display-values.ts
@@ -43,7 +43,15 @@ function stampSelectedItemLocaleMaps(
   labelsByValue: Map<string, Record<string, string>>,
 ): void {
   const selected = (question as SelectBaseQuestion).selectedItemValues;
-  const items = Array.isArray(selected) ? selected : selected ? [selected] : [];
+  let items: Array<{
+    value?: unknown;
+    locText?: { setJson?: (json: unknown) => void };
+  }> = [];
+  if (Array.isArray(selected)) {
+    items = selected;
+  } else if (selected) {
+    items = [selected];
+  }
 
   for (const item of items) {
     if (item?.value == null || typeof item.locText?.setJson !== "function") {

--- a/lib/survey-features/data-lists/infrastructure/apply-multilingual-choice-display-values.ts
+++ b/lib/survey-features/data-lists/infrastructure/apply-multilingual-choice-display-values.ts
@@ -1,0 +1,60 @@
+import type { Question } from "survey-core";
+import { resolvePublicChoiceLabel } from "../use-cases/search-data-lists/map-public-choice";
+
+type SelectBaseQuestion = Question & {
+  selectedItemValues?:
+    | { value?: unknown; locText?: { setJson?: (json: unknown) => void } }
+    | Array<{
+        value?: unknown;
+        locText?: { setJson?: (json: unknown) => void };
+      }>;
+};
+
+/**
+ * Applies multilingual choice labels to SurveyJS selected items.
+ *
+ * `onGetChoiceDisplayValue` only accepts flat strings, which SurveyJS stores
+ * under the *current* locale. After setItems, stamp the full catalog label map
+ * onto `locText` so SurveyJS switches languages natively — same shape as
+ * lazy-load choice `text` maps (`default` + cultures).
+ */
+export function applyMultilingualChoiceDisplayValues(
+  question: Question,
+  values: string[],
+  labelsByValue: Map<string, Record<string, string>>,
+  setItems: (displayValues: string[]) => void,
+  activeLocale?: string,
+): void {
+  const labelsForStamp = new Map<string, Record<string, string>>();
+  const flatLabels: string[] = [];
+
+  for (const value of values) {
+    const labels = labelsByValue.get(value) ?? { default: value };
+    labelsForStamp.set(value, labels);
+    flatLabels.push(resolvePublicChoiceLabel({ value, labels }, activeLocale));
+  }
+
+  setItems(flatLabels);
+  stampSelectedItemLocaleMaps(question, labelsForStamp);
+}
+
+function stampSelectedItemLocaleMaps(
+  question: Question,
+  labelsByValue: Map<string, Record<string, string>>,
+): void {
+  const selected = (question as SelectBaseQuestion).selectedItemValues;
+  const items = Array.isArray(selected) ? selected : selected ? [selected] : [];
+
+  for (const item of items) {
+    if (item?.value == null || typeof item.locText?.setJson !== "function") {
+      continue;
+    }
+
+    const labels = labelsByValue.get(String(item.value));
+    if (!labels) {
+      continue;
+    }
+
+    item.locText.setJson(labels);
+  }
+}

--- a/lib/survey-features/data-lists/infrastructure/apply-multilingual-choice-display-values.ts
+++ b/lib/survey-features/data-lists/infrastructure/apply-multilingual-choice-display-values.ts
@@ -1,4 +1,5 @@
 import type { Question } from "survey-core";
+import { parseScalarString } from "@/lib/utils/type-parsers";
 import { resolvePublicChoiceLabel } from "../use-cases/search-data-lists/map-public-choice";
 
 type SelectBaseQuestion = Question & {
@@ -54,11 +55,12 @@ function stampSelectedItemLocaleMaps(
   }
 
   for (const item of items) {
-    if (item?.value == null || typeof item.locText?.setJson !== "function") {
+    const valueKey = parseScalarString(item?.value);
+    if (valueKey == null || typeof item.locText?.setJson !== "function") {
       continue;
     }
 
-    const labels = labelsByValue.get(String(item.value));
+    const labels = labelsByValue.get(valueKey);
     if (!labels) {
       continue;
     }

--- a/lib/survey-features/data-lists/infrastructure/resolve-survey-locales-for-data-list.ts
+++ b/lib/survey-features/data-lists/infrastructure/resolve-survey-locales-for-data-list.ts
@@ -1,0 +1,69 @@
+import type { Question } from "survey-core";
+import {
+  DEFAULT_CATALOG_LOCALE,
+  fromSurveyModelLocale,
+  isDefaultCatalogLocale,
+  toCatalogLocales,
+} from "@/lib/localization";
+
+export type SurveyLocaleSource = {
+  locale?: string;
+  getUsedLocales?: () => string[];
+};
+
+export type ResolvedSurveyLocalesForDataList = {
+  /**
+   * Active catalog locale for API projection.
+   * `undefined` means use labels.default (survey default language).
+   */
+  locale?: string;
+  /** Catalog locales to request so locale switches need no refetch. */
+  includeLocales: string[];
+};
+
+/**
+ * Resolves the active catalog locale and includeLocales for data-list APIs
+ * from SurveyJS model/question locale state.
+ */
+export function resolveSurveyLocalesForDataList(
+  model: SurveyLocaleSource,
+  question: Pick<Question, "getLocale">,
+): ResolvedSurveyLocalesForDataList {
+  const rawLocale = (question.getLocale() || model.locale || "").trim();
+  const catalogLocale = fromSurveyModelLocale(rawLocale);
+  const locale = isDefaultCatalogLocale(catalogLocale)
+    ? undefined
+    : catalogLocale;
+
+  const usedLocales =
+    typeof model.getUsedLocales === "function" ? model.getUsedLocales() : [];
+
+  const includeLocales = uniqueLocales([
+    DEFAULT_CATALOG_LOCALE,
+    ...toCatalogLocales(usedLocales),
+    ...(locale ? [locale] : []),
+  ]);
+
+  return { locale, includeLocales };
+}
+
+function uniqueLocales(locales: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const locale of locales) {
+    const trimmed = locale.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    const key =
+      trimmed === DEFAULT_CATALOG_LOCALE
+        ? DEFAULT_CATALOG_LOCALE
+        : trimmed.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(key);
+  }
+  return result;
+}

--- a/lib/survey-features/data-lists/infrastructure/survey-bindings.ts
+++ b/lib/survey-features/data-lists/infrastructure/survey-bindings.ts
@@ -16,12 +16,14 @@ import {
 } from "../use-cases/search-data-lists";
 import { resolveDataListDisplayValues } from "../use-cases/resolve-data-list-display-values";
 import { getDataListIdFromQuestion } from "./data-list-survey-integration";
+import { applyMultilingualChoiceDisplayValues } from "./apply-multilingual-choice-display-values";
 import {
   dispatchPropertyGridChoiceDisplayValues,
   dispatchPropertyGridChoicesLazyLoad,
   type PropertyGridLazyChoiceContext,
 } from "./property-grid-lazy-choice-registry";
 import { registerDataListGlobals } from "./registry";
+import { resolveSurveyLocalesForDataList } from "./resolve-survey-locales-for-data-list";
 
 const DATA_LIST_HANDLERS_ATTACHED_KEY = "__endatixDataListHandlersAttached";
 
@@ -109,10 +111,16 @@ export function bindDataListsToSurvey(
       return;
     }
 
+    const { locale, includeLocales } = resolveSurveyLocalesForDataList(
+      model,
+      options.question,
+    );
+
     const response = await searchDataListChoices(deps, dataListId, {
       filter: options.filter,
       searchMode: getQuestionSearchMode(options.question),
-      locale: options.question.getLocale() || undefined,
+      locale,
+      includeLocales,
       skip: options.skip,
       take: options.take,
     });
@@ -124,7 +132,11 @@ export function bindDataListsToSurvey(
       return;
     }
 
-    options.setItems(response.data.items, response.data.total);
+    // SurveyJS accepts nested locale maps on text at runtime; typings only allow string.
+    options.setItems(
+      response.data.items as Array<{ value: string; text?: string }>,
+      response.data.total,
+    );
     notifyChoicesLazyLoadCompleted(
       options.question,
       filter,
@@ -158,10 +170,20 @@ export function bindDataListsToSurvey(
       return;
     }
 
+    const values = options.values.map(String);
+    const { locale, includeLocales } = resolveSurveyLocalesForDataList(
+      model,
+      options.question,
+    );
+
     const response = await resolveDataListDisplayValues(
       deps,
       dataListId,
-      options.values.map(String),
+      values,
+      {
+        locale,
+        includeLocales,
+      },
     );
 
     if (!response.success) {
@@ -170,14 +192,16 @@ export function bindDataListsToSurvey(
         message: response.error.message,
         errorCode: response.error.errorCode,
       });
-      options.setItems(options.values.map(String));
+      options.setItems(values);
       return;
     }
 
-    options.setItems(
-      options.values.map(
-        (value) => response.data.get(String(value)) ?? String(value),
-      ),
+    applyMultilingualChoiceDisplayValues(
+      options.question,
+      values,
+      response.data,
+      options.setItems,
+      locale,
     );
   };
 

--- a/lib/survey-features/data-lists/types.ts
+++ b/lib/survey-features/data-lists/types.ts
@@ -1,7 +1,11 @@
 import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
 import type { Model, SurveyModel } from "survey-core";
 
-export type DataListChoiceItem = { value: string; text: string };
+export type DataListChoiceItem = {
+  value: string;
+  /** Plain string or SurveyJS nested locale map. */
+  text: string | Record<string, string>;
+};
 
 /** SurveyJS dropdown/tagbox searchMode values. */
 export type SurveySearchMode = "contains" | "startsWith";
@@ -12,6 +16,8 @@ export type DataListChoicePageParams = {
   searchMode?: SurveySearchMode;
   /** Survey locale used to select Labels.default vs a catalog key (e.g. es). */
   locale?: string;
+  /** Locales to request for labels projection / multi-key search. */
+  includeLocales?: string[];
   skip: number;
   take: number;
 };

--- a/lib/survey-features/data-lists/use-cases/__tests__/resolve-data-list-display-values.test.ts
+++ b/lib/survey-features/data-lists/use-cases/__tests__/resolve-data-list-display-values.test.ts
@@ -84,4 +84,53 @@ describe("resolveDataListDisplayValues", () => {
       });
     }
   });
+
+  it("re-fetches when cached labels miss a requested locale", async () => {
+    getDisplayValuesMock
+      .mockResolvedValueOnce(
+        ApiResult.success([
+          {
+            value: "728193",
+            labels: { default: "Plovdiv" },
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        ApiResult.success([
+          {
+            value: "728193",
+            labels: { default: "Plovdiv", bg: "Пловдив" },
+          },
+        ]),
+      );
+
+    await resolveDataListDisplayValues(
+      { getRuntimeState: () => ({ formId: "101" }) },
+      "42",
+      ["728193"],
+      { includeLocales: ["default"] },
+    );
+
+    const second = await resolveDataListDisplayValues(
+      { getRuntimeState: () => ({ formId: "101" }) },
+      "42",
+      ["728193"],
+      { includeLocales: ["default", "bg"] },
+    );
+
+    expect(getDisplayValuesMock).toHaveBeenCalledTimes(2);
+    expect(getDisplayValuesMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        includeLocales: ["default", "bg"],
+        values: ["728193"],
+      }),
+    );
+    expect(second.success).toBe(true);
+    if (second.success) {
+      expect(second.data.get("728193")).toEqual({
+        default: "Plovdiv",
+        bg: "Пловдив",
+      });
+    }
+  });
 });

--- a/lib/survey-features/data-lists/use-cases/__tests__/resolve-data-list-display-values.test.ts
+++ b/lib/survey-features/data-lists/use-cases/__tests__/resolve-data-list-display-values.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiResult } from "@/lib/endatix-api/shared/api-result";
+import {
+  clearDataListDisplayValuesCacheForTests,
+  resolveDataListDisplayValues,
+} from "../resolve-data-list-display-values";
+
+const { getDisplayValuesMock } = vi.hoisted(() => ({
+  getDisplayValuesMock: vi.fn(),
+}));
+
+vi.mock("@/lib/endatix-api/public", () => ({
+  createEndatixPublicApi: () => ({
+    dataLists: {
+      getDisplayValues: getDisplayValuesMock,
+    },
+  }),
+}));
+
+vi.mock("@/lib/form-runtime/form-access-jwt-orchestrator", () => ({
+  ensureRuntimeFormAccessJwt: vi.fn().mockResolvedValue("test-form-access-jwt"),
+  invalidateRuntimeFormAccessJwt: vi.fn(),
+}));
+
+describe("resolveDataListDisplayValues", () => {
+  beforeEach(() => {
+    clearDataListDisplayValuesCacheForTests();
+    getDisplayValuesMock.mockReset();
+    getDisplayValuesMock.mockResolvedValue(
+      ApiResult.success([
+        {
+          value: "728193",
+          labels: { default: "Plovdiv", bg: "Пловдив" },
+        },
+      ]),
+    );
+  });
+
+  it("requests includeLocales and returns full label maps", async () => {
+    const result = await resolveDataListDisplayValues(
+      { getRuntimeState: () => ({ formId: "101" }) },
+      "42",
+      ["728193"],
+      { locale: "bg", includeLocales: ["default", "bg"] },
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.get("728193")).toEqual({
+        default: "Plovdiv",
+        bg: "Пловдив",
+      });
+    }
+    expect(getDisplayValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeLocales: ["default", "bg"],
+        locale: "bg",
+        values: ["728193"],
+      }),
+    );
+  });
+
+  it("reuses cached labels without another network call", async () => {
+    await resolveDataListDisplayValues(
+      { getRuntimeState: () => ({ formId: "101" }) },
+      "42",
+      ["728193"],
+      { includeLocales: ["default", "bg"] },
+    );
+
+    const second = await resolveDataListDisplayValues(
+      { getRuntimeState: () => ({ formId: "101" }) },
+      "42",
+      ["728193"],
+      { includeLocales: ["default", "bg"] },
+    );
+
+    expect(getDisplayValuesMock).toHaveBeenCalledTimes(1);
+    expect(second.success).toBe(true);
+    if (second.success) {
+      expect(second.data.get("728193")).toEqual({
+        default: "Plovdiv",
+        bg: "Пловдив",
+      });
+    }
+  });
+});

--- a/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
+++ b/lib/survey-features/data-lists/use-cases/load-choices-in-creator.ts
@@ -1,6 +1,10 @@
 import { normalizeChoiceKey } from "@/lib/utils/survey";
 import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
-import type { DataListSourceRef, PropertyGridChoice } from "../types";
+import type {
+  DataListChoiceItem,
+  DataListSourceRef,
+  PropertyGridChoice,
+} from "../types";
 import { searchDataListChoices } from "./search-data-lists/search-data-list-choices";
 
 type DataListSearchResult = Awaited<ReturnType<typeof searchDataListChoices>>;
@@ -202,7 +206,7 @@ function logDataListSourceError(
 function appendUniqueChoices(
   merged: PropertyGridChoice[],
   seen: Set<string>,
-  items: Array<{ value: string; text: string }>,
+  items: DataListChoiceItem[],
   sourceName: string,
   formatLabel: (sourceName: string, value: string, text: string) => string,
   takeTarget: number,
@@ -218,9 +222,11 @@ function appendUniqueChoices(
     }
 
     seen.add(value);
+    const plainText =
+      typeof item.text === "string" ? item.text : (item.text.default ?? value);
     merged.push({
       value,
-      text: formatLabel(sourceName, value, item.text),
+      text: formatLabel(sourceName, value, plainText),
     });
   }
 }

--- a/lib/survey-features/data-lists/use-cases/resolve-data-list-display-values.ts
+++ b/lib/survey-features/data-lists/use-cases/resolve-data-list-display-values.ts
@@ -1,34 +1,96 @@
 import { createEndatixPublicApi } from "@/lib/endatix-api/public";
+import type { DataListChoiceItem } from "@/lib/endatix-api/public/data-lists/types";
 import { ApiResult } from "@/lib/endatix-api/shared/api-result";
 import { resolveFormRuntimeState } from "@/lib/form-runtime/resolve-form-runtime-state";
 import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
 import { withFormAccessJwtRetry } from "../utils/with-form-access-jwt-retry";
 
+export type ResolveDisplayValuesOptions = {
+  locale?: string;
+  includeLocales?: string[];
+};
+
+const labelsByValueCache = new Map<string, Record<string, string>>();
+
+function cacheKey(formId: string, dataListId: string, value: string): string {
+  return `${formId}|${dataListId}|${value}`;
+}
+
+/** Test-only: clears the display-values labels cache. */
+export function clearDataListDisplayValuesCacheForTests(): void {
+  labelsByValueCache.clear();
+}
+
+/**
+ * Ensures choice labels are cached for the given values and returns the full
+ * locale map per value. SurveyJS {@link LocalizableString} can then switch
+ * locales without another fetch or flattening to a single string.
+ */
 export async function resolveDataListDisplayValues(
   deps: ExtensionRuntimeDeps,
   dataListId: string,
   values: string[],
-): Promise<ApiResult<Map<string, string>>> {
+  options: ResolveDisplayValuesOptions = {},
+): Promise<ApiResult<Map<string, Record<string, string>>>> {
   const runtime = resolveFormRuntimeState(deps.getRuntimeState());
   if (!runtime || values.length === 0) {
     return ApiResult.authError("Form runtime is not available.");
   }
 
-  const api = createEndatixPublicApi().dataLists;
-  const response = await withFormAccessJwtRetry(runtime, (jwt) =>
-    api.getDisplayValues({
-      formId: runtime.formId,
-      dataListId,
-      formAccessJwt: jwt,
-      values,
-    }),
+  const distinctValues = [
+    ...new Set(
+      values.map((value) => String(value)).filter((value) => value.length > 0),
+    ),
+  ];
+
+  const missingValues = distinctValues.filter(
+    (value) =>
+      !labelsByValueCache.has(cacheKey(runtime.formId, dataListId, value)),
   );
 
-  if (!response.success) {
-    return response;
+  if (missingValues.length > 0) {
+    const api = createEndatixPublicApi().dataLists;
+    const response = await withFormAccessJwtRetry(runtime, (jwt) =>
+      api.getDisplayValues({
+        formId: runtime.formId,
+        dataListId,
+        formAccessJwt: jwt,
+        values: missingValues,
+        locale: options.locale,
+        includeLocales: options.includeLocales,
+      }),
+    );
+
+    if (!response.success) {
+      return response;
+    }
+
+    for (const item of response.data) {
+      rememberLabels(runtime.formId, dataListId, item);
+    }
   }
 
   return ApiResult.success(
-    new Map(response.data.map((item) => [item.value, item.label] as const)),
+    new Map(
+      distinctValues.map((value) => {
+        const labels = labelsByValueCache.get(
+          cacheKey(runtime.formId, dataListId, value),
+        );
+        return [value, labels ? { ...labels } : { default: value }] as const;
+      }),
+    ),
+  );
+}
+
+function rememberLabels(
+  formId: string,
+  dataListId: string,
+  item: DataListChoiceItem,
+): void {
+  const key = cacheKey(formId, dataListId, item.value);
+  const existing = labelsByValueCache.get(key);
+  labelsByValueCache.set(
+    key,
+    existing ? { ...existing, ...item.labels } : { ...item.labels },
   );
 }

--- a/lib/survey-features/data-lists/use-cases/resolve-data-list-display-values.ts
+++ b/lib/survey-features/data-lists/use-cases/resolve-data-list-display-values.ts
@@ -39,7 +39,7 @@ export async function resolveDataListDisplayValues(
 
   const distinctValues = [
     ...new Set(
-      values.map((value) => String(value)).filter((value) => value.length > 0),
+      values.map(String).filter((value) => value.length > 0),
     ),
   ];
 

--- a/lib/survey-features/data-lists/use-cases/resolve-data-list-display-values.ts
+++ b/lib/survey-features/data-lists/use-cases/resolve-data-list-display-values.ts
@@ -16,6 +16,23 @@ function cacheKey(formId: string, dataListId: string, value: string): string {
   return `${formId}|${dataListId}|${value}`;
 }
 
+/**
+ * True when cache has no entry, or when any requested includeLocale is absent
+ * from the stored label map (partial coverage must re-fetch and merge).
+ */
+function needsDisplayValuesFetch(
+  labels: Record<string, string> | undefined,
+  includeLocales: string[] | undefined,
+): boolean {
+  if (!labels) {
+    return true;
+  }
+  if (!includeLocales || includeLocales.length === 0) {
+    return false;
+  }
+  return includeLocales.some((locale) => !(locale in labels));
+}
+
 /** Test-only: clears the display-values labels cache. */
 export function clearDataListDisplayValuesCacheForTests(): void {
   labelsByValueCache.clear();
@@ -38,14 +55,14 @@ export async function resolveDataListDisplayValues(
   }
 
   const distinctValues = [
-    ...new Set(
-      values.map(String).filter((value) => value.length > 0),
-    ),
+    ...new Set(values.map(String).filter((value) => value.length > 0)),
   ];
 
-  const missingValues = distinctValues.filter(
-    (value) =>
-      !labelsByValueCache.has(cacheKey(runtime.formId, dataListId, value)),
+  const missingValues = distinctValues.filter((value) =>
+    needsDisplayValuesFetch(
+      labelsByValueCache.get(cacheKey(runtime.formId, dataListId, value)),
+      options.includeLocales,
+    ),
   );
 
   if (missingValues.length > 0) {

--- a/lib/survey-features/data-lists/use-cases/resolve-multi-source-display-values.ts
+++ b/lib/survey-features/data-lists/use-cases/resolve-multi-source-display-values.ts
@@ -7,6 +7,7 @@ import {
   getStaticChoicesFromSources,
 } from "../utils/property-grid-source-choices";
 import { resolveDataListDisplayValues } from "./resolve-data-list-display-values";
+import { resolvePublicChoiceLabel } from "./search-data-lists/map-public-choice";
 
 /**
  * Resolves display labels for values selected from aggregated survey sources
@@ -64,10 +65,16 @@ export async function resolveMultiSourceDisplayValues(
     }
 
     for (const value of unresolved) {
-      const label = response.data.get(value);
-      if (label) {
-        labels.set(value, formatSourceChoiceLabel(sourceName, value, label));
+      const labelsByLocale = response.data.get(value);
+      if (!labelsByLocale) {
+        continue;
       }
+
+      const flatLabel = resolvePublicChoiceLabel({
+        value,
+        labels: labelsByLocale,
+      });
+      labels.set(value, formatSourceChoiceLabel(sourceName, value, flatLabel));
     }
   }
 

--- a/lib/survey-features/data-lists/use-cases/search-data-lists/__tests__/map-public-choice.test.ts
+++ b/lib/survey-features/data-lists/use-cases/search-data-lists/__tests__/map-public-choice.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapPublicChoiceToSurveyItem,
+  resolvePublicChoiceLabel,
+} from "../map-public-choice";
+
+describe("mapPublicChoiceToSurveyItem", () => {
+  it("passes API label maps through unchanged", () => {
+    expect(
+      mapPublicChoiceToSurveyItem({
+        value: "apple",
+        labels: { default: "Apple", bg: "Ябълка" },
+      }),
+    ).toEqual({
+      value: "apple",
+      text: { default: "Apple", bg: "Ябълка" },
+    });
+  });
+});
+
+describe("resolvePublicChoiceLabel", () => {
+  it("prefers requested catalog locale then default", () => {
+    const item = {
+      value: "apple",
+      labels: { default: "Apple", es: "Manzana" },
+    };
+    expect(resolvePublicChoiceLabel(item, "es")).toBe("Manzana");
+    expect(resolvePublicChoiceLabel(item, "fr")).toBe("Apple");
+    expect(resolvePublicChoiceLabel(item)).toBe("Apple");
+  });
+
+  it("treats empty, default, and SurveyJS defaultLocale as labels.default", () => {
+    const item = {
+      value: "728193",
+      labels: { default: "Plovdiv", bg: "Пловдив" },
+    };
+    expect(resolvePublicChoiceLabel(item, "en")).toBe("Plovdiv");
+    expect(resolvePublicChoiceLabel(item, "default")).toBe("Plovdiv");
+    expect(resolvePublicChoiceLabel(item, "")).toBe("Plovdiv");
+    expect(resolvePublicChoiceLabel(item, "bg")).toBe("Пловдив");
+  });
+
+  it("falls back to value when default is missing", () => {
+    expect(resolvePublicChoiceLabel({ value: "apple", labels: {} })).toBe(
+      "apple",
+    );
+  });
+});

--- a/lib/survey-features/data-lists/use-cases/search-data-lists/index.ts
+++ b/lib/survey-features/data-lists/use-cases/search-data-lists/index.ts
@@ -4,3 +4,7 @@ export {
   mapSurveySearchModeToMatchMode,
   type SurveySearchMode,
 } from "./map-survey-search-mode";
+export {
+  mapPublicChoiceToSurveyItem,
+  resolvePublicChoiceLabel,
+} from "./map-public-choice";

--- a/lib/survey-features/data-lists/use-cases/search-data-lists/map-public-choice.ts
+++ b/lib/survey-features/data-lists/use-cases/search-data-lists/map-public-choice.ts
@@ -1,0 +1,38 @@
+import type { DataListChoiceItem as ApiChoiceItem } from "@/lib/endatix-api/public/data-lists/types";
+import {
+  DEFAULT_CATALOG_LOCALE,
+  isDefaultCatalogLocale,
+} from "@/lib/localization";
+import type { DataListChoiceItem } from "../../types";
+
+/**
+ * Maps Endatix public choice (`value` + `labels`) to a SurveyJS lazy-load item.
+ * Passes API label maps through unchanged (`default` + cultures).
+ */
+export function mapPublicChoiceToSurveyItem(
+  item: ApiChoiceItem,
+): DataListChoiceItem {
+  return {
+    value: item.value,
+    text: item.labels,
+  };
+}
+
+/**
+ * Resolves a display string from an API choice for a catalog locale.
+ * Default / empty / SurveyJS defaultLocale code all use `labels.default`.
+ */
+export function resolvePublicChoiceLabel(
+  item: ApiChoiceItem,
+  preferredLocale?: string,
+): string {
+  const labels = item.labels;
+  if (preferredLocale && !isDefaultCatalogLocale(preferredLocale)) {
+    const localized = labels[preferredLocale];
+    if (localized) {
+      return localized;
+    }
+  }
+
+  return labels[DEFAULT_CATALOG_LOCALE] ?? labels.default ?? item.value;
+}

--- a/lib/survey-features/data-lists/use-cases/search-data-lists/search-data-list-choices.ts
+++ b/lib/survey-features/data-lists/use-cases/search-data-lists/search-data-list-choices.ts
@@ -4,6 +4,7 @@ import { resolveFormRuntimeState } from "@/lib/form-runtime/resolve-form-runtime
 import type { ExtensionRuntimeDeps } from "@/lib/survey-extensions/types";
 import type { DataListChoiceItem, DataListChoicePageParams } from "../../types";
 import { withFormAccessJwtRetry } from "../../utils/with-form-access-jwt-retry";
+import { mapPublicChoiceToSurveyItem } from "./map-public-choice";
 import { mapSurveySearchModeToMatchMode } from "./map-survey-search-mode";
 
 export async function searchDataListChoices(
@@ -25,6 +26,7 @@ export async function searchDataListChoices(
       query: params.filter,
       matchMode: mapSurveySearchModeToMatchMode(params.searchMode),
       locale: params.locale,
+      includeLocales: params.includeLocales,
       skip: params.skip,
       take: params.take,
     }),
@@ -35,10 +37,7 @@ export async function searchDataListChoices(
   }
 
   return ApiResult.success({
-    items: response.data.items.map((item) => ({
-      value: item.value,
-      text: item.label,
-    })),
+    items: response.data.items.map(mapPublicChoiceToSurveyItem),
     total: response.data.totalRecords,
   });
 }

--- a/lib/survey-features/data-lists/utils/__tests__/data-list-utils.test.ts
+++ b/lib/survey-features/data-lists/utils/__tests__/data-list-utils.test.ts
@@ -32,8 +32,8 @@ describe("data-list utils", () => {
       expect(r.ok).toBe(true);
       if (r.ok) {
         expect(r.items).toEqual([
-          { label: "a", value: "a" },
-          { label: "b", value: "b" },
+          { value: "a", labels: { default: "a" } },
+          { value: "b", labels: { default: "b" } },
         ]);
       }
     });
@@ -46,8 +46,8 @@ describe("data-list utils", () => {
       expect(r.ok).toBe(true);
       if (r.ok) {
         expect(r.items).toEqual([
-          { label: "One", value: "v1" },
-          { label: "Two", value: "v2" },
+          { value: "v1", labels: { default: "One" } },
+          { value: "v2", labels: { default: "Two" } },
         ]);
       }
     });
@@ -58,15 +58,21 @@ describe("data-list utils", () => {
       ]);
       expect(r.ok).toBe(true);
       if (r.ok) {
-        expect(r.items).toEqual([{ label: "Bulgaria", value: "bg" }]);
+        expect(r.items).toEqual([
+          { value: "bg", labels: { default: "Bulgaria" } },
+        ]);
       }
     });
 
     it("coerces numeric choice values to strings", () => {
-      const r = normalizeChoicesToDataListItems([{ value: 42, text: "Forty-two" }]);
+      const r = normalizeChoicesToDataListItems([
+        { value: 42, text: "Forty-two" },
+      ]);
       expect(r.ok).toBe(true);
       if (r.ok) {
-        expect(r.items).toEqual([{ label: "Forty-two", value: "42" }]);
+        expect(r.items).toEqual([
+          { value: "42", labels: { default: "Forty-two" } },
+        ]);
       }
     });
 
@@ -76,7 +82,9 @@ describe("data-list utils", () => {
       ]);
       expect(r.ok).toBe(true);
       if (r.ok) {
-        expect(r.items).toEqual([{ label: "Bulgaria", value: "bg" }]);
+        expect(r.items).toEqual([
+          { value: "bg", labels: { default: "Bulgaria" } },
+        ]);
       }
     });
 
@@ -86,7 +94,9 @@ describe("data-list utils", () => {
       ]);
       expect(r.ok).toBe(true);
       if (r.ok) {
-        expect(r.items).toEqual([{ label: "Label only", value: "Label only" }]);
+        expect(r.items).toEqual([
+          { value: "Label only", labels: { default: "Label only" } },
+        ]);
       }
     });
 
@@ -237,8 +247,8 @@ describe("data-list utils", () => {
       expect(r.ok).toBe(true);
       if (r.ok) {
         expect(r.items).toEqual([
-          { label: "One", value: "v1" },
-          { label: "Two", value: "v2" },
+          { value: "v1", labels: { default: "One" } },
+          { value: "v2", labels: { default: "Two" } },
         ]);
       }
       m.dispose?.();

--- a/lib/survey-features/data-lists/utils/data-list-items.ts
+++ b/lib/survey-features/data-lists/utils/data-list-items.ts
@@ -116,7 +116,7 @@ export function normalizeChoicesToDataListItems(
       };
     }
     seenValues.add(value);
-    items.push({ value, labels: { default: label } });
+    items.push({ value, label });
   }
 
   return { ok: true, items };

--- a/lib/survey-features/data-lists/utils/data-list-items.ts
+++ b/lib/survey-features/data-lists/utils/data-list-items.ts
@@ -116,7 +116,7 @@ export function normalizeChoicesToDataListItems(
       };
     }
     seenValues.add(value);
-    items.push({ value, label });
+    items.push({ value, labels: { default: label } });
   }
 
   return { ok: true, items };

--- a/lib/survey-features/data-lists/utils/data-list-items.ts
+++ b/lib/survey-features/data-lists/utils/data-list-items.ts
@@ -116,7 +116,7 @@ export function normalizeChoicesToDataListItems(
       };
     }
     seenValues.add(value);
-    items.push({ label, value });
+    items.push({ value, labels: { default: label } });
   }
 
   return { ok: true, items };


### PR DESCRIPTION
# feat(h831): Multilingual support for public data lists API/UI

## Description
- Add support for multilingual data lists on the frontend
- Resolves the correct display value based of language selector
- Passes correct search locales when searching or listing data list items
- Adding public API changes and refactor DataListItem type

## Related Issues
- related to #831 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="571" height="389" alt="image" src="https://github.com/user-attachments/assets/c41e1897-6c71-4368-ba88-980ca376fecb" />
<img width="555" height="394" alt="image" src="https://github.com/user-attachments/assets/8d7338f0-f184-4b21-8ca5-6e7621bef3ba" />


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>