### PR TITLE
feat(h844): Add delete locale dialog for UX confirmation and proper test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,47 @@
 - Preserve API-provided user-facing messages, validation errors, and error codes through the shared result mappers.
 - Use `parseZodError()` or `ServerActionState.fromZodError()` for Zod validation failures in form actions.
 - Do not log expected user/action failures such as validation, authentication, or authorization failures as application errors.
-- Use `TelemetryLogger` for unexpected operational failures. Only log safe scalar attributes; never log tokens, cookies, raw request bodies, field values, or raw API detail strings.
+- Use `TelemetryLogger` for unexpected operational failures. Only log safe scalar attributes (`errorCode`, ids already shown in UI, status/method/endpoint from `mapApiErrorToTelemetryAttributes`); never log tokens, cookies, raw request bodies, field values, or raw API detail/message strings.
+- **Composing actions** (workflows that call other actions returning `Result<T>`): do **not** call `toResult` again. Check `Result.isError`, return/combine user-facing messages, and if you must log the workflow failure use safe scalars only. API telemetry belongs in the leaf action that received `ApiResult`.
+
+### Example: API leaf action (`toResult`)
+
+```typescript
+const result = toResult(await api.dataLists.delete(dataListId), {
+  fallbackMessage: "Failed to delete data list",
+  logMessage: "Failed to delete data list",
+  loggerName: "data-lists",
+});
+
+if (Result.isSuccess(result)) {
+  revalidatePath("/(main)/data-lists");
+}
+
+return result;
+```
+
+### Example: composing action (rollback / multi-step)
+
+```typescript
+const imported = await replaceDataListItemsAction(...);
+if (Result.isError(imported)) {
+  const rollback = await deleteDataListAction(dataListId);
+  if (Result.isError(rollback)) {
+    TelemetryLogger.error(
+      "Failed to roll back data list creation after import failure",
+      undefined,
+      { dataListId, errorCode: rollback.errorCode },
+      "data-lists.createWithImport",
+    );
+    return Result.error(
+      `${imported.message} Cleanup failed (id: ${dataListId}).`,
+      imported.details,
+      imported.errorCode,
+    );
+  }
+}
+return imported;
+```
 
 ## UI Feedback
 
@@ -52,6 +92,7 @@ When the Endatix API exposes a catalog for options, labels, or descriptions (cap
 - Prefer displaying `capability.label` / `format.label` / naming-convention `label` over concatenating Hub-authored strings.
 
 **Status (reporting export):**
+
 - Done: Hub derives create-form options + type labels from `GET /settings/export-capabilities` and column naming from `GET /settings/export-naming-conventions` (`lib/endatix-api/reporting/export-format-types.ts` projects only; no Hub label catalog).
 - Not yet: target group headings still use raw wire enum names; no i18n for API-sourced copy; no codegen of wire unions/labels from .NET into TypeScript.
 

--- a/app/api/data-lists/[dataListId]/export/route.ts
+++ b/app/api/data-lists/[dataListId]/export/route.ts
@@ -3,7 +3,9 @@ import { auth } from "@/auth";
 import { authorization } from "@/features/auth";
 import { EndatixApi } from "@/lib/endatix-api";
 import type { DataListExportFormat } from "@/lib/endatix-api/data-lists/types";
+import { Result } from "@/lib/result";
 import { toUpstreamFileResponse } from "@/lib/utils/route-handlers";
+import { validateEndatixId } from "@/lib/utils/type-validators";
 
 function parseExportFormat(value: string | null): DataListExportFormat {
   return value === "json" ? "json" : "csv";
@@ -13,12 +15,21 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ dataListId: string }> },
 ) {
-  const { dataListId } = await params;
+  const { dataListId: rawDataListId } = await params;
   const session = await auth();
 
   const { requireHubAccess } = await authorization(session);
   await requireHubAccess();
 
+  const dataListIdResult = validateEndatixId(rawDataListId, "dataListId");
+  if (Result.isError(dataListIdResult)) {
+    return new Response(JSON.stringify({ error: dataListIdResult.message }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const dataListId = dataListIdResult.value;
   const format = parseExportFormat(request.nextUrl.searchParams.get("format"));
   const api = new EndatixApi(session?.accessToken);
   const exportResult = await api.dataLists.export(dataListId, format);

--- a/features/data-lists/__tests__/import-payload-guards.test.ts
+++ b/features/data-lists/__tests__/import-payload-guards.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+import { Result } from "@/lib/result";
+import {
+  guardEnsureLocalesCount,
+  guardJsonImportItems,
+  guardTranslationsCsvPayload,
+} from "../import-payload-guards";
+import {
+  DATA_LIST_MAX_ITEMS,
+  DATA_LIST_MAX_LOCALES,
+} from "../translations/locale-discovery";
+import type { DataListChoiceItem } from "@/lib/endatix-api/data-lists/types";
+
+function expectErrorMessage(result: Result<unknown>, fragment: string): void {
+  expect(Result.isError(result)).toBe(true);
+  if (!Result.isError(result)) {
+    return;
+  }
+  expect(result.message).toContain(fragment);
+}
+
+function buildCsv(rowCount: number): string {
+  const rows = Array.from(
+    { length: rowCount },
+    (_, index) => `v${index},Label ${index}`,
+  );
+  return `value,default\r\n${rows.join("\r\n")}\r\n`;
+}
+
+function buildItems(count: number): DataListChoiceItem[] {
+  return Array.from({ length: count }, (_, index) => ({
+    value: `v${index}`,
+    labels: { default: `Label ${index}` },
+  }));
+}
+
+describe("guardTranslationsCsvPayload", () => {
+  it("rejects oversized csv payloads", () => {
+    expectErrorMessage(
+      guardTranslationsCsvPayload("x".repeat(2_000_001)),
+      "2,000,000",
+    );
+  });
+
+  it("rejects csv without data rows", () => {
+    expectErrorMessage(
+      guardTranslationsCsvPayload("value,default\r\n"),
+      "At least one data row",
+    );
+  });
+
+  it("rejects csv that only has blank rows after the header", () => {
+    expectErrorMessage(
+      guardTranslationsCsvPayload("value,default\r\n\r\n   \r\n"),
+      "At least one data row",
+    );
+  });
+
+  it("rejects malformed csv that cannot be parsed", () => {
+    expectErrorMessage(
+      guardTranslationsCsvPayload('value,default\r\n"a","Apple"junk\r\n'),
+      "Unexpected text after a quoted CSV field",
+    );
+  });
+
+  it("rejects csv with more than the max item rows", () => {
+    expectErrorMessage(
+      guardTranslationsCsvPayload(buildCsv(DATA_LIST_MAX_ITEMS + 1)),
+      "5,000",
+    );
+  });
+
+  it("accepts a minimal valid csv", () => {
+    const result = guardTranslationsCsvPayload(
+      "value,default\r\napple,Apple\r\n",
+    );
+
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+
+  it("accepts csv at the max item row count", () => {
+    const result = guardTranslationsCsvPayload(buildCsv(DATA_LIST_MAX_ITEMS));
+
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+
+  it("maps non-Error parse failures to a generic message", async () => {
+    // Arrange
+    vi.resetModules();
+    vi.doMock("../translations/parse-translations-csv", () => ({
+      readCsvRecords: () => {
+        throw "boom";
+      },
+    }));
+
+    const { guardTranslationsCsvPayload: guarded } = await import(
+      "../import-payload-guards"
+    );
+
+    // Act
+    const result = guarded("value,default\r\na,A\r\n");
+
+    // Assert
+    expectErrorMessage(result, "Invalid CSV format.");
+    vi.doUnmock("../translations/parse-translations-csv");
+    vi.resetModules();
+  });
+});
+
+describe("guardJsonImportItems", () => {
+  it("rejects empty json item arrays", () => {
+    expectErrorMessage(guardJsonImportItems([]), "At least one item");
+  });
+
+  it("rejects arrays above the max item count", () => {
+    expectErrorMessage(
+      guardJsonImportItems(buildItems(DATA_LIST_MAX_ITEMS + 1)),
+      "5,000",
+    );
+  });
+
+  it("accepts a single valid item", () => {
+    const result = guardJsonImportItems(buildItems(1));
+
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+
+  it("accepts arrays at the max item count", () => {
+    const result = guardJsonImportItems(buildItems(DATA_LIST_MAX_ITEMS));
+
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+});
+
+describe("guardEnsureLocalesCount", () => {
+  it("rejects ensureLocales that would exceed the catalog cap", () => {
+    const ensure = Array.from(
+      { length: DATA_LIST_MAX_LOCALES },
+      (_, index) => `l${index}`,
+    );
+    expectErrorMessage(
+      guardEnsureLocalesCount(ensure, 1),
+      String(DATA_LIST_MAX_LOCALES),
+    );
+  });
+
+  it("accepts ensureLocales that land exactly on the catalog cap", () => {
+    const ensure = Array.from(
+      { length: 2 },
+      (_, index) => `l${index}`,
+    );
+    const result = guardEnsureLocalesCount(
+      ensure,
+      DATA_LIST_MAX_LOCALES - ensure.length,
+    );
+
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+
+  it("accepts an empty ensureLocales list", () => {
+    const result = guardEnsureLocalesCount([], DATA_LIST_MAX_LOCALES);
+
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+});

--- a/features/data-lists/__tests__/import-payload-guards.test.ts
+++ b/features/data-lists/__tests__/import-payload-guards.test.ts
@@ -7,9 +7,10 @@ import {
   guardTranslationsCsvPayload,
 } from "../import-payload-guards";
 import {
+  DATA_LIST_MAX_CSV_CHARS,
   DATA_LIST_MAX_ITEMS,
   DATA_LIST_MAX_LOCALES,
-} from "../translations/locale-discovery";
+} from "../import-limits";
 import type { DataListChoiceItem } from "@/lib/endatix-api/data-lists/types";
 
 function expectErrorMessage(result: Result<unknown>, fragment: string): void {
@@ -38,8 +39,8 @@ function buildItems(count: number): DataListChoiceItem[] {
 describe("guardTranslationsCsvPayload", () => {
   it("rejects oversized csv payloads", () => {
     expectErrorMessage(
-      guardTranslationsCsvPayload("x".repeat(2_000_001)),
-      "2,000,000",
+      guardTranslationsCsvPayload("x".repeat(DATA_LIST_MAX_CSV_CHARS + 1)),
+      DATA_LIST_MAX_CSV_CHARS.toLocaleString(),
     );
   });
 

--- a/features/data-lists/__tests__/import-payload-guards.test.ts
+++ b/features/data-lists/__tests__/import-payload-guards.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { Result } from "@/lib/result";
 import {
   guardEnsureLocalesCount,
+  guardImportPayload,
   guardJsonImportItems,
   guardTranslationsCsvPayload,
 } from "../import-payload-guards";
@@ -93,9 +94,8 @@ describe("guardTranslationsCsvPayload", () => {
       },
     }));
 
-    const { guardTranslationsCsvPayload: guarded } = await import(
-      "../import-payload-guards"
-    );
+    const { guardTranslationsCsvPayload: guarded } =
+      await import("../import-payload-guards");
 
     // Act
     const result = guarded("value,default\r\na,A\r\n");
@@ -145,10 +145,7 @@ describe("guardEnsureLocalesCount", () => {
   });
 
   it("accepts ensureLocales that land exactly on the catalog cap", () => {
-    const ensure = Array.from(
-      { length: 2 },
-      (_, index) => `l${index}`,
-    );
+    const ensure = Array.from({ length: 2 }, (_, index) => `l${index}`);
     const result = guardEnsureLocalesCount(
       ensure,
       DATA_LIST_MAX_LOCALES - ensure.length,
@@ -159,6 +156,59 @@ describe("guardEnsureLocalesCount", () => {
 
   it("accepts an empty ensureLocales list", () => {
     const result = guardEnsureLocalesCount([], DATA_LIST_MAX_LOCALES);
+
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+});
+
+describe("guardImportPayload", () => {
+  it("rejects csv payloads via the combined entry point", () => {
+    expectErrorMessage(
+      guardImportPayload({
+        format: "csv",
+        csv: "value,default\r\n",
+        ensureLocales: [],
+        catalogLocaleCount: 0,
+      }),
+      "At least one data row",
+    );
+  });
+
+  it("rejects json payloads via the combined entry point", () => {
+    expectErrorMessage(
+      guardImportPayload({
+        format: "json",
+        items: [],
+        ensureLocales: [],
+        catalogLocaleCount: 0,
+      }),
+      "At least one item",
+    );
+  });
+
+  it("rejects ensureLocales before checking payload shape", () => {
+    const ensure = Array.from(
+      { length: DATA_LIST_MAX_LOCALES },
+      (_, index) => `l${index}`,
+    );
+    expectErrorMessage(
+      guardImportPayload({
+        format: "json",
+        items: buildItems(1),
+        ensureLocales: ensure,
+        catalogLocaleCount: 1,
+      }),
+      String(DATA_LIST_MAX_LOCALES),
+    );
+  });
+
+  it("accepts a valid csv payload with room for new locales", () => {
+    const result = guardImportPayload({
+      format: "csv",
+      csv: "value,default\r\napple,Apple\r\n",
+      ensureLocales: ["fr-FR"],
+      catalogLocaleCount: 1,
+    });
 
     expect(Result.isSuccess(result)).toBe(true);
   });

--- a/features/data-lists/__tests__/import-payload-guards.test.ts
+++ b/features/data-lists/__tests__/import-payload-guards.test.ts
@@ -40,7 +40,7 @@ describe("guardTranslationsCsvPayload", () => {
   it("rejects oversized csv payloads", () => {
     expectErrorMessage(
       guardTranslationsCsvPayload("x".repeat(DATA_LIST_MAX_CSV_CHARS + 1)),
-      DATA_LIST_MAX_CSV_CHARS.toLocaleString(),
+      DATA_LIST_MAX_CSV_CHARS.toLocaleString("en-US"),
     );
   });
 
@@ -140,23 +140,51 @@ describe("guardEnsureLocalesCount", () => {
       (_, index) => `l${index}`,
     );
     expectErrorMessage(
-      guardEnsureLocalesCount(ensure, 1),
+      guardEnsureLocalesCount(ensure, ["already-there"]),
       String(DATA_LIST_MAX_LOCALES),
     );
   });
 
   it("accepts ensureLocales that land exactly on the catalog cap", () => {
     const ensure = Array.from({ length: 2 }, (_, index) => `l${index}`);
+    const existing = Array.from(
+      { length: DATA_LIST_MAX_LOCALES - ensure.length },
+      (_, index) => `existing-${index}`,
+    );
+    const result = guardEnsureLocalesCount(ensure, existing);
+
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+
+  it("does not double-count ensureLocales already present in the catalog", () => {
+    const existing = Array.from(
+      { length: DATA_LIST_MAX_LOCALES },
+      (_, index) => `l${index}`,
+    );
     const result = guardEnsureLocalesCount(
-      ensure,
-      DATA_LIST_MAX_LOCALES - ensure.length,
+      [existing[0], existing[1]],
+      existing,
     );
 
     expect(Result.isSuccess(result)).toBe(true);
   });
 
+  it("dedupes ensureLocales before comparing against the catalog cap", () => {
+    const existing = Array.from(
+      { length: DATA_LIST_MAX_LOCALES - 1 },
+      (_, index) => `existing-${index}`,
+    );
+    const result = guardEnsureLocalesCount(["fr", "FR", " fr "], existing);
+
+    expect(Result.isSuccess(result)).toBe(true);
+  });
+
   it("accepts an empty ensureLocales list", () => {
-    const result = guardEnsureLocalesCount([], DATA_LIST_MAX_LOCALES);
+    const existing = Array.from(
+      { length: DATA_LIST_MAX_LOCALES },
+      (_, index) => `l${index}`,
+    );
+    const result = guardEnsureLocalesCount([], existing);
 
     expect(Result.isSuccess(result)).toBe(true);
   });
@@ -169,7 +197,7 @@ describe("guardImportPayload", () => {
         format: "csv",
         csv: "value,default\r\n",
         ensureLocales: [],
-        catalogLocaleCount: 0,
+        existingCatalogLocales: [],
       }),
       "At least one data row",
     );
@@ -181,7 +209,7 @@ describe("guardImportPayload", () => {
         format: "json",
         items: [],
         ensureLocales: [],
-        catalogLocaleCount: 0,
+        existingCatalogLocales: [],
       }),
       "At least one item",
     );
@@ -197,7 +225,7 @@ describe("guardImportPayload", () => {
         format: "json",
         items: buildItems(1),
         ensureLocales: ensure,
-        catalogLocaleCount: 1,
+        existingCatalogLocales: ["already-there"],
       }),
       String(DATA_LIST_MAX_LOCALES),
     );
@@ -208,7 +236,7 @@ describe("guardImportPayload", () => {
       format: "csv",
       csv: "value,default\r\napple,Apple\r\n",
       ensureLocales: ["fr-FR"],
-      catalogLocaleCount: 1,
+      existingCatalogLocales: ["en"],
     });
 
     expect(Result.isSuccess(result)).toBe(true);

--- a/features/data-lists/add-items/__tests__/use-data-list-source.hook.test.ts
+++ b/features/data-lists/add-items/__tests__/use-data-list-source.hook.test.ts
@@ -85,7 +85,25 @@ describe("useDataListSource", () => {
 
     expect(result.current.canConfirm).toBe(false);
     expect(result.current.sourceError).toContain(
-      DATA_LIST_MAX_ITEMS.toLocaleString(),
+      DATA_LIST_MAX_ITEMS.toLocaleString("en-US"),
+    );
+  });
+
+  it("exposes a non-blocking sourceWarning for duplicate locale columns", () => {
+    const { result } = renderHook(() =>
+      useDataListSource({ initialFormat: "csv" }),
+    );
+
+    act(() => {
+      result.current.setCsvInput(
+        "value,default,it,IT\r\napple,Apple,Mela1,Mela2\r\n",
+      );
+    });
+
+    expect(result.current.canConfirm).toBe(true);
+    expect(result.current.sourceError).toBeNull();
+    expect(result.current.sourceWarning).toContain(
+      "Duplicate locale column 'IT'",
     );
   });
 

--- a/features/data-lists/add-items/__tests__/use-data-list-source.hook.test.ts
+++ b/features/data-lists/add-items/__tests__/use-data-list-source.hook.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { useDataListSource } from "../use-data-list-source.hook";
-import { FILE_SIZE_ERROR, MAX_FILE_SIZE_BYTES } from "../../utils";
+import {
+  CSV_FILE_SIZE_ERROR,
+  FILE_SIZE_ERROR,
+  MAX_FILE_SIZE_BYTES,
+} from "../../utils";
+import { DATA_LIST_MAX_CSV_CHARS } from "../../translations/locale-discovery";
 
 describe("useDataListSource", () => {
   it("starts on json and can switch to csv", () => {
@@ -31,10 +36,10 @@ describe("useDataListSource", () => {
     expect(result.current.hasSourceContent).toBe(true);
   });
 
-  it("rejects oversized files", () => {
+  it("rejects oversized json files", () => {
     const { result } = renderHook(() => useDataListSource());
 
-    const largeFile = new File([""], "big.csv", { type: "text/csv" });
+    const largeFile = new File([""], "big.json", { type: "application/json" });
     Object.defineProperty(largeFile, "size", {
       value: MAX_FILE_SIZE_BYTES + 1,
     });
@@ -44,7 +49,52 @@ describe("useDataListSource", () => {
     });
 
     expect(result.current.validationError).toBe(FILE_SIZE_ERROR);
+    expect(result.current.selectedFileName).toBe("big.json");
+  });
+
+  it("rejects csv files above the csv character cap", () => {
+    const { result } = renderHook(() => useDataListSource());
+
+    const largeFile = new File([""], "big.csv", { type: "text/csv" });
+    Object.defineProperty(largeFile, "size", {
+      value: DATA_LIST_MAX_CSV_CHARS + 1,
+    });
+
+    act(() => {
+      void result.current.handleFileSelected(largeFile);
+    });
+
+    expect(result.current.validationError).toBe(CSV_FILE_SIZE_ERROR);
     expect(result.current.selectedFileName).toBe("big.csv");
+  });
+
+  it("exposes sourceError for oversize csv row counts", () => {
+    const { result } = renderHook(() =>
+      useDataListSource({ initialFormat: "csv" }),
+    );
+
+    const rows = Array.from(
+      { length: 5_001 },
+      (_, index) => `v${index},Label ${index}`,
+    ).join("\r\n");
+
+    act(() => {
+      result.current.setCsvInput(`value,default\r\n${rows}\r\n`);
+    });
+
+    expect(result.current.canConfirm).toBe(false);
+    expect(result.current.sourceError).toContain("5,000");
+  });
+
+  it("exposes sourceError for json validation failures", () => {
+    const { result } = renderHook(() => useDataListSource());
+
+    act(() => {
+      result.current.setJsonInput("[]");
+    });
+
+    expect(result.current.canConfirm).toBe(false);
+    expect(result.current.sourceError).toContain("At least one item");
   });
 
   it("infers csv from file extension", async () => {

--- a/features/data-lists/add-items/__tests__/use-data-list-source.hook.test.ts
+++ b/features/data-lists/add-items/__tests__/use-data-list-source.hook.test.ts
@@ -6,7 +6,10 @@ import {
   FILE_SIZE_ERROR,
   MAX_FILE_SIZE_BYTES,
 } from "../../utils";
-import { DATA_LIST_MAX_CSV_CHARS } from "../../translations/locale-discovery";
+import {
+  DATA_LIST_MAX_CSV_CHARS,
+  DATA_LIST_MAX_ITEMS,
+} from "../../import-limits";
 
 describe("useDataListSource", () => {
   it("starts on json and can switch to csv", () => {
@@ -52,16 +55,14 @@ describe("useDataListSource", () => {
     expect(result.current.selectedFileName).toBe("big.json");
   });
 
-  it("rejects csv files above the csv character cap", () => {
+  it("rejects csv files above the csv character cap", async () => {
     const { result } = renderHook(() => useDataListSource());
 
-    const largeFile = new File([""], "big.csv", { type: "text/csv" });
-    Object.defineProperty(largeFile, "size", {
-      value: DATA_LIST_MAX_CSV_CHARS + 1,
-    });
+    const content = "é".repeat(DATA_LIST_MAX_CSV_CHARS + 1);
+    const largeFile = new File([content], "big.csv", { type: "text/csv" });
 
-    act(() => {
-      void result.current.handleFileSelected(largeFile);
+    await act(async () => {
+      await result.current.handleFileSelected(largeFile);
     });
 
     expect(result.current.validationError).toBe(CSV_FILE_SIZE_ERROR);
@@ -74,7 +75,7 @@ describe("useDataListSource", () => {
     );
 
     const rows = Array.from(
-      { length: 5_001 },
+      { length: DATA_LIST_MAX_ITEMS + 1 },
       (_, index) => `v${index},Label ${index}`,
     ).join("\r\n");
 
@@ -83,7 +84,9 @@ describe("useDataListSource", () => {
     });
 
     expect(result.current.canConfirm).toBe(false);
-    expect(result.current.sourceError).toContain("5,000");
+    expect(result.current.sourceError).toContain(
+      DATA_LIST_MAX_ITEMS.toLocaleString(),
+    );
   });
 
   it("exposes sourceError for json validation failures", () => {

--- a/features/data-lists/add-items/__tests__/validation.test.ts
+++ b/features/data-lists/add-items/__tests__/validation.test.ts
@@ -199,6 +199,30 @@ describe("validateJsonInput", () => {
     });
   });
 
+  it("returns error when item count exceeds the catalog limit", () => {
+    const items = Array.from({ length: 5_001 }, (_, index) => ({
+      label: `Item ${index}`,
+      value: `v${index}`,
+    }));
+
+    const result = validateJsonInput(JSON.stringify(items));
+
+    expect(result.validItems).toEqual([]);
+    expect(result.errors[0]).toContain("5,000");
+  });
+
+  it("returns error when item count exceeds the catalog limit", () => {
+    const items = Array.from({ length: 5_001 }, (_, index) => ({
+      label: `Item ${index}`,
+      value: `v${index}`,
+    }));
+
+    const result = validateJsonInput(JSON.stringify(items));
+
+    expect(result.validItems).toEqual([]);
+    expect(result.errors[0]).toContain("5,000");
+  });
+
   it("round-trips culture-coded default label through validation and filter", () => {
     const json = JSON.stringify([
       {

--- a/features/data-lists/add-items/__tests__/validation.test.ts
+++ b/features/data-lists/add-items/__tests__/validation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { DATA_LIST_MAX_ITEMS } from "../../import-limits";
 import { filterJsonItemsByLocales, validateJsonInput } from "../../utils";
 
 describe("validateJsonInput", () => {
@@ -200,27 +201,18 @@ describe("validateJsonInput", () => {
   });
 
   it("returns error when item count exceeds the catalog limit", () => {
-    const items = Array.from({ length: 5_001 }, (_, index) => ({
-      label: `Item ${index}`,
-      value: `v${index}`,
-    }));
+    const items = Array.from(
+      { length: DATA_LIST_MAX_ITEMS + 1 },
+      (_, index) => ({
+        label: `Item ${index}`,
+        value: `v${index}`,
+      }),
+    );
 
     const result = validateJsonInput(JSON.stringify(items));
 
     expect(result.validItems).toEqual([]);
-    expect(result.errors[0]).toContain("5,000");
-  });
-
-  it("returns error when item count exceeds the catalog limit", () => {
-    const items = Array.from({ length: 5_001 }, (_, index) => ({
-      label: `Item ${index}`,
-      value: `v${index}`,
-    }));
-
-    const result = validateJsonInput(JSON.stringify(items));
-
-    expect(result.validItems).toEqual([]);
-    expect(result.errors[0]).toContain("5,000");
+    expect(result.errors[0]).toContain(DATA_LIST_MAX_ITEMS.toLocaleString());
   });
 
   it("round-trips culture-coded default label through validation and filter", () => {

--- a/features/data-lists/add-items/data-list-csv-preview.tsx
+++ b/features/data-lists/add-items/data-list-csv-preview.tsx
@@ -78,6 +78,14 @@ export function DataListCsvPreview({
             Invalid locales: {discovery.invalidLocales.join(", ")}
           </p>
         ) : null}
+
+        {discovery.warnings.length > 0 ? (
+          <ul className="list-disc space-y-1 pl-5 text-amber-700 dark:text-amber-400">
+            {discovery.warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/features/data-lists/add-items/data-list-items-input.tsx
+++ b/features/data-lists/add-items/data-list-items-input.tsx
@@ -3,6 +3,10 @@
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { DataListExportFormat } from "@/lib/endatix-api/data-lists/types";
 import { Download, FileBraces, FileSpreadsheet, FileUp } from "lucide-react";
+import {
+  DATA_LIST_MAX_CSV_CHARS,
+  DATA_LIST_MAX_JSON_FILE_BYTES,
+} from "../translations/locale-discovery";
 
 export type DataListSourceFormat = DataListExportFormat;
 
@@ -34,6 +38,9 @@ export function DataListItemsInput({
   const templateHref = isCsv ? CSV_TEMPLATE_HREF : JSON_TEMPLATE_HREF;
   const accept = isCsv ? ".csv,text/csv" : "application/json,.json";
   const formatLabel = isCsv ? "CSV" : "JSON";
+  const maxSizeHint = isCsv
+    ? `Max size: ${DATA_LIST_MAX_CSV_CHARS.toLocaleString()} characters`
+    : `Max file size: ${DATA_LIST_MAX_JSON_FILE_BYTES / (1024 * 1024)}MB`;
 
   return (
     <div className="space-y-4">
@@ -64,9 +71,7 @@ export function DataListItemsInput({
       >
         <FileUp className="mb-2 h-5 w-5 text-muted-foreground" />
         <span className="text-sm font-medium">Browse {formatLabel} file</span>
-        <span className="text-xs text-muted-foreground">
-          Max file size: 5MB
-        </span>
+        <span className="text-xs text-muted-foreground">{maxSizeHint}</span>
       </label>
 
       <input

--- a/features/data-lists/add-items/use-data-list-source.hook.ts
+++ b/features/data-lists/add-items/use-data-list-source.hook.ts
@@ -42,6 +42,8 @@ export interface UseDataListSourceReturn extends JsonFileHandlerState {
   canConfirm: boolean;
   hasSourceContent: boolean;
   sourceError: string | null;
+  /** Non-blocking CSV discovery notices (e.g. duplicate locale columns). */
+  sourceWarning: string | null;
   activeError: ErrorPointer | null;
   setJsonInput: (value: string) => void;
   setValidationError: (error: string | null) => void;
@@ -76,6 +78,16 @@ function resolveCsvSourceError(
   return null;
 }
 
+function resolveCsvSourceWarning(
+  discovery: LocaleImportDiscovery | null,
+): string | null {
+  if (!discovery || discovery.warnings.length === 0) {
+    return null;
+  }
+
+  return discovery.warnings[0];
+}
+
 function resolveJsonSourceError(
   validation: ParsedValidation | null,
 ): string | null {
@@ -97,6 +109,13 @@ function resolveSourceError(
     case "json":
       return resolveJsonSourceError(validation);
   }
+}
+
+function resolveSourceWarning(
+  format: DataListSourceFormat,
+  discovery: LocaleImportDiscovery | null,
+): string | null {
+  return format === "csv" ? resolveCsvSourceWarning(discovery) : null;
 }
 
 /**
@@ -163,6 +182,11 @@ export function useDataListSource(
   const sourceError = useMemo(
     () => resolveSourceError(format, csvDiscovery, validation),
     [csvDiscovery, format, validation],
+  );
+
+  const sourceWarning = useMemo(
+    () => resolveSourceWarning(format, csvDiscovery),
+    [csvDiscovery, format],
   );
 
   const hasSourceContent = useMemo(() => {
@@ -266,6 +290,7 @@ export function useDataListSource(
     canConfirm,
     hasSourceContent,
     sourceError,
+    sourceWarning,
     validationError,
     selectedFileName,
     activeError,

--- a/features/data-lists/add-items/use-data-list-source.hook.ts
+++ b/features/data-lists/add-items/use-data-list-source.hook.ts
@@ -3,15 +3,17 @@
 import { useCallback, useMemo, useState } from "react";
 import type { JsonFileHandlerState, ParsedValidation } from "../types";
 import {
+  CSV_FILE_SIZE_ERROR,
   FILE_SIZE_ERROR,
   MAX_FILE_SIZE_BYTES,
   READ_ERROR,
   validateJsonInput,
 } from "../utils";
 import { discoverLocalesFromTranslationsCsv } from "../translations/parse-translations-csv";
-import type {
-  LocaleDiscoveryOptions,
-  LocaleImportDiscovery,
+import {
+  DATA_LIST_MAX_CSV_CHARS,
+  type LocaleDiscoveryOptions,
+  type LocaleImportDiscovery,
 } from "../translations/locale-discovery";
 import type { DataListSourceFormat } from "./data-list-items-input";
 
@@ -39,6 +41,7 @@ export interface UseDataListSourceReturn extends JsonFileHandlerState {
   /** True when the active format has a payload ready for locale confirm. */
   canConfirm: boolean;
   hasSourceContent: boolean;
+  sourceError: string | null;
   activeError: ErrorPointer | null;
   setJsonInput: (value: string) => void;
   setValidationError: (error: string | null) => void;
@@ -54,6 +57,47 @@ const initialState: JsonFileHandlerState = {
 };
 
 const EMPTY_AVAILABLE_LOCALES: string[] = [];
+
+function resolveCsvSourceError(
+  discovery: LocaleImportDiscovery | null,
+): string | null {
+  if (!discovery) {
+    return null;
+  }
+
+  if (discovery.structuralErrors.length > 0) {
+    return discovery.structuralErrors[0];
+  }
+
+  if (discovery.invalidLocales.length > 0) {
+    return `Invalid locale columns: ${discovery.invalidLocales.join(", ")}.`;
+  }
+
+  return null;
+}
+
+function resolveJsonSourceError(
+  validation: ParsedValidation | null,
+): string | null {
+  if (!validation || validation.errors.length === 0) {
+    return null;
+  }
+
+  return validation.errors[0];
+}
+
+function resolveSourceError(
+  format: DataListSourceFormat,
+  discovery: LocaleImportDiscovery | null,
+  validation: ParsedValidation | null,
+): string | null {
+  switch (format) {
+    case "csv":
+      return resolveCsvSourceError(discovery);
+    case "json":
+      return resolveJsonSourceError(validation);
+  }
+}
 
 /**
  * Shared Create/Replace source state for JSON and CSV upload.
@@ -116,6 +160,11 @@ export function useDataListSource(
     );
   }, [csvDiscovery, format, validation]);
 
+  const sourceError = useMemo(
+    () => resolveSourceError(format, csvDiscovery, validation),
+    [csvDiscovery, format, validation],
+  );
+
   const hasSourceContent = useMemo(() => {
     if (format === "csv") {
       return csvInput.trim().length > 0;
@@ -159,10 +208,18 @@ export function useDataListSource(
         return;
       }
 
-      if (file.size > maxFileSize) {
+      const lowerName = file.name.toLowerCase();
+      const inferredCsv =
+        lowerName.endsWith(".csv") ||
+        file.type === "text/csv" ||
+        file.type === "application/vnd.ms-excel";
+      const treatAsCsv = inferredCsv || format === "csv";
+      const maxBytes = treatAsCsv ? DATA_LIST_MAX_CSV_CHARS : maxFileSize;
+
+      if (file.size > maxBytes) {
         setJsonInput(initialState.jsonInput);
         setCsvInput("");
-        setValidationError(FILE_SIZE_ERROR);
+        setValidationError(treatAsCsv ? CSV_FILE_SIZE_ERROR : FILE_SIZE_ERROR);
         setSelectedFileName(file.name);
         return;
       }
@@ -173,13 +230,14 @@ export function useDataListSource(
         setValidationError(null);
         setActiveError(null);
 
-        const lowerName = file.name.toLowerCase();
-        const inferredCsv =
-          lowerName.endsWith(".csv") ||
-          file.type === "text/csv" ||
-          file.type === "application/vnd.ms-excel";
+        if (treatAsCsv) {
+          if (content.length > DATA_LIST_MAX_CSV_CHARS) {
+            setCsvInput("");
+            setJsonInput("");
+            setValidationError(CSV_FILE_SIZE_ERROR);
+            return;
+          }
 
-        if (inferredCsv || format === "csv") {
           setFormat("csv");
           setCsvInput(content);
           setJsonInput("");
@@ -206,6 +264,7 @@ export function useDataListSource(
     csvDiscovery,
     canConfirm,
     hasSourceContent,
+    sourceError,
     validationError,
     selectedFileName,
     activeError,

--- a/features/data-lists/add-items/use-data-list-source.hook.ts
+++ b/features/data-lists/add-items/use-data-list-source.hook.ts
@@ -214,7 +214,8 @@ export function useDataListSource(
         file.type === "text/csv" ||
         file.type === "application/vnd.ms-excel";
       const treatAsCsv = inferredCsv || format === "csv";
-      const maxBytes = treatAsCsv ? DATA_LIST_MAX_CSV_CHARS : maxFileSize;
+      // UTF-8 worst-case: 4 bytes per code unit; char cap is enforced after decode.
+      const maxBytes = treatAsCsv ? DATA_LIST_MAX_CSV_CHARS * 4 : maxFileSize;
 
       if (file.size > maxBytes) {
         setJsonInput(initialState.jsonInput);

--- a/features/data-lists/create-list/__tests__/create-data-list-with-import.action.test.ts
+++ b/features/data-lists/create-list/__tests__/create-data-list-with-import.action.test.ts
@@ -273,7 +273,7 @@ describe("createDataListWithImportAction", () => {
     expect(mockDelete).toHaveBeenCalledWith("99");
     expect(mockTelemetryError).toHaveBeenCalledWith(
       "Failed to roll back data list creation after import failure",
-      "delete rejected",
+      expect.any(Error),
       { dataListId: "99" },
       "data-lists.createWithImport",
     );

--- a/features/data-lists/create-list/__tests__/create-data-list-with-import.action.test.ts
+++ b/features/data-lists/create-list/__tests__/create-data-list-with-import.action.test.ts
@@ -29,12 +29,9 @@ vi.mock(
   }),
 );
 
-vi.mock(
-  "@/features/data-lists/translations/translations-csv.action",
-  () => ({
-    uploadTranslationsCsvAction: (...args: unknown[]) => mockUploadCsv(...args),
-  }),
-);
+vi.mock("@/features/data-lists/translations/translations-csv.action", () => ({
+  uploadTranslationsCsvAction: (...args: unknown[]) => mockUploadCsv(...args),
+}));
 
 vi.mock("@/features/data-lists/delete-list/delete-data-list.action", () => ({
   deleteDataListAction: (...args: unknown[]) => mockDelete(...args),
@@ -252,6 +249,31 @@ describe("createDataListWithImportAction", () => {
     expect(mockTelemetryError).toHaveBeenCalledWith(
       "Failed to roll back data list creation after import failure",
       expect.any(Error),
+      { dataListId: "99" },
+      "data-lists.createWithImport",
+    );
+  });
+
+  it("returns the import error and logs when rollback delete returns Result.error", async () => {
+    mockCreate.mockResolvedValue(Result.success(emptyDetails));
+    mockReplace.mockResolvedValue(Result.error("replace failed"));
+    mockDelete.mockResolvedValue(Result.error("delete rejected"));
+
+    const result = await createDataListWithImportAction({
+      name: "Fruits",
+      format: "json",
+      items: validItems,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toBe("replace failed");
+    expect(mockDelete).toHaveBeenCalledWith("99");
+    expect(mockTelemetryError).toHaveBeenCalledWith(
+      "Failed to roll back data list creation after import failure",
+      "delete rejected",
       { dataListId: "99" },
       "data-lists.createWithImport",
     );

--- a/features/data-lists/create-list/__tests__/create-data-list-with-import.action.test.ts
+++ b/features/data-lists/create-list/__tests__/create-data-list-with-import.action.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DataListChoiceItem } from "@/lib/endatix-api/data-lists/types";
+import { Result } from "@/lib/result";
+import { DATA_LIST_MAX_LOCALES } from "@/features/data-lists/import-limits";
+import { createDataListWithImportAction } from "../create-data-list-with-import.action";
+
+const {
+  mockCreate,
+  mockReplace,
+  mockUploadCsv,
+  mockDelete,
+  mockTelemetryError,
+} = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+  mockReplace: vi.fn(),
+  mockUploadCsv: vi.fn(),
+  mockDelete: vi.fn(),
+  mockTelemetryError: vi.fn(),
+}));
+
+vi.mock("@/features/data-lists/create-list/create-data-list.action", () => ({
+  createDataListAction: (...args: unknown[]) => mockCreate(...args),
+}));
+
+vi.mock(
+  "@/features/data-lists/replace-items/replace-data-list-items.action",
+  () => ({
+    replaceDataListItemsAction: (...args: unknown[]) => mockReplace(...args),
+  }),
+);
+
+vi.mock(
+  "@/features/data-lists/translations/translations-csv.action",
+  () => ({
+    uploadTranslationsCsvAction: (...args: unknown[]) => mockUploadCsv(...args),
+  }),
+);
+
+vi.mock("@/features/data-lists/delete-list/delete-data-list.action", () => ({
+  deleteDataListAction: (...args: unknown[]) => mockDelete(...args),
+}));
+
+vi.mock("@/features/telemetry", () => ({
+  TelemetryLogger: {
+    error: (...args: unknown[]) => mockTelemetryError(...args),
+  },
+}));
+
+const emptyDetails = {
+  id: "99",
+  name: "Fruits",
+  isActive: true,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  itemsCount: 0,
+  availableLocales: [],
+  items: [],
+};
+
+const importedDetails = {
+  ...emptyDetails,
+  itemsCount: 1,
+  items: [{ id: "1", value: "apple", labels: { default: "Apple" } }],
+};
+
+const validItems: DataListChoiceItem[] = [
+  { value: "apple", labels: { default: "Apple" } },
+];
+
+const validCsv = "value,default\r\napple,Apple\r\n";
+
+describe("createDataListWithImportAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects invalid csv payloads before creating a list", async () => {
+    const result = await createDataListWithImportAction({
+      name: "Fruits",
+      format: "csv",
+      csv: "value,default\r\n",
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain("At least one data row");
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockUploadCsv).not.toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty json items before creating a list", async () => {
+    const result = await createDataListWithImportAction({
+      name: "Fruits",
+      format: "json",
+      items: [],
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain("At least one item");
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("rejects ensureLocales that would exceed the catalog locale cap", async () => {
+    const ensureLocales = Array.from(
+      { length: DATA_LIST_MAX_LOCALES + 1 },
+      (_, index) => `fr-${index}`,
+    );
+
+    const result = await createDataListWithImportAction({
+      name: "Fruits",
+      format: "json",
+      items: validItems,
+      ensureLocales,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain(String(DATA_LIST_MAX_LOCALES));
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns create failure without calling import or rollback", async () => {
+    mockCreate.mockResolvedValue(Result.error("create failed"));
+
+    const result = await createDataListWithImportAction({
+      name: "Fruits",
+      description: "Seasonal fruit",
+      format: "json",
+      items: validItems,
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      name: "Fruits",
+      description: "Seasonal fruit",
+    });
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toBe("create failed");
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockUploadCsv).not.toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("creates then imports json items and does not roll back on success", async () => {
+    mockCreate.mockResolvedValue(Result.success(emptyDetails));
+    mockReplace.mockResolvedValue(Result.success(importedDetails));
+
+    const result = await createDataListWithImportAction({
+      name: "Fruits",
+      format: "json",
+      items: validItems,
+      ensureLocales: ["fr"],
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("99", validItems, ["fr"]);
+    expect(mockUploadCsv).not.toHaveBeenCalled();
+    expect(Result.isSuccess(result)).toBe(true);
+    if (!Result.isSuccess(result)) {
+      return;
+    }
+    expect(result.value.id).toBe("99");
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("creates then uploads csv and does not roll back on success", async () => {
+    mockCreate.mockResolvedValue(Result.success(emptyDetails));
+    mockUploadCsv.mockResolvedValue(Result.success(importedDetails));
+
+    const result = await createDataListWithImportAction({
+      name: "Fruits",
+      format: "csv",
+      csv: validCsv,
+      ensureLocales: ["de"],
+    });
+
+    expect(mockUploadCsv).toHaveBeenCalledWith({
+      dataListId: "99",
+      csv: validCsv,
+      ensureLocales: ["de"],
+    });
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(Result.isSuccess(result)).toBe(true);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the created list when json import fails", async () => {
+    mockCreate.mockResolvedValue(Result.success(emptyDetails));
+    mockReplace.mockResolvedValue(Result.error("replace failed"));
+    mockDelete.mockResolvedValue(Result.success("99"));
+
+    const result = await createDataListWithImportAction({
+      name: "Fruits",
+      format: "json",
+      items: validItems,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toBe("replace failed");
+    expect(mockDelete).toHaveBeenCalledWith("99");
+    expect(mockTelemetryError).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the created list when csv import fails", async () => {
+    mockCreate.mockResolvedValue(Result.success(emptyDetails));
+    mockUploadCsv.mockResolvedValue(Result.error("csv upload failed"));
+    mockDelete.mockResolvedValue(Result.success("99"));
+
+    const result = await createDataListWithImportAction({
+      name: "Fruits",
+      format: "csv",
+      csv: validCsv,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toBe("csv upload failed");
+    expect(mockDelete).toHaveBeenCalledWith("99");
+  });
+
+  it("returns the import error even when rollback delete throws", async () => {
+    mockCreate.mockResolvedValue(Result.success(emptyDetails));
+    mockReplace.mockResolvedValue(Result.error("replace failed"));
+    mockDelete.mockRejectedValue(new Error("delete boom"));
+
+    const result = await createDataListWithImportAction({
+      name: "Fruits",
+      format: "json",
+      items: validItems,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toBe("replace failed");
+    expect(mockDelete).toHaveBeenCalledWith("99");
+    expect(mockTelemetryError).toHaveBeenCalledWith(
+      "Failed to roll back data list creation after import failure",
+      expect.any(Error),
+      { dataListId: "99" },
+      "data-lists.createWithImport",
+    );
+  });
+});

--- a/features/data-lists/create-list/__tests__/create-data-list-with-import.action.test.ts
+++ b/features/data-lists/create-list/__tests__/create-data-list-with-import.action.test.ts
@@ -244,7 +244,9 @@ describe("createDataListWithImportAction", () => {
     if (!Result.isError(result)) {
       return;
     }
-    expect(result.message).toBe("replace failed");
+    expect(result.message).toContain("replace failed");
+    expect(result.message).toContain("could not be removed automatically");
+    expect(result.message).toContain("id: 99");
     expect(mockDelete).toHaveBeenCalledWith("99");
     expect(mockTelemetryError).toHaveBeenCalledWith(
       "Failed to roll back data list creation after import failure",
@@ -257,7 +259,9 @@ describe("createDataListWithImportAction", () => {
   it("returns the import error and logs when rollback delete returns Result.error", async () => {
     mockCreate.mockResolvedValue(Result.success(emptyDetails));
     mockReplace.mockResolvedValue(Result.error("replace failed"));
-    mockDelete.mockResolvedValue(Result.error("delete rejected"));
+    mockDelete.mockResolvedValue(
+      Result.error("delete rejected", undefined, "DELETE_FAILED"),
+    );
 
     const result = await createDataListWithImportAction({
       name: "Fruits",
@@ -269,12 +273,14 @@ describe("createDataListWithImportAction", () => {
     if (!Result.isError(result)) {
       return;
     }
-    expect(result.message).toBe("replace failed");
+    expect(result.message).toContain("replace failed");
+    expect(result.message).toContain("could not be removed automatically");
+    expect(result.message).toContain("id: 99");
     expect(mockDelete).toHaveBeenCalledWith("99");
     expect(mockTelemetryError).toHaveBeenCalledWith(
       "Failed to roll back data list creation after import failure",
-      expect.any(Error),
-      { dataListId: "99" },
+      undefined,
+      { dataListId: "99", errorCode: "DELETE_FAILED" },
       "data-lists.createWithImport",
     );
   });

--- a/features/data-lists/create-list/create-data-list-with-import.action.ts
+++ b/features/data-lists/create-list/create-data-list-with-import.action.ts
@@ -27,7 +27,15 @@ export type CreateDataListWithImportInput = {
 
 async function rollBackCreatedList(dataListId: string): Promise<void> {
   try {
-    await deleteDataListAction(dataListId);
+    const deleted = await deleteDataListAction(dataListId);
+    if (Result.isError(deleted)) {
+      TelemetryLogger.error(
+        "Failed to roll back data list creation after import failure",
+        deleted.message,
+        { dataListId },
+        LOGGER_NAME,
+      );
+    }
   } catch (error) {
     TelemetryLogger.error(
       "Failed to roll back data list creation after import failure",
@@ -92,7 +100,6 @@ export async function createDataListWithImportAction(
 
   if (Result.isError(imported)) {
     await rollBackCreatedList(dataListId);
-    return imported;
   }
 
   return imported;

--- a/features/data-lists/create-list/create-data-list-with-import.action.ts
+++ b/features/data-lists/create-list/create-data-list-with-import.action.ts
@@ -31,7 +31,7 @@ async function rollBackCreatedList(dataListId: string): Promise<void> {
     if (Result.isError(deleted)) {
       TelemetryLogger.error(
         "Failed to roll back data list creation after import failure",
-        deleted.message,
+        new Error("deleteDataListAction returned an error result"),
         { dataListId },
         LOGGER_NAME,
       );

--- a/features/data-lists/create-list/create-data-list-with-import.action.ts
+++ b/features/data-lists/create-list/create-data-list-with-import.action.ts
@@ -1,0 +1,99 @@
+"use server";
+
+import { deleteDataListAction } from "@/features/data-lists/delete-list/delete-data-list.action";
+import { replaceDataListItemsAction } from "@/features/data-lists/replace-items/replace-data-list-items.action";
+import { uploadTranslationsCsvAction } from "@/features/data-lists/translations/translations-csv.action";
+import { guardImportPayload } from "@/features/data-lists/import-payload-guards";
+import { TelemetryLogger } from "@/features/telemetry";
+import type {
+  DataListChoiceItem,
+  DataListDetails,
+} from "@/lib/endatix-api/data-lists/types";
+import { Result } from "@/lib/result";
+import { createDataListAction } from "./create-data-list.action";
+
+const LOGGER_NAME = "data-lists.createWithImport";
+
+export type CreateDataListWithImportResult = Result<DataListDetails>;
+
+export type CreateDataListWithImportInput = {
+  name: string;
+  description?: string;
+  ensureLocales?: string[];
+} & (
+  | { format: "csv"; csv: string; items?: never }
+  | { format: "json"; items: DataListChoiceItem[]; csv?: never }
+);
+
+async function rollBackCreatedList(dataListId: string): Promise<void> {
+  try {
+    await deleteDataListAction(dataListId);
+  } catch (error) {
+    TelemetryLogger.error(
+      "Failed to roll back data list creation after import failure",
+      error,
+      { dataListId },
+      LOGGER_NAME,
+    );
+  }
+}
+
+/**
+ * Creates a data list and imports items in one Hub workflow.
+ * Rolls back (deletes) the list if import fails so callers never leave empty orphans.
+ */
+export async function createDataListWithImportAction(
+  input: CreateDataListWithImportInput,
+): Promise<CreateDataListWithImportResult> {
+  const ensureLocales = input.ensureLocales ?? [];
+
+  const payloadGuard = guardImportPayload(
+    input.format === "csv"
+      ? {
+          format: "csv",
+          csv: input.csv,
+          ensureLocales,
+          catalogLocaleCount: 0,
+        }
+      : {
+          format: "json",
+          items: input.items,
+          ensureLocales,
+          catalogLocaleCount: 0,
+        },
+  );
+  if (Result.isError(payloadGuard)) {
+    return payloadGuard;
+  }
+
+  const created = await createDataListAction({
+    name: input.name,
+    description: input.description,
+  });
+
+  if (Result.isError(created)) {
+    return created;
+  }
+
+  const dataListId = String(created.value.id);
+
+  const imported =
+    input.format === "csv"
+      ? await uploadTranslationsCsvAction({
+          dataListId,
+          csv: input.csv,
+          ensureLocales,
+        })
+      : await replaceDataListItemsAction(
+          dataListId,
+          input.items,
+          ensureLocales,
+        );
+
+  if (Result.isError(imported)) {
+    await rollBackCreatedList(dataListId);
+    return imported;
+  }
+
+  return imported;
+}

--- a/features/data-lists/create-list/create-data-list-with-import.action.ts
+++ b/features/data-lists/create-list/create-data-list-with-import.action.ts
@@ -4,6 +4,7 @@ import { deleteDataListAction } from "@/features/data-lists/delete-list/delete-d
 import { replaceDataListItemsAction } from "@/features/data-lists/replace-items/replace-data-list-items.action";
 import { uploadTranslationsCsvAction } from "@/features/data-lists/translations/translations-csv.action";
 import { guardImportPayload } from "@/features/data-lists/import-payload-guards";
+import { IMPORT_ROLLBACK_FAILED_SUFFIX } from "@/features/data-lists/import-validation-messages";
 import { TelemetryLogger } from "@/features/telemetry";
 import type {
   DataListChoiceItem,
@@ -25,17 +26,28 @@ export type CreateDataListWithImportInput = {
   | { format: "json"; items: DataListChoiceItem[]; csv?: never }
 );
 
-async function rollBackCreatedList(dataListId: string): Promise<void> {
+/**
+ * Compensating delete after a failed import. Child actions already map
+ * `ApiResult` via `toResult` (including API telemetry). This layer only logs
+ * the workflow failure with safe scalars and returns a Result for the caller.
+ */
+async function rollBackCreatedList(dataListId: string): Promise<Result<void>> {
   try {
     const deleted = await deleteDataListAction(dataListId);
     if (Result.isError(deleted)) {
       TelemetryLogger.error(
         "Failed to roll back data list creation after import failure",
-        new Error("deleteDataListAction returned an error result"),
-        { dataListId },
+        undefined,
+        {
+          dataListId,
+          errorCode: deleted.errorCode,
+        },
         LOGGER_NAME,
       );
+      return Result.error(deleted.message, deleted.details, deleted.errorCode);
     }
+
+    return Result.success(undefined);
   } catch (error) {
     TelemetryLogger.error(
       "Failed to roll back data list creation after import failure",
@@ -43,7 +55,21 @@ async function rollBackCreatedList(dataListId: string): Promise<void> {
       { dataListId },
       LOGGER_NAME,
     );
+    return Result.error("Failed to delete the newly created data list.");
   }
+}
+
+function importErrorWithFailedRollback(
+  importMessage: string,
+  dataListId: string,
+  details?: string,
+  errorCode?: string,
+): Result<DataListDetails> {
+  return Result.error(
+    `${importMessage} ${IMPORT_ROLLBACK_FAILED_SUFFIX} (id: ${dataListId}).`,
+    details,
+    errorCode,
+  );
 }
 
 /**
@@ -61,13 +87,13 @@ export async function createDataListWithImportAction(
           format: "csv",
           csv: input.csv,
           ensureLocales,
-          catalogLocaleCount: 0,
+          existingCatalogLocales: [],
         }
       : {
           format: "json",
           items: input.items,
           ensureLocales,
-          catalogLocaleCount: 0,
+          existingCatalogLocales: [],
         },
   );
   if (Result.isError(payloadGuard)) {
@@ -99,7 +125,15 @@ export async function createDataListWithImportAction(
         );
 
   if (Result.isError(imported)) {
-    await rollBackCreatedList(dataListId);
+    const rollback = await rollBackCreatedList(dataListId);
+    if (Result.isError(rollback)) {
+      return importErrorWithFailedRollback(
+        imported.message,
+        dataListId,
+        imported.details,
+        imported.errorCode,
+      );
+    }
   }
 
   return imported;

--- a/features/data-lists/create-list/create-data-list.action.ts
+++ b/features/data-lists/create-list/create-data-list.action.ts
@@ -6,7 +6,7 @@ import { EndatixApi } from "@/lib/endatix-api";
 import type { DataListDetails } from "@/lib/endatix-api/data-lists/types";
 import { DATA_LIST_NAME_MAX_LENGTH } from "@/lib/survey-features/data-lists/constants";
 import { Result } from "@/lib/result";
-import { mapApiErrorToResult } from "@/lib/result/map-api-error-to-result";
+import { toResult } from "@/lib/result/map-api-result-to-result";
 
 export type CreateDataListResult = Result<DataListDetails>;
 
@@ -30,17 +30,16 @@ export async function createDataListAction(
   }
 
   const api = new EndatixApi(session?.accessToken);
-  const result = await api.dataLists.create({
-    ...input,
-    name: normalizedName,
-  });
-
-  if (!result.success) {
-    return mapApiErrorToResult(result, {
+  return toResult(
+    await api.dataLists.create({
+      ...input,
+      name: normalizedName,
+    }),
+    {
       fallbackMessage: "Failed to create data list",
       preferredFields: ["name"],
-    });
-  }
-
-  return Result.success(result.data);
+      logMessage: "Failed to create data list",
+      loggerName: "data-lists.create",
+    },
+  );
 }

--- a/features/data-lists/create-list/ui/create-data-list-dialog.tsx
+++ b/features/data-lists/create-list/ui/create-data-list-dialog.tsx
@@ -141,6 +141,7 @@ interface CreateDataListDialogBodyProps {
   csvDiscovery: LocaleImportDiscovery | null;
   pendingDiscovery: LocaleImportDiscovery | null;
   displayError: string | null;
+  displayWarning: string | null;
   selectedFileName: string | null;
   isPending: boolean;
   setName: (value: string) => void;
@@ -163,6 +164,7 @@ function CreateDataListDialogBody(
     csvDiscovery,
     pendingDiscovery,
     displayError,
+    displayWarning,
     selectedFileName,
     isPending,
     setName,
@@ -200,6 +202,12 @@ function CreateDataListDialogBody(
         {displayError ? (
           <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
             {displayError}
+          </div>
+        ) : null}
+
+        {!displayError && displayWarning ? (
+          <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-sm text-amber-800 dark:text-amber-300">
+            {displayWarning}
           </div>
         ) : null}
       </>
@@ -327,6 +335,7 @@ export function CreateDataListDialog({
     canConfirm,
     hasSourceContent,
     sourceError,
+    sourceWarning,
     validationError: fileValidationError,
     selectedFileName,
     setValidationError,
@@ -335,6 +344,7 @@ export function CreateDataListDialog({
   } = useDataListSource();
 
   const displayError = fileValidationError ?? sourceError;
+  const displayWarning = displayError ? null : sourceWarning;
   useEffect(() => {
     if (!open) {
       setStep(1);
@@ -446,6 +456,7 @@ export function CreateDataListDialog({
             csvDiscovery={csvDiscovery}
             pendingDiscovery={pendingDiscovery}
             displayError={displayError}
+            displayWarning={displayWarning}
             selectedFileName={selectedFileName}
             isPending={isPending}
             setName={setName}

--- a/features/data-lists/create-list/ui/create-data-list-dialog.tsx
+++ b/features/data-lists/create-list/ui/create-data-list-dialog.tsx
@@ -14,9 +14,22 @@ import { toast } from "@/components/ui/toast";
 import type { DataListDetails } from "@/lib/endatix-api/data-lists/types";
 import { Result } from "@/lib/result";
 import { Upload } from "lucide-react";
-import { useEffect, useMemo, useRef, useState, useTransition } from "react";
-import { createDataListWithImportAction } from "../create-data-list-with-import.action";
-import { DataListItemsInput } from "../../add-items/data-list-items-input";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type ReactNode,
+} from "react";
+import {
+  createDataListWithImportAction,
+  type CreateDataListWithImportInput,
+} from "../create-data-list-with-import.action";
+import {
+  DataListItemsInput,
+  type DataListSourceFormat,
+} from "../../add-items/data-list-items-input";
 import { DataListValidationPreview } from "../../add-items/data-list-validation-preview";
 import { DataListCsvPreview } from "../../add-items/data-list-csv-preview";
 import { useDataListSource } from "../../add-items/use-data-list-source.hook";
@@ -30,6 +43,7 @@ import type {
   LocaleImportDiscovery,
   LocaleImportSelection,
 } from "../../translations/locale-discovery";
+import type { ParsedValidation } from "../../types";
 
 interface CreateDataListDialogProps {
   open: boolean;
@@ -38,6 +52,246 @@ interface CreateDataListDialogProps {
 }
 
 type CreateStep = 1 | 2 | 3;
+
+const CREATE_STEP_DESCRIPTION: Record<CreateStep, string> = {
+  1: "Define your new curated dataset and upload CSV or JSON.",
+  2: "Review validation before creating the list.",
+  3: "Choose which locales to import.",
+};
+
+function reportCreateImportResult(
+  importResult: Result<DataListDetails>,
+  onCreated: ((details: DataListDetails) => void) | undefined,
+  onOpenChange: (open: boolean) => void,
+): void {
+  if (Result.isError(importResult)) {
+    toast.error(importResult.message || "Failed to create data list");
+    return;
+  }
+
+  onCreated?.(importResult.value);
+  toast.success("Data list created successfully");
+  onOpenChange(false);
+}
+
+function buildCreateImportInput(args: {
+  format: DataListSourceFormat;
+  name: string;
+  description: string;
+  csvInput: string;
+  validation: ParsedValidation | null;
+  selection: LocaleImportSelection;
+}): CreateDataListWithImportInput | null {
+  const { format, name, description, csvInput, validation, selection } = args;
+  const trimmedName = name.trim();
+  const trimmedDescription = description.trim();
+
+  if (format === "csv") {
+    return {
+      name: trimmedName,
+      description: trimmedDescription,
+      format: "csv",
+      csv: filterTranslationsCsv(csvInput, selection.includedLocales),
+      ensureLocales: selection.ensureLocales,
+    };
+  }
+
+  if (!validation) {
+    return null;
+  }
+
+  return {
+    name: trimmedName,
+    description: trimmedDescription,
+    format: "json",
+    items: filterJsonItemsByLocales(
+      validation.validItems,
+      selection.includedLocales,
+    ),
+    ensureLocales: selection.ensureLocales,
+  };
+}
+
+function resolvePendingDiscovery(args: {
+  format: DataListSourceFormat;
+  validation: ParsedValidation | null;
+  csvDiscovery: LocaleImportDiscovery | null;
+}): LocaleImportDiscovery | null {
+  const { format, validation, csvDiscovery } = args;
+
+  if (format === "json" && validation) {
+    return discoverLocalesFromJsonItems(validation.validItems, {
+      availableLocales: [],
+    });
+  }
+
+  if (format === "csv" && csvDiscovery) {
+    return csvDiscovery;
+  }
+
+  return null;
+}
+
+function CreateDataListDialogBody(props: {
+  step: CreateStep;
+  name: string;
+  description: string;
+  format: DataListSourceFormat;
+  validation: ParsedValidation | null;
+  csvDiscovery: LocaleImportDiscovery | null;
+  pendingDiscovery: LocaleImportDiscovery | null;
+  displayError: string | null;
+  selectedFileName: string | null;
+  isPending: boolean;
+  setName: (value: string) => void;
+  setDescription: (value: string) => void;
+  setFormat: (format: DataListSourceFormat) => void;
+  onFileSelected: (file: File | null) => Promise<void>;
+  setStep: (step: CreateStep) => void;
+  onConfirmCreate: (selection: LocaleImportSelection) => void;
+}): ReactNode {
+  const {
+    step,
+    name,
+    description,
+    format,
+    validation,
+    csvDiscovery,
+    pendingDiscovery,
+    displayError,
+    selectedFileName,
+    isPending,
+    setName,
+    setDescription,
+    setFormat,
+    onFileSelected,
+    setStep,
+    onConfirmCreate,
+  } = props;
+
+  if (step === 1) {
+    return (
+      <>
+        <div className="space-y-4">
+          <Input
+            placeholder="Friendly Name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+          <Input
+            placeholder="Description (optional)"
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+          />
+        </div>
+
+        <DataListItemsInput
+          format={format}
+          onFormatChange={setFormat}
+          onFileSelected={onFileSelected}
+          selectedFileName={selectedFileName}
+          fileInputId="create-data-list-file-upload"
+        />
+
+        {displayError ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+            {displayError}
+          </div>
+        ) : null}
+      </>
+    );
+  }
+
+  if (step === 2 && format === "json" && validation) {
+    return (
+      <DataListValidationPreview
+        validation={validation}
+        name={name}
+        description={description}
+      />
+    );
+  }
+
+  if (step === 2 && format === "csv" && csvDiscovery) {
+    return (
+      <DataListCsvPreview
+        discovery={csvDiscovery}
+        name={name}
+        description={description}
+      />
+    );
+  }
+
+  if (step === 3) {
+    return (
+      <LocaleImportConfirmPanel
+        title="Confirm locales for new list"
+        mode="create"
+        discovery={pendingDiscovery}
+        catalogLocaleCount={0}
+        isPending={isPending}
+        onCancel={() => setStep(2)}
+        onConfirm={onConfirmCreate}
+      />
+    );
+  }
+
+  return null;
+}
+
+function CreateDataListDialogFooter(props: {
+  step: CreateStep;
+  name: string;
+  hasSourceContent: boolean;
+  canConfirm: boolean;
+  onOpenChange: (open: boolean) => void;
+  onContinue: () => void;
+  onReviewLocales: () => void;
+  setStep: (step: CreateStep) => void;
+}): ReactNode {
+  const {
+    step,
+    name,
+    hasSourceContent,
+    canConfirm,
+    onOpenChange,
+    onContinue,
+    onReviewLocales,
+    setStep,
+  } = props;
+
+  if (step === 3) {
+    return null;
+  }
+
+  return (
+    <DialogFooter className="border-t px-6 py-4">
+      {step === 2 ? (
+        <Button variant="outline" onClick={() => setStep(1)}>
+          Back
+        </Button>
+      ) : (
+        <Button variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+      )}
+
+      {step === 1 ? (
+        <Button
+          onClick={onContinue}
+          disabled={name.trim().length === 0 || !hasSourceContent}
+        >
+          Continue
+        </Button>
+      ) : (
+        <Button onClick={onReviewLocales} disabled={!canConfirm}>
+          <Upload className="h-4 w-4" />
+          Review locales
+        </Button>
+      )}
+    </DialogFooter>
+  );
+}
 
 /**
  * Create a new data list from CSV or JSON upload.
@@ -96,20 +350,11 @@ export function CreateDataListDialog({
   };
 
   useEffect(() => {
-    if (!advanceAfterUploadRef.current || step !== 1) {
+    if (!advanceAfterUploadRef.current || step !== 1 || !hasSourceContent) {
       return;
     }
 
-    if (!hasSourceContent) {
-      return;
-    }
-
-    if (!canConfirm) {
-      advanceAfterUploadRef.current = false;
-      return;
-    }
-
-    if (name.trim().length === 0) {
+    if (!canConfirm || name.trim().length === 0) {
       advanceAfterUploadRef.current = false;
       return;
     }
@@ -121,10 +366,10 @@ export function CreateDataListDialog({
 
   const handleContinue = () => {
     if (!canProceedToReview) {
-      let fallbackError = "Please provide valid JSON items.";
-      if (format === "csv") {
-        fallbackError = "Please provide a valid translations CSV.";
-      }
+      const fallbackError =
+        format === "csv"
+          ? "Please provide a valid translations CSV."
+          : "Please provide valid JSON items.";
       setValidationError(sourceError ?? fallbackError);
       return;
     }
@@ -138,20 +383,17 @@ export function CreateDataListDialog({
       return;
     }
 
-    if (format === "json" && validation) {
-      setPendingDiscovery(
-        discoverLocalesFromJsonItems(validation.validItems, {
-          availableLocales: [],
-        }),
-      );
-      setStep(3);
+    const discovery = resolvePendingDiscovery({
+      format,
+      validation,
+      csvDiscovery,
+    });
+    if (!discovery) {
       return;
     }
 
-    if (format === "csv" && csvDiscovery) {
-      setPendingDiscovery(csvDiscovery);
-      setStep(3);
-    }
+    setPendingDiscovery(discovery);
+    setStep(3);
   };
 
   const handleConfirmCreate = (selection: LocaleImportSelection): void => {
@@ -159,158 +401,66 @@ export function CreateDataListDialog({
       return;
     }
 
-    if (format === "csv") {
-      startTransition(async () => {
-        const importResult = await createDataListWithImportAction({
-          name: name.trim(),
-          description: description.trim(),
-          format: "csv",
-          csv: filterTranslationsCsv(csvInput, selection.includedLocales),
-          ensureLocales: selection.ensureLocales,
-        });
-
-        if (Result.isError(importResult)) {
-          toast.error(importResult.message || "Failed to create data list");
-          return;
-        }
-
-        onCreated?.(importResult.value);
-        toast.success("Data list created successfully");
-        onOpenChange(false);
-      });
-      return;
-    }
-
-    if (!validation) {
+    const input = buildCreateImportInput({
+      format,
+      name,
+      description,
+      csvInput,
+      validation,
+      selection,
+    });
+    if (!input) {
       toast.error("JSON validation is missing. Please re-upload the file.");
       return;
     }
 
-    const jsonItems = validation.validItems;
     startTransition(async () => {
-      const importResult = await createDataListWithImportAction({
-        name: name.trim(),
-        description: description.trim(),
-        format: "json",
-        items: filterJsonItemsByLocales(jsonItems, selection.includedLocales),
-        ensureLocales: selection.ensureLocales,
-      });
-
-      if (Result.isError(importResult)) {
-        toast.error(importResult.message || "Failed to create data list");
-        return;
-      }
-
-      onCreated?.(importResult.value);
-      toast.success("Data list created successfully");
-      onOpenChange(false);
+      const importResult = await createDataListWithImportAction(input);
+      reportCreateImportResult(importResult, onCreated, onOpenChange);
     });
   };
-
-  let stepDescription =
-    "Define your new curated dataset and upload CSV or JSON.";
-  if (step === 2) {
-    stepDescription = "Review validation before creating the list.";
-  } else if (step === 3) {
-    stepDescription = "Choose which locales to import.";
-  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col overflow-hidden p-0">
         <DialogHeader className="border-b px-6 py-4">
           <DialogTitle>Create Data List</DialogTitle>
-          <DialogDescription>{stepDescription}</DialogDescription>
+          <DialogDescription>
+            {CREATE_STEP_DESCRIPTION[step]}
+          </DialogDescription>
         </DialogHeader>
 
         <div className="flex-1 space-y-6 overflow-y-auto px-6 py-4">
-          {step === 1 ? (
-            <>
-              <div className="space-y-4">
-                <Input
-                  placeholder="Friendly Name"
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                />
-                <Input
-                  placeholder="Description (optional)"
-                  value={description}
-                  onChange={(event) => setDescription(event.target.value)}
-                />
-              </div>
-
-              <DataListItemsInput
-                format={format}
-                onFormatChange={setFormat}
-                onFileSelected={handleFileSelectedWithAdvance}
-                selectedFileName={selectedFileName}
-                fileInputId="create-data-list-file-upload"
-              />
-
-              {displayError ? (
-                <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-                  {displayError}
-                </div>
-              ) : null}
-            </>
-          ) : null}
-
-          {step === 2 && format === "json" && validation ? (
-            <DataListValidationPreview
-              validation={validation}
-              name={name}
-              description={description}
-            />
-          ) : null}
-
-          {step === 2 && format === "csv" && csvDiscovery ? (
-            <DataListCsvPreview
-              discovery={csvDiscovery}
-              name={name}
-              description={description}
-            />
-          ) : null}
-
-          {step === 3 ? (
-            <LocaleImportConfirmPanel
-              title="Confirm locales for new list"
-              mode="create"
-              discovery={pendingDiscovery}
-              catalogLocaleCount={0}
-              isPending={isPending}
-              onCancel={() => setStep(2)}
-              onConfirm={handleConfirmCreate}
-            />
-          ) : null}
+          <CreateDataListDialogBody
+            step={step}
+            name={name}
+            description={description}
+            format={format}
+            validation={validation}
+            csvDiscovery={csvDiscovery}
+            pendingDiscovery={pendingDiscovery}
+            displayError={displayError}
+            selectedFileName={selectedFileName}
+            isPending={isPending}
+            setName={setName}
+            setDescription={setDescription}
+            setFormat={setFormat}
+            onFileSelected={handleFileSelectedWithAdvance}
+            setStep={setStep}
+            onConfirmCreate={handleConfirmCreate}
+          />
         </div>
 
-        {step !== 3 ? (
-          <DialogFooter className="border-t px-6 py-4">
-            {step === 2 ? (
-              <Button variant="outline" onClick={() => setStep(1)}>
-                Back
-              </Button>
-            ) : (
-              <Button variant="outline" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-            )}
-
-            {step === 1 ? (
-              <Button
-                onClick={handleContinue}
-                disabled={name.trim().length === 0 || !hasSourceContent}
-              >
-                Continue
-              </Button>
-            ) : (
-              <Button onClick={handleReviewLocales} disabled={!canConfirm}>
-                <Upload className="h-4 w-4" />
-                Review locales
-              </Button>
-            )}
-          </DialogFooter>
-        ) : null}
+        <CreateDataListDialogFooter
+          step={step}
+          name={name}
+          hasSourceContent={hasSourceContent}
+          canConfirm={canConfirm}
+          onOpenChange={onOpenChange}
+          onContinue={handleContinue}
+          onReviewLocales={handleReviewLocales}
+          setStep={setStep}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/features/data-lists/create-list/ui/create-data-list-dialog.tsx
+++ b/features/data-lists/create-list/ui/create-data-list-dialog.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Spinner } from "@/components/loaders/spinner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -160,31 +159,42 @@ export function CreateDataListDialog({
       return;
     }
 
-    if (format === "json" && !validation) {
+    if (format === "csv") {
+      startTransition(async () => {
+        const importResult = await createDataListWithImportAction({
+          name: name.trim(),
+          description: description.trim(),
+          format: "csv",
+          csv: filterTranslationsCsv(csvInput, selection.includedLocales),
+          ensureLocales: selection.ensureLocales,
+        });
+
+        if (Result.isError(importResult)) {
+          toast.error(importResult.message || "Failed to create data list");
+          return;
+        }
+
+        onCreated?.(importResult.value);
+        toast.success("Data list created successfully");
+        onOpenChange(false);
+      });
+      return;
+    }
+
+    if (!validation) {
       toast.error("JSON validation is missing. Please re-upload the file.");
       return;
     }
 
+    const jsonItems = validation.validItems;
     startTransition(async () => {
-      const importResult =
-        format === "csv"
-          ? await createDataListWithImportAction({
-              name: name.trim(),
-              description: description.trim(),
-              format: "csv",
-              csv: filterTranslationsCsv(csvInput, selection.includedLocales),
-              ensureLocales: selection.ensureLocales,
-            })
-          : await createDataListWithImportAction({
-              name: name.trim(),
-              description: description.trim(),
-              format: "json",
-              items: filterJsonItemsByLocales(
-                validation!.validItems,
-                selection.includedLocales,
-              ),
-              ensureLocales: selection.ensureLocales,
-            });
+      const importResult = await createDataListWithImportAction({
+        name: name.trim(),
+        description: description.trim(),
+        format: "json",
+        items: filterJsonItemsByLocales(jsonItems, selection.includedLocales),
+        ensureLocales: selection.ensureLocales,
+      });
 
       if (Result.isError(importResult)) {
         toast.error(importResult.message || "Failed to create data list");
@@ -294,21 +304,9 @@ export function CreateDataListDialog({
                 Continue
               </Button>
             ) : (
-              <Button
-                onClick={handleReviewLocales}
-                disabled={!canConfirm || isPending}
-              >
-                {isPending ? (
-                  <>
-                    <Spinner className="mr-1 h-4 w-4" />
-                    Creating...
-                  </>
-                ) : (
-                  <>
-                    <Upload className="h-4 w-4" />
-                    Review locales
-                  </>
-                )}
+              <Button onClick={handleReviewLocales} disabled={!canConfirm}>
+                <Upload className="h-4 w-4" />
+                Review locales
               </Button>
             )}
           </DialogFooter>

--- a/features/data-lists/create-list/ui/create-data-list-dialog.tsx
+++ b/features/data-lists/create-list/ui/create-data-list-dialog.tsx
@@ -132,7 +132,7 @@ function resolvePendingDiscovery(args: {
   return null;
 }
 
-function CreateDataListDialogBody(props: {
+interface CreateDataListDialogBodyProps {
   step: CreateStep;
   name: string;
   description: string;
@@ -149,7 +149,11 @@ function CreateDataListDialogBody(props: {
   onFileSelected: (file: File | null) => Promise<void>;
   setStep: (step: CreateStep) => void;
   onConfirmCreate: (selection: LocaleImportSelection) => void;
-}): ReactNode {
+}
+
+function CreateDataListDialogBody(
+  props: Readonly<CreateDataListDialogBodyProps>,
+): ReactNode {
   const {
     step,
     name,
@@ -239,7 +243,7 @@ function CreateDataListDialogBody(props: {
   return null;
 }
 
-function CreateDataListDialogFooter(props: {
+interface CreateDataListDialogFooterProps {
   step: CreateStep;
   name: string;
   hasSourceContent: boolean;
@@ -248,7 +252,11 @@ function CreateDataListDialogFooter(props: {
   onContinue: () => void;
   onReviewLocales: () => void;
   setStep: (step: CreateStep) => void;
-}): ReactNode {
+}
+
+function CreateDataListDialogFooter(
+  props: Readonly<CreateDataListDialogFooterProps>,
+): ReactNode {
   const {
     step,
     name,
@@ -425,9 +433,7 @@ export function CreateDataListDialog({
       <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col overflow-hidden p-0">
         <DialogHeader className="border-b px-6 py-4">
           <DialogTitle>Create Data List</DialogTitle>
-          <DialogDescription>
-            {CREATE_STEP_DESCRIPTION[step]}
-          </DialogDescription>
+          <DialogDescription>{CREATE_STEP_DESCRIPTION[step]}</DialogDescription>
         </DialogHeader>
 
         <div className="flex-1 space-y-6 overflow-y-auto px-6 py-4">

--- a/features/data-lists/create-list/ui/create-data-list-dialog.tsx
+++ b/features/data-lists/create-list/ui/create-data-list-dialog.tsx
@@ -16,18 +16,16 @@ import type { DataListDetails } from "@/lib/endatix-api/data-lists/types";
 import { Result } from "@/lib/result";
 import { Upload } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
-import { createDataListAction } from "../create-data-list.action";
+import { createDataListWithImportAction } from "../create-data-list-with-import.action";
 import { DataListItemsInput } from "../../add-items/data-list-items-input";
 import { DataListValidationPreview } from "../../add-items/data-list-validation-preview";
 import { DataListCsvPreview } from "../../add-items/data-list-csv-preview";
 import { useDataListSource } from "../../add-items/use-data-list-source.hook";
-import { replaceDataListItemsAction } from "../../replace-items/replace-data-list-items.action";
 import {
   discoverLocalesFromJsonItems,
   filterJsonItemsByLocales,
 } from "../../utils";
-import { LocaleImportConfirmDialog } from "../../translations/locale-import-confirm-dialog";
-import { uploadTranslationsCsvAction } from "../../translations/translations-csv.action";
+import { LocaleImportConfirmPanel } from "../../translations/locale-import-confirm-dialog";
 import { filterTranslationsCsv } from "../../translations/parse-translations-csv";
 import type {
   LocaleImportDiscovery,
@@ -40,11 +38,11 @@ interface CreateDataListDialogProps {
   onCreated?: (details: DataListDetails) => void;
 }
 
-type CreateStep = 1 | 2;
+type CreateStep = 1 | 2 | 3;
 
 /**
  * Create a new data list from CSV or JSON upload.
- * Step 1: details + source · Step 2: preview · then locale confirm.
+ * Step 1: details + source · Step 2: preview · Step 3: locale confirm.
  */
 export function CreateDataListDialog({
   open,
@@ -55,7 +53,6 @@ export function CreateDataListDialog({
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [isPending, startTransition] = useTransition();
-  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [pendingDiscovery, setPendingDiscovery] =
     useState<LocaleImportDiscovery | null>(null);
   const advanceAfterUploadRef = useRef(false);
@@ -68,6 +65,7 @@ export function CreateDataListDialog({
     csvDiscovery,
     canConfirm,
     hasSourceContent,
+    sourceError,
     validationError: fileValidationError,
     selectedFileName,
     setValidationError,
@@ -75,12 +73,12 @@ export function CreateDataListDialog({
     reset: resetFileHandler,
   } = useDataListSource();
 
+  const displayError = fileValidationError ?? sourceError;
   useEffect(() => {
     if (!open) {
       setStep(1);
       setName("");
       setDescription("");
-      setIsConfirmOpen(false);
       setPendingDiscovery(null);
       advanceAfterUploadRef.current = false;
       resetFileHandler();
@@ -124,11 +122,11 @@ export function CreateDataListDialog({
 
   const handleContinue = () => {
     if (!canProceedToReview) {
-      setValidationError(
-        format === "csv"
-          ? "Please provide a valid translations CSV."
-          : "Please provide valid JSON items.",
-      );
+      let fallbackError = "Please provide valid JSON items.";
+      if (format === "csv") {
+        fallbackError = "Please provide a valid translations CSV.";
+      }
+      setValidationError(sourceError ?? fallbackError);
       return;
     }
 
@@ -136,7 +134,7 @@ export function CreateDataListDialog({
     setStep(2);
   };
 
-  const handleCreate = () => {
+  const handleReviewLocales = () => {
     if (!canConfirm) {
       return;
     }
@@ -147,13 +145,13 @@ export function CreateDataListDialog({
           availableLocales: [],
         }),
       );
-      setIsConfirmOpen(true);
+      setStep(3);
       return;
     }
 
     if (format === "csv" && csvDiscovery) {
       setPendingDiscovery(csvDiscovery);
-      setIsConfirmOpen(true);
+      setStep(3);
     }
   };
 
@@ -162,130 +160,121 @@ export function CreateDataListDialog({
       return;
     }
 
-    startTransition(async () => {
-      const createResult = await createDataListAction({
-        name: name.trim(),
-        description: description.trim(),
-      });
+    if (format === "json" && !validation) {
+      toast.error("JSON validation is missing. Please re-upload the file.");
+      return;
+    }
 
-      if (Result.isError(createResult)) {
-        toast.error(createResult.message || "Failed to create data list");
+    startTransition(async () => {
+      const importResult =
+        format === "csv"
+          ? await createDataListWithImportAction({
+              name: name.trim(),
+              description: description.trim(),
+              format: "csv",
+              csv: filterTranslationsCsv(csvInput, selection.includedLocales),
+              ensureLocales: selection.ensureLocales,
+            })
+          : await createDataListWithImportAction({
+              name: name.trim(),
+              description: description.trim(),
+              format: "json",
+              items: filterJsonItemsByLocales(
+                validation!.validItems,
+                selection.includedLocales,
+              ),
+              ensureLocales: selection.ensureLocales,
+            });
+
+      if (Result.isError(importResult)) {
+        toast.error(importResult.message || "Failed to create data list");
         return;
       }
 
-      const createdList = createResult.value;
-      const dataListId = String(createdList.id);
-
-      if (format === "csv") {
-        const csv = filterTranslationsCsv(csvInput, selection.includedLocales);
-        const uploadResult = await uploadTranslationsCsvAction({
-          dataListId,
-          csv,
-          ensureLocales: selection.ensureLocales,
-        });
-
-        if (Result.isError(uploadResult)) {
-          toast.error(
-            uploadResult.message ||
-              "List created but failed to import CSV items",
-          );
-          return;
-        }
-
-        onCreated?.(uploadResult.value);
-      } else {
-        if (!validation) {
-          return;
-        }
-
-        const items = filterJsonItemsByLocales(
-          validation.validItems,
-          selection.includedLocales,
-        );
-        const replaceResult = await replaceDataListItemsAction(
-          dataListId,
-          items,
-          selection.ensureLocales,
-        );
-
-        if (Result.isError(replaceResult)) {
-          toast.error(
-            replaceResult.message || "List created but failed to import items",
-          );
-          return;
-        }
-
-        onCreated?.(replaceResult.value);
-      }
-
+      onCreated?.(importResult.value);
       toast.success("Data list created successfully");
-      setIsConfirmOpen(false);
       onOpenChange(false);
     });
   };
 
+  let stepDescription =
+    "Define your new curated dataset and upload CSV or JSON.";
+  if (step === 2) {
+    stepDescription = "Review validation before creating the list.";
+  } else if (step === 3) {
+    stepDescription = "Choose which locales to import.";
+  }
+
   return (
-    <>
-      <Dialog open={open} onOpenChange={onOpenChange} modal={!isConfirmOpen}>
-        <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col overflow-hidden p-0">
-          <DialogHeader className="border-b px-6 py-4">
-            <DialogTitle>Create Data List</DialogTitle>
-            <DialogDescription>
-              {step === 1
-                ? "Define your new curated dataset and upload CSV or JSON."
-                : "Review validation before creating the list."}
-            </DialogDescription>
-          </DialogHeader>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col overflow-hidden p-0">
+        <DialogHeader className="border-b px-6 py-4">
+          <DialogTitle>Create Data List</DialogTitle>
+          <DialogDescription>{stepDescription}</DialogDescription>
+        </DialogHeader>
 
-          <div className="flex-1 space-y-6 overflow-y-auto px-6 py-4">
-            {step === 1 ? (
-              <>
-                <div className="space-y-4">
-                  <Input
-                    placeholder="Friendly Name"
-                    value={name}
-                    onChange={(event) => setName(event.target.value)}
-                  />
-                  <Input
-                    placeholder="Description (optional)"
-                    value={description}
-                    onChange={(event) => setDescription(event.target.value)}
-                  />
-                </div>
-
-                <DataListItemsInput
-                  format={format}
-                  onFormatChange={setFormat}
-                  onFileSelected={handleFileSelectedWithAdvance}
-                  selectedFileName={selectedFileName}
-                  fileInputId="create-data-list-file-upload"
+        <div className="flex-1 space-y-6 overflow-y-auto px-6 py-4">
+          {step === 1 ? (
+            <>
+              <div className="space-y-4">
+                <Input
+                  placeholder="Friendly Name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
                 />
+                <Input
+                  placeholder="Description (optional)"
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                />
+              </div>
 
-                {fileValidationError ? (
-                  <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-                    {fileValidationError}
-                  </div>
-                ) : null}
-              </>
-            ) : null}
-
-            {step === 2 && format === "json" && validation ? (
-              <DataListValidationPreview
-                validation={validation}
-                name={name}
-                description={description}
+              <DataListItemsInput
+                format={format}
+                onFormatChange={setFormat}
+                onFileSelected={handleFileSelectedWithAdvance}
+                selectedFileName={selectedFileName}
+                fileInputId="create-data-list-file-upload"
               />
-            ) : null}
 
-            {step === 2 && format === "csv" && csvDiscovery ? (
-              <DataListCsvPreview
-                discovery={csvDiscovery}
-                name={name}
-                description={description}
-              />
-            ) : null}
-          </div>
+              {displayError ? (
+                <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+                  {displayError}
+                </div>
+              ) : null}
+            </>
+          ) : null}
 
+          {step === 2 && format === "json" && validation ? (
+            <DataListValidationPreview
+              validation={validation}
+              name={name}
+              description={description}
+            />
+          ) : null}
+
+          {step === 2 && format === "csv" && csvDiscovery ? (
+            <DataListCsvPreview
+              discovery={csvDiscovery}
+              name={name}
+              description={description}
+            />
+          ) : null}
+
+          {step === 3 ? (
+            <LocaleImportConfirmPanel
+              title="Confirm locales for new list"
+              mode="create"
+              discovery={pendingDiscovery}
+              catalogLocaleCount={0}
+              isPending={isPending}
+              onCancel={() => setStep(2)}
+              onConfirm={handleConfirmCreate}
+            />
+          ) : null}
+        </div>
+
+        {step !== 3 ? (
           <DialogFooter className="border-t px-6 py-4">
             {step === 2 ? (
               <Button variant="outline" onClick={() => setStep(1)}>
@@ -306,7 +295,7 @@ export function CreateDataListDialog({
               </Button>
             ) : (
               <Button
-                onClick={handleCreate}
+                onClick={handleReviewLocales}
                 disabled={!canConfirm || isPending}
               >
                 {isPending ? (
@@ -323,19 +312,8 @@ export function CreateDataListDialog({
               </Button>
             )}
           </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <LocaleImportConfirmDialog
-        open={isConfirmOpen}
-        onOpenChange={setIsConfirmOpen}
-        title="Confirm locales for new list"
-        mode="create"
-        discovery={pendingDiscovery}
-        catalogLocaleCount={0}
-        isPending={isPending}
-        onConfirm={handleConfirmCreate}
-      />
-    </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/features/data-lists/delete-list/delete-data-list.action.ts
+++ b/features/data-lists/delete-list/delete-data-list.action.ts
@@ -2,9 +2,9 @@
 
 import { auth } from "@/auth";
 import { authorization } from "@/features/auth/authorization";
-import { TelemetryLogger } from "@/features/telemetry";
 import { EndatixApi } from "@/lib/endatix-api";
 import { Result } from "@/lib/result";
+import { toResult } from "@/lib/result/map-api-result-to-result";
 import { revalidatePath } from "next/cache";
 
 const LOGGER_NAME = "data-lists";
@@ -19,18 +19,15 @@ export async function deleteDataListAction(
   await requireHubAccess();
 
   const api = new EndatixApi(session?.accessToken);
-  const result = await api.dataLists.delete(dataListId);
-
-  if (!result.success) {
-    TelemetryLogger.error(
-      result.error.message || "Error during deleting data list",
-      result?.error,
-      {},
-      LOGGER_NAME,
-    );
-    return Result.error(result.error.message || "Failed to delete data list");
+  const result = toResult(await api.dataLists.delete(dataListId), {
+    fallbackMessage: "Failed to delete data list",
+    logMessage: "Failed to delete data list",
+    loggerName: LOGGER_NAME,
+  });
+  
+  if (Result.isSuccess(result)) {
+    revalidatePath("/(main)/data-lists");
   }
 
-  revalidatePath("/(main)/data-lists");
-  return Result.success(result.data);
+  return result;
 }

--- a/features/data-lists/import-limits.ts
+++ b/features/data-lists/import-limits.ts
@@ -1,0 +1,9 @@
+import { DATA_LIST_ITEM_MAX_LENGTH } from "@/lib/survey-features/data-lists/constants";
+
+/** Shared data-list import caps (client discovery + server guards). */
+export const DATA_LIST_MAX_ITEMS = 5_000;
+export const DATA_LIST_MAX_LOCALES = 20;
+/** Alias of API max label/value length — keep UI copy and validation on one constant. */
+export const DATA_LIST_MAX_LABEL_LENGTH = DATA_LIST_ITEM_MAX_LENGTH;
+export const DATA_LIST_MAX_CSV_CHARS = 2_000_000;
+export const DATA_LIST_MAX_JSON_FILE_BYTES = 5 * 1024 * 1024;

--- a/features/data-lists/import-limits.ts
+++ b/features/data-lists/import-limits.ts
@@ -1,9 +1,7 @@
-import { DATA_LIST_ITEM_MAX_LENGTH } from "@/lib/survey-features/data-lists/constants";
-
 /** Shared data-list import caps (client discovery + server guards). */
 export const DATA_LIST_MAX_ITEMS = 5_000;
 export const DATA_LIST_MAX_LOCALES = 20;
 /** Alias of API max label/value length — keep UI copy and validation on one constant. */
-export const DATA_LIST_MAX_LABEL_LENGTH = DATA_LIST_ITEM_MAX_LENGTH;
+export { DATA_LIST_ITEM_MAX_LENGTH as DATA_LIST_MAX_LABEL_LENGTH } from "@/lib/survey-features/data-lists/constants";
 export const DATA_LIST_MAX_CSV_CHARS = 2_000_000;
 export const DATA_LIST_MAX_JSON_FILE_BYTES = 5 * 1024 * 1024;

--- a/features/data-lists/import-payload-guards.ts
+++ b/features/data-lists/import-payload-guards.ts
@@ -1,0 +1,80 @@
+import type { DataListChoiceItem } from "@/lib/endatix-api/data-lists/types";
+import { Result } from "@/lib/result";
+import {
+  DATA_LIST_MAX_CSV_CHARS,
+  DATA_LIST_MAX_ITEMS,
+  DATA_LIST_MAX_LOCALES,
+} from "./translations/locale-discovery";
+import { readCsvRecords } from "./translations/parse-translations-csv";
+
+/**
+ * Shared Hub-side guards for data-list import payloads (CSV / JSON items).
+ * Mirrors client discovery limits so server actions do not trust the browser alone.
+ */
+export function guardTranslationsCsvPayload(csv: string): Result<void> {
+  if (csv.length > DATA_LIST_MAX_CSV_CHARS) {
+    return Result.error(
+      `CSV exceeds the maximum size of ${DATA_LIST_MAX_CSV_CHARS.toLocaleString()} characters.`,
+    );
+  }
+
+  let records: string[][];
+  try {
+    records = readCsvRecords(csv);
+  } catch (error) {
+    return Result.error(
+      error instanceof Error ? error.message : "Invalid CSV format.",
+    );
+  }
+
+  const dataRows = records
+    .slice(1)
+    .filter((row) => row.some((cell) => cell.trim().length > 0));
+
+  if (dataRows.length === 0) {
+    return Result.error("At least one data row is required.");
+  }
+
+  if (dataRows.length > DATA_LIST_MAX_ITEMS) {
+    return Result.error(
+      `A data list cannot have more than ${DATA_LIST_MAX_ITEMS.toLocaleString()} items.`,
+    );
+  }
+
+  return Result.success(undefined);
+}
+
+/**
+ * Guard to ensure the number of items in the import payload does not exceed the maximum limit.
+ */
+export function guardJsonImportItems(
+  items: DataListChoiceItem[],
+): Result<void> {
+  if (items.length === 0) {
+    return Result.error("At least one item is required.");
+  }
+
+  if (items.length > DATA_LIST_MAX_ITEMS) {
+    return Result.error(
+      `A data list cannot have more than ${DATA_LIST_MAX_ITEMS.toLocaleString()} items.`,
+    );
+  }
+
+  return Result.success(undefined);
+}
+
+/**
+ * Guard to ensure the number of locales selected does not exceed the catalog limit.
+ */
+export function guardEnsureLocalesCount(
+  ensureLocales: readonly string[],
+  catalogLocaleCount: number,
+): Result<void> {
+  if (catalogLocaleCount + ensureLocales.length > DATA_LIST_MAX_LOCALES) {
+    return Result.error(
+      `Selecting these locales would exceed the catalog limit of ${DATA_LIST_MAX_LOCALES}.`,
+    );
+  }
+
+  return Result.success(undefined);
+}

--- a/features/data-lists/import-payload-guards.ts
+++ b/features/data-lists/import-payload-guards.ts
@@ -16,7 +16,8 @@ import { readCsvRecords } from "./translations/parse-translations-csv";
 
 export type GuardImportPayloadInput = {
   ensureLocales?: readonly string[];
-  catalogLocaleCount?: number;
+  /** Locales already on the catalog; overlapping `ensureLocales` are not counted as new. */
+  existingCatalogLocales?: readonly string[];
 } & (
   | { format: "csv"; csv: string; items?: never }
   | { format: "json"; items: DataListChoiceItem[]; csv?: never }
@@ -72,14 +73,41 @@ export function guardJsonImportItems(
   return Result.success(undefined);
 }
 
+function countNewEnsureLocales(
+  ensureLocales: readonly string[],
+  existingCatalogLocales: readonly string[],
+): number {
+  const existing = new Set(
+    existingCatalogLocales.map((locale) => locale.trim().toLowerCase()),
+  );
+  const seenNew = new Set<string>();
+
+  for (const locale of ensureLocales) {
+    const key = locale.trim().toLowerCase();
+    if (!key || existing.has(key) || seenNew.has(key)) {
+      continue;
+    }
+    seenNew.add(key);
+  }
+
+  return seenNew.size;
+}
+
 /**
- * Guard to ensure the number of locales selected does not exceed the catalog limit.
+ * Guard to ensure adding `ensureLocales` would not exceed the catalog limit.
+ * Locales already present in the catalog (and duplicates within `ensureLocales`)
+ * are not counted as new.
  */
 export function guardEnsureLocalesCount(
   ensureLocales: readonly string[],
-  catalogLocaleCount: number,
+  existingCatalogLocales: readonly string[] = [],
 ): Result<void> {
-  if (catalogLocaleCount + ensureLocales.length > DATA_LIST_MAX_LOCALES) {
+  const newLocaleCount = countNewEnsureLocales(
+    ensureLocales,
+    existingCatalogLocales,
+  );
+
+  if (existingCatalogLocales.length + newLocaleCount > DATA_LIST_MAX_LOCALES) {
     return Result.error(IMPORT_LOCALES_CATALOG_LIMIT_ERROR);
   }
 
@@ -94,7 +122,7 @@ export function guardImportPayload(
 ): Result<void> {
   const localesGuard = guardEnsureLocalesCount(
     input.ensureLocales ?? [],
-    input.catalogLocaleCount ?? 0,
+    input.existingCatalogLocales ?? [],
   );
   if (Result.isError(localesGuard)) {
     return localesGuard;

--- a/features/data-lists/import-payload-guards.ts
+++ b/features/data-lists/import-payload-guards.ts
@@ -4,8 +4,23 @@ import {
   DATA_LIST_MAX_CSV_CHARS,
   DATA_LIST_MAX_ITEMS,
   DATA_LIST_MAX_LOCALES,
-} from "./translations/locale-discovery";
+} from "./import-limits";
+import {
+  IMPORT_AT_LEAST_ONE_CSV_ROW_ERROR,
+  IMPORT_AT_LEAST_ONE_ITEM_ERROR,
+  IMPORT_CSV_TOO_LARGE_ERROR,
+  IMPORT_LOCALES_CATALOG_LIMIT_ERROR,
+  IMPORT_TOO_MANY_ITEMS_ERROR,
+} from "./import-validation-messages";
 import { readCsvRecords } from "./translations/parse-translations-csv";
+
+export type GuardImportPayloadInput = {
+  ensureLocales?: readonly string[];
+  catalogLocaleCount?: number;
+} & (
+  | { format: "csv"; csv: string; items?: never }
+  | { format: "json"; items: DataListChoiceItem[]; csv?: never }
+);
 
 /**
  * Shared Hub-side guards for data-list import payloads (CSV / JSON items).
@@ -13,9 +28,7 @@ import { readCsvRecords } from "./translations/parse-translations-csv";
  */
 export function guardTranslationsCsvPayload(csv: string): Result<void> {
   if (csv.length > DATA_LIST_MAX_CSV_CHARS) {
-    return Result.error(
-      `CSV exceeds the maximum size of ${DATA_LIST_MAX_CSV_CHARS.toLocaleString()} characters.`,
-    );
+    return Result.error(IMPORT_CSV_TOO_LARGE_ERROR);
   }
 
   let records: string[][];
@@ -32,13 +45,11 @@ export function guardTranslationsCsvPayload(csv: string): Result<void> {
     .filter((row) => row.some((cell) => cell.trim().length > 0));
 
   if (dataRows.length === 0) {
-    return Result.error("At least one data row is required.");
+    return Result.error(IMPORT_AT_LEAST_ONE_CSV_ROW_ERROR);
   }
 
   if (dataRows.length > DATA_LIST_MAX_ITEMS) {
-    return Result.error(
-      `A data list cannot have more than ${DATA_LIST_MAX_ITEMS.toLocaleString()} items.`,
-    );
+    return Result.error(IMPORT_TOO_MANY_ITEMS_ERROR);
   }
 
   return Result.success(undefined);
@@ -51,13 +62,11 @@ export function guardJsonImportItems(
   items: DataListChoiceItem[],
 ): Result<void> {
   if (items.length === 0) {
-    return Result.error("At least one item is required.");
+    return Result.error(IMPORT_AT_LEAST_ONE_ITEM_ERROR);
   }
 
   if (items.length > DATA_LIST_MAX_ITEMS) {
-    return Result.error(
-      `A data list cannot have more than ${DATA_LIST_MAX_ITEMS.toLocaleString()} items.`,
-    );
+    return Result.error(IMPORT_TOO_MANY_ITEMS_ERROR);
   }
 
   return Result.success(undefined);
@@ -71,10 +80,30 @@ export function guardEnsureLocalesCount(
   catalogLocaleCount: number,
 ): Result<void> {
   if (catalogLocaleCount + ensureLocales.length > DATA_LIST_MAX_LOCALES) {
-    return Result.error(
-      `Selecting these locales would exceed the catalog limit of ${DATA_LIST_MAX_LOCALES}.`,
-    );
+    return Result.error(IMPORT_LOCALES_CATALOG_LIMIT_ERROR);
   }
 
   return Result.success(undefined);
+}
+
+/**
+ * Single entry for create/upload/replace server actions: locales cap + format payload.
+ */
+export function guardImportPayload(
+  input: GuardImportPayloadInput,
+): Result<void> {
+  const localesGuard = guardEnsureLocalesCount(
+    input.ensureLocales ?? [],
+    input.catalogLocaleCount ?? 0,
+  );
+  if (Result.isError(localesGuard)) {
+    return localesGuard;
+  }
+
+  switch (input.format) {
+    case "csv":
+      return guardTranslationsCsvPayload(input.csv);
+    case "json":
+      return guardJsonImportItems(input.items);
+  }
 }

--- a/features/data-lists/import-validation-messages.ts
+++ b/features/data-lists/import-validation-messages.ts
@@ -4,6 +4,11 @@ import {
   DATA_LIST_MAX_LOCALES,
 } from "./import-limits";
 
+/** Stable grouping for user-facing limits (avoids CI flakes under non–en-US locales). */
+function formatCount(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
 /**
  * Shared copy for client discovery (`utils`, CSV/locale helpers) and server
  * `import-payload-guards`. Keep wording identical across Hub import paths.
@@ -11,6 +16,8 @@ import {
 export const IMPORT_AT_LEAST_ONE_ITEM_ERROR = "At least one item is required.";
 export const IMPORT_AT_LEAST_ONE_CSV_ROW_ERROR =
   "At least one data row is required.";
-export const IMPORT_TOO_MANY_ITEMS_ERROR = `A data list cannot have more than ${DATA_LIST_MAX_ITEMS.toLocaleString()} items.`;
-export const IMPORT_CSV_TOO_LARGE_ERROR = `CSV exceeds the maximum size of ${DATA_LIST_MAX_CSV_CHARS.toLocaleString()} characters.`;
+export const IMPORT_TOO_MANY_ITEMS_ERROR = `A data list cannot have more than ${formatCount(DATA_LIST_MAX_ITEMS)} items.`;
+export const IMPORT_CSV_TOO_LARGE_ERROR = `CSV exceeds the maximum size of ${formatCount(DATA_LIST_MAX_CSV_CHARS)} characters.`;
 export const IMPORT_LOCALES_CATALOG_LIMIT_ERROR = `Selecting these locales would exceed the catalog limit of ${DATA_LIST_MAX_LOCALES}.`;
+export const IMPORT_ROLLBACK_FAILED_SUFFIX =
+  "The new data list could not be removed automatically. Delete it from Data lists or contact support.";

--- a/features/data-lists/import-validation-messages.ts
+++ b/features/data-lists/import-validation-messages.ts
@@ -1,0 +1,16 @@
+import {
+  DATA_LIST_MAX_CSV_CHARS,
+  DATA_LIST_MAX_ITEMS,
+  DATA_LIST_MAX_LOCALES,
+} from "./import-limits";
+
+/**
+ * Shared copy for client discovery (`utils`, CSV/locale helpers) and server
+ * `import-payload-guards`. Keep wording identical across Hub import paths.
+ */
+export const IMPORT_AT_LEAST_ONE_ITEM_ERROR = "At least one item is required.";
+export const IMPORT_AT_LEAST_ONE_CSV_ROW_ERROR =
+  "At least one data row is required.";
+export const IMPORT_TOO_MANY_ITEMS_ERROR = `A data list cannot have more than ${DATA_LIST_MAX_ITEMS.toLocaleString()} items.`;
+export const IMPORT_CSV_TOO_LARGE_ERROR = `CSV exceeds the maximum size of ${DATA_LIST_MAX_CSV_CHARS.toLocaleString()} characters.`;
+export const IMPORT_LOCALES_CATALOG_LIMIT_ERROR = `Selecting these locales would exceed the catalog limit of ${DATA_LIST_MAX_LOCALES}.`;

--- a/features/data-lists/remove-locale/__tests__/remove-locale-confirm-dialog.test.tsx
+++ b/features/data-lists/remove-locale/__tests__/remove-locale-confirm-dialog.test.tsx
@@ -23,13 +23,13 @@ vi.mock("@/features/data-lists/translations/locale-discovery", () => ({
 describe("RemoveLocaleConfirmDialog", () => {
   const onOpenChange = vi.fn();
   const onRemoved = vi.fn();
+  const onPendingChange = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("highlights the locale and keeps Remove disabled when locale is null", () => {
-    // Arrange / Act
     render(
       <RemoveLocaleConfirmDialog
         open
@@ -40,7 +40,6 @@ describe("RemoveLocaleConfirmDialog", () => {
       />,
     );
 
-    // Assert
     expect(
       (screen.getByRole("button", { name: "Remove" }) as HTMLButtonElement)
         .disabled,
@@ -48,8 +47,7 @@ describe("RemoveLocaleConfirmDialog", () => {
     expect(screen.queryByText(/· Test/)).toBeNull();
   });
 
-  it("shows the locale subtitle when a locale is selected", () => {
-    // Arrange / Act
+  it("shows the locale subtitle and catalog warning copy", () => {
     render(
       <RemoveLocaleConfirmDialog
         open
@@ -60,15 +58,15 @@ describe("RemoveLocaleConfirmDialog", () => {
       />,
     );
 
-    // Assert
     expect(screen.getByText("fr · Test")).not.toBeNull();
     expect(
-      screen.getByText(/deletes its labels from every item/i),
+      screen.getByText(
+        /This removes the language from the data catalog and deletes each label translation from every item/,
+      ),
     ).not.toBeNull();
   });
 
-  it("calls removeLocaleAction and notifies parent on confirm", async () => {
-    // Arrange
+  it("keeps the dialog open until remove succeeds, then closes", async () => {
     const details = {
       id: "42",
       name: "Countries",
@@ -78,7 +76,13 @@ describe("RemoveLocaleConfirmDialog", () => {
       availableLocales: [],
       items: [],
     };
-    vi.mocked(removeLocaleAction).mockResolvedValue(Result.success(details));
+    let resolveRemove: ((value: Result<typeof details>) => void) | undefined;
+    vi.mocked(removeLocaleAction).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRemove = resolve;
+        }),
+    );
 
     render(
       <RemoveLocaleConfirmDialog
@@ -87,23 +91,29 @@ describe("RemoveLocaleConfirmDialog", () => {
         dataListId="42"
         locale="fr"
         onRemoved={onRemoved}
+        onPendingChange={onPendingChange}
       />,
     );
 
-    // Act
     fireEvent.click(screen.getByRole("button", { name: "Remove" }));
 
-    // Assert
-    expect(onOpenChange).toHaveBeenCalledWith(false);
+    await waitFor(() => {
+      expect(onPendingChange).toHaveBeenCalledWith(true);
+    });
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    resolveRemove?.(Result.success(details));
+
     await waitFor(() => {
       expect(removeLocaleAction).toHaveBeenCalledWith("42", "fr");
       expect(onRemoved).toHaveBeenCalledWith(details);
       expect(toast.success).toHaveBeenCalledWith("Removed locale fr");
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(onPendingChange).toHaveBeenCalledWith(false);
     });
   });
 
-  it("shows an error toast when removeLocaleAction fails", async () => {
-    // Arrange
+  it("shows an error toast and keeps the dialog open when remove fails", async () => {
     vi.mocked(removeLocaleAction).mockResolvedValue(
       Result.error("Locale is still in use"),
     );
@@ -118,13 +128,12 @@ describe("RemoveLocaleConfirmDialog", () => {
       />,
     );
 
-    // Act
     fireEvent.click(screen.getByRole("button", { name: "Remove" }));
 
-    // Assert
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("Locale is still in use");
     });
     expect(onRemoved).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 });

--- a/features/data-lists/remove-locale/__tests__/remove-locale-confirm-dialog.test.tsx
+++ b/features/data-lists/remove-locale/__tests__/remove-locale-confirm-dialog.test.tsx
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Result } from "@/lib/result";
+import { toast } from "@/components/ui/toast";
+import { RemoveLocaleConfirmDialog } from "../ui/remove-locale-confirm-dialog";
+import { removeLocaleAction } from "../remove-locale.action";
+
+vi.mock("../remove-locale.action", () => ({
+  removeLocaleAction: vi.fn(),
+}));
+
+vi.mock("@/components/ui/toast", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/features/data-lists/translations/locale-discovery", () => ({
+  formatLocaleLabel: (locale: string) => `${locale} · Test`,
+}));
+
+describe("RemoveLocaleConfirmDialog", () => {
+  const onOpenChange = vi.fn();
+  const onRemoved = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("highlights the locale and keeps Remove disabled when locale is null", () => {
+    // Arrange / Act
+    render(
+      <RemoveLocaleConfirmDialog
+        open
+        onOpenChange={onOpenChange}
+        dataListId="42"
+        locale={null}
+        onRemoved={onRemoved}
+      />,
+    );
+
+    // Assert
+    expect(screen.getByRole("button", { name: "Remove" }).disabled).toBe(true);
+    expect(screen.queryByText(/· Test/)).toBeNull();
+  });
+
+  it("shows the locale subtitle when a locale is selected", () => {
+    // Arrange / Act
+    render(
+      <RemoveLocaleConfirmDialog
+        open
+        onOpenChange={onOpenChange}
+        dataListId="42"
+        locale="fr"
+        onRemoved={onRemoved}
+      />,
+    );
+
+    // Assert
+    expect(screen.getByText("fr · Test")).not.toBeNull();
+    expect(
+      screen.getByText(/deletes its labels from every item/i),
+    ).not.toBeNull();
+  });
+
+  it("calls removeLocaleAction and notifies parent on confirm", async () => {
+    // Arrange
+    const details = {
+      id: "42",
+      name: "Countries",
+      isActive: true,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      itemsCount: 1,
+      availableLocales: [],
+      items: [],
+    };
+    vi.mocked(removeLocaleAction).mockResolvedValue(Result.success(details));
+
+    render(
+      <RemoveLocaleConfirmDialog
+        open
+        onOpenChange={onOpenChange}
+        dataListId="42"
+        locale="fr"
+        onRemoved={onRemoved}
+      />,
+    );
+
+    // Act
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    // Assert
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    await waitFor(() => {
+      expect(removeLocaleAction).toHaveBeenCalledWith("42", "fr");
+      expect(onRemoved).toHaveBeenCalledWith(details);
+      expect(toast.success).toHaveBeenCalledWith("Removed locale fr");
+    });
+  });
+
+  it("shows an error toast when removeLocaleAction fails", async () => {
+    // Arrange
+    vi.mocked(removeLocaleAction).mockResolvedValue(
+      Result.error("Locale is still in use"),
+    );
+
+    render(
+      <RemoveLocaleConfirmDialog
+        open
+        onOpenChange={onOpenChange}
+        dataListId="42"
+        locale="fr"
+        onRemoved={onRemoved}
+      />,
+    );
+
+    // Act
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    // Assert
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Locale is still in use");
+    });
+    expect(onRemoved).not.toHaveBeenCalled();
+  });
+});

--- a/features/data-lists/remove-locale/__tests__/remove-locale-confirm-dialog.test.tsx
+++ b/features/data-lists/remove-locale/__tests__/remove-locale-confirm-dialog.test.tsx
@@ -41,7 +41,10 @@ describe("RemoveLocaleConfirmDialog", () => {
     );
 
     // Assert
-    expect(screen.getByRole("button", { name: "Remove" }).disabled).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Remove" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
     expect(screen.queryByText(/· Test/)).toBeNull();
   });
 

--- a/features/data-lists/remove-locale/__tests__/remove-locale.action.test.ts
+++ b/features/data-lists/remove-locale/__tests__/remove-locale.action.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiResult } from "@/lib/endatix-api";
+import { Result } from "@/lib/result";
+import { revalidatePath } from "next/cache";
+import { removeLocaleAction } from "../remove-locale.action";
+
+const { mockRemoveLocale, mockRequireHubAccess, mockAuth } = vi.hoisted(() => ({
+  mockRemoveLocale: vi.fn(),
+  mockRequireHubAccess: vi.fn(),
+  mockAuth: vi.fn(),
+}));
+
+vi.mock("@/auth", () => ({
+  auth: (...args: unknown[]) => mockAuth(...args),
+}));
+
+vi.mock("@/features/auth/authorization", () => ({
+  authorization: vi.fn(async () => ({
+    requireHubAccess: mockRequireHubAccess,
+  })),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/endatix-api", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/lib/endatix-api")>();
+  return {
+    ...mod,
+    EndatixApi: vi.fn().mockImplementation(function () {
+      return {
+        dataLists: {
+          removeLocale: mockRemoveLocale,
+        },
+      };
+    }),
+  };
+});
+
+describe("removeLocaleAction", () => {
+  const details = {
+    id: "42",
+    name: "Countries",
+    isActive: true,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    itemsCount: 1,
+    availableLocales: [],
+    items: [{ id: "1", value: "ch", labels: { default: "Switzerland" } }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ accessToken: "token", isLoggedIn: true });
+    mockRequireHubAccess.mockResolvedValue(undefined);
+  });
+
+  it("returns validation error for an invalid data list id", async () => {
+    // Arrange / Act
+    const result = await removeLocaleAction("not-an-id", "fr");
+
+    // Assert
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain("dataListId");
+    expect(mockRemoveLocale).not.toHaveBeenCalled();
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("returns error for an invalid culture code", async () => {
+    // Arrange / Act
+    const result = await removeLocaleAction("42", "!!!");
+
+    // Assert
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain("valid culture code");
+    expect(mockRemoveLocale).not.toHaveBeenCalled();
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("normalizes locale, calls API, and revalidates on success", async () => {
+    // Arrange
+    mockRemoveLocale.mockResolvedValue(ApiResult.success(details));
+
+    // Act
+    const result = await removeLocaleAction("42", " FR ");
+
+    // Assert
+    expect(mockRemoveLocale).toHaveBeenCalledWith("42", "fr");
+    expect(Result.isSuccess(result)).toBe(true);
+    if (!Result.isSuccess(result)) {
+      return;
+    }
+    expect(result.value.id).toBe("42");
+    expect(revalidatePath).toHaveBeenCalledWith("/data-lists/42");
+  });
+
+  it("does not revalidate when the API call fails", async () => {
+    // Arrange
+    mockRemoveLocale.mockResolvedValue(
+      ApiResult.notFoundError("Locale not found"),
+    );
+
+    // Act
+    const result = await removeLocaleAction("42", "fr");
+
+    // Assert
+    expect(Result.isError(result)).toBe(true);
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("propagates requireHubAccess failures", async () => {
+    // Arrange
+    mockRequireHubAccess.mockRejectedValue(new Error("NEXT_REDIRECT"));
+
+    // Act & Assert
+    await expect(removeLocaleAction("42", "fr")).rejects.toThrow(
+      "NEXT_REDIRECT",
+    );
+    expect(mockRemoveLocale).not.toHaveBeenCalled();
+  });
+});

--- a/features/data-lists/remove-locale/index.ts
+++ b/features/data-lists/remove-locale/index.ts
@@ -1,0 +1,4 @@
+export { removeLocaleAction } from "./remove-locale.action";
+export type { RemoveLocaleResult } from "./remove-locale.action";
+export { RemoveLocaleConfirmDialog } from "./ui/remove-locale-confirm-dialog";
+export type { RemoveLocaleConfirmDialogProps } from "./ui/remove-locale-confirm-dialog";

--- a/features/data-lists/remove-locale/remove-locale.action.ts
+++ b/features/data-lists/remove-locale/remove-locale.action.ts
@@ -1,0 +1,53 @@
+"use server";
+
+import { auth } from "@/auth";
+import { authorization } from "@/features/auth/authorization";
+import { EndatixApi } from "@/lib/endatix-api";
+import type { DataListDetails } from "@/lib/endatix-api/data-lists/types";
+import { tryNormalizeCultureCode } from "@/lib/localization";
+import { Result } from "@/lib/result";
+import { toResult } from "@/lib/result/map-api-result-to-result";
+import { validateEndatixId } from "@/lib/utils/type-validators";
+import { revalidatePath } from "next/cache";
+
+export type RemoveLocaleResult = Result<DataListDetails>;
+
+/**
+ * Removes a catalog locale and strips that key from every item's labels.
+ */
+export async function removeLocaleAction(
+  dataListId: string,
+  locale: string,
+): Promise<RemoveLocaleResult> {
+  const session = await auth();
+  const { requireHubAccess } = await authorization(session);
+  await requireHubAccess();
+
+  const idResult = validateEndatixId(dataListId, "dataListId");
+  if (Result.isError(idResult)) {
+    return idResult;
+  }
+
+  const normalized = tryNormalizeCultureCode(locale);
+  if (normalized === null) {
+    return Result.error(
+      `'${locale.trim() || locale}' is not a valid culture code.`,
+    );
+  }
+
+  const api = new EndatixApi(session?.accessToken);
+  const result = toResult(
+    await api.dataLists.removeLocale(idResult.value, normalized),
+    {
+      fallbackMessage: "Failed to remove locale",
+      logMessage: "Failed to remove locale",
+      loggerName: "data-lists.removeLocale",
+    },
+  );
+
+  if (Result.isSuccess(result)) {
+    revalidatePath(`/data-lists/${idResult.value}`);
+  }
+
+  return result;
+}

--- a/features/data-lists/remove-locale/ui/remove-locale-confirm-dialog.tsx
+++ b/features/data-lists/remove-locale/ui/remove-locale-confirm-dialog.tsx
@@ -13,7 +13,7 @@ import {
 import { toast } from "@/components/ui/toast";
 import type { DataListDetails } from "@/lib/endatix-api/data-lists/types";
 import { Result } from "@/lib/result";
-import { useTransition } from "react";
+import { useEffect, useTransition, type MouseEvent } from "react";
 import { formatLocaleLabel } from "@/features/data-lists/translations/locale-discovery";
 import { removeLocaleAction } from "../remove-locale.action";
 
@@ -23,6 +23,7 @@ export type RemoveLocaleConfirmDialogProps = {
   dataListId: string;
   locale: string | null;
   onRemoved: (details: DataListDetails) => void;
+  onPendingChange?: (isPending: boolean) => void;
 };
 
 /**
@@ -34,16 +35,22 @@ export function RemoveLocaleConfirmDialog({
   dataListId,
   locale,
   onRemoved,
+  onPendingChange,
 }: Readonly<RemoveLocaleConfirmDialogProps>) {
   const [isPending, startTransition] = useTransition();
 
-  const handleConfirm = (): void => {
-    if (locale === null) {
+  useEffect(() => {
+    onPendingChange?.(isPending);
+  }, [isPending, onPendingChange]);
+
+  const handleConfirm = (event: MouseEvent<HTMLButtonElement>): void => {
+    event.preventDefault();
+
+    if (locale === null || isPending) {
       return;
     }
 
     const localeToRemove = locale;
-    onOpenChange(false);
 
     startTransition(async () => {
       const result = await removeLocaleAction(dataListId, localeToRemove);
@@ -54,6 +61,7 @@ export function RemoveLocaleConfirmDialog({
 
       onRemoved(result.value);
       toast.success(`Removed locale ${localeToRemove}`);
+      onOpenChange(false);
     });
   };
 
@@ -68,7 +76,7 @@ export function RemoveLocaleConfirmDialog({
             </p>
           ) : null}
           <AlertDialogDescription>
-            This removes the language from the data datalog and deletes each
+            This removes the language from the data catalog and deletes each
             label translation from every item in this list. This cannot be
             undone from Hub without re-importing translations.
           </AlertDialogDescription>

--- a/features/data-lists/remove-locale/ui/remove-locale-confirm-dialog.tsx
+++ b/features/data-lists/remove-locale/ui/remove-locale-confirm-dialog.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { toast } from "@/components/ui/toast";
+import type { DataListDetails } from "@/lib/endatix-api/data-lists/types";
+import { Result } from "@/lib/result";
+import { useTransition } from "react";
+import { formatLocaleLabel } from "@/features/data-lists/translations/locale-discovery";
+import { removeLocaleAction } from "../remove-locale.action";
+
+export type RemoveLocaleConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  dataListId: string;
+  locale: string | null;
+  onRemoved: (details: DataListDetails) => void;
+};
+
+/**
+ * Confirms catalog locale removal (strips item labels for that culture).
+ */
+export function RemoveLocaleConfirmDialog({
+  open,
+  onOpenChange,
+  dataListId,
+  locale,
+  onRemoved,
+}: Readonly<RemoveLocaleConfirmDialogProps>) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleConfirm = (): void => {
+    if (locale === null) {
+      return;
+    }
+
+    const localeToRemove = locale;
+    onOpenChange(false);
+
+    startTransition(async () => {
+      const result = await removeLocaleAction(dataListId, localeToRemove);
+      if (Result.isError(result)) {
+        toast.error(result.message);
+        return;
+      }
+
+      onRemoved(result.value);
+      toast.success(`Removed locale ${localeToRemove}`);
+    });
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove locale?</AlertDialogTitle>
+          {locale ? (
+            <p className="text-base font-medium text-foreground">
+              {formatLocaleLabel(locale)}
+            </p>
+          ) : null}
+          <AlertDialogDescription>
+            This removes the locale from the catalog and deletes its labels from
+            every item in this list. This cannot be undone from Hub without
+            re-importing translations.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isPending || !locale}
+            onClick={handleConfirm}
+          >
+            Remove
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/features/data-lists/remove-locale/ui/remove-locale-confirm-dialog.tsx
+++ b/features/data-lists/remove-locale/ui/remove-locale-confirm-dialog.tsx
@@ -61,16 +61,16 @@ export function RemoveLocaleConfirmDialog({
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Remove locale?</AlertDialogTitle>
+          <AlertDialogTitle>Remove translation?</AlertDialogTitle>
           {locale ? (
             <p className="text-base font-medium text-foreground">
               {formatLocaleLabel(locale)}
             </p>
           ) : null}
           <AlertDialogDescription>
-            This removes the locale from the catalog and deletes its labels from
-            every item in this list. This cannot be undone from Hub without
-            re-importing translations.
+            This removes the language from the data datalog and deletes each
+            label translation from every item in this list. This cannot be
+            undone from Hub without re-importing translations.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/features/data-lists/replace-items/__tests__/replace-data-list-items.action.test.ts
+++ b/features/data-lists/replace-items/__tests__/replace-data-list-items.action.test.ts
@@ -98,7 +98,7 @@ describe("replaceDataListItemsAction", () => {
       return;
     }
     expect(result.message).toContain("At least one item");
-    expect(mockGetById).toHaveBeenCalledWith("42");
+    expect(mockGetById).not.toHaveBeenCalled();
     expect(mockReplaceItems).not.toHaveBeenCalled();
   });
 

--- a/features/data-lists/replace-items/__tests__/replace-data-list-items.action.test.ts
+++ b/features/data-lists/replace-items/__tests__/replace-data-list-items.action.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiResult } from "@/lib/endatix-api";
+import type { DataListChoiceItem } from "@/lib/endatix-api/data-lists/types";
+import { Result } from "@/lib/result";
+import { revalidatePath } from "next/cache";
+import { DATA_LIST_MAX_LOCALES } from "@/features/data-lists/import-limits";
+import { replaceDataListItemsAction } from "../replace-data-list-items.action";
+
+const { mockReplaceItems, mockRequireHubAccess, mockAuth } = vi.hoisted(() => ({
+  mockReplaceItems: vi.fn(),
+  mockRequireHubAccess: vi.fn(),
+  mockAuth: vi.fn(),
+}));
+
+vi.mock("@/auth", () => ({
+  auth: (...args: unknown[]) => mockAuth(...args),
+}));
+
+vi.mock("@/features/auth/authorization", () => ({
+  authorization: vi.fn(async () => ({
+    requireHubAccess: mockRequireHubAccess,
+  })),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/endatix-api", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/lib/endatix-api")>();
+  return {
+    ...mod,
+    EndatixApi: vi.fn().mockImplementation(function () {
+      return {
+        dataLists: {
+          replaceItems: mockReplaceItems,
+        },
+      };
+    }),
+  };
+});
+
+const details = {
+  id: "42",
+  name: "Countries",
+  isActive: true,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  itemsCount: 1,
+  availableLocales: ["en"],
+  items: [{ id: "1", value: "ch", labels: { default: "Switzerland" } }],
+};
+
+const validItems: DataListChoiceItem[] = [
+  { value: "apple", labels: { default: "Apple" } },
+];
+
+describe("replaceDataListItemsAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ accessToken: "token", isLoggedIn: true });
+    mockRequireHubAccess.mockResolvedValue(undefined);
+  });
+
+  it("returns validation error for an invalid data list id", async () => {
+    const result = await replaceDataListItemsAction("not-an-id", validItems);
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain("dataListId");
+    expect(mockReplaceItems).not.toHaveBeenCalled();
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("returns error for an invalid ensureLocales culture code", async () => {
+    const result = await replaceDataListItemsAction("42", validItems, ["!!!"]);
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain("valid culture code");
+    expect(mockReplaceItems).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty items via import payload guards before calling the API", async () => {
+    const result = await replaceDataListItemsAction("42", []);
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain("At least one item");
+    expect(mockReplaceItems).not.toHaveBeenCalled();
+  });
+
+  it("rejects ensureLocales that would exceed the catalog locale cap", async () => {
+    const ensureLocales = [
+      "fr",
+      "de",
+      "es",
+      "it",
+      "pt",
+      "nl",
+      "pl",
+      "sv",
+      "da",
+      "fi",
+      "cs",
+      "hu",
+      "ro",
+      "bg",
+      "el",
+      "tr",
+      "ja",
+      "ko",
+      "zh",
+      "ar",
+    ];
+    expect(ensureLocales).toHaveLength(DATA_LIST_MAX_LOCALES);
+
+    const result = await replaceDataListItemsAction(
+      "42",
+      validItems,
+      ensureLocales,
+      1,
+    );
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain(String(DATA_LIST_MAX_LOCALES));
+    expect(mockReplaceItems).not.toHaveBeenCalled();
+  });
+
+  it("normalizes locales, replaces items, and revalidates on success", async () => {
+    mockReplaceItems.mockResolvedValue(ApiResult.success(details));
+
+    const result = await replaceDataListItemsAction(
+      "42",
+      validItems,
+      [" FR ", "de"],
+      1,
+    );
+
+    expect(mockReplaceItems).toHaveBeenCalledWith("42", validItems, {
+      ensureLocales: ["fr", "de"],
+    });
+    expect(Result.isSuccess(result)).toBe(true);
+    if (!Result.isSuccess(result)) {
+      return;
+    }
+    expect(result.value.id).toBe("42");
+    expect(revalidatePath).toHaveBeenCalledWith("/data-lists/42");
+  });
+
+  it("defaults ensureLocales to an empty list when omitted", async () => {
+    mockReplaceItems.mockResolvedValue(ApiResult.success(details));
+
+    await replaceDataListItemsAction("42", validItems);
+
+    expect(mockReplaceItems).toHaveBeenCalledWith("42", validItems, {
+      ensureLocales: [],
+    });
+  });
+
+  it("does not revalidate when the API call fails", async () => {
+    mockReplaceItems.mockResolvedValue(
+      ApiResult.validationError("Replace failed"),
+    );
+
+    const result = await replaceDataListItemsAction("42", validItems);
+
+    expect(Result.isError(result)).toBe(true);
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("propagates requireHubAccess failures", async () => {
+    mockRequireHubAccess.mockRejectedValue(new Error("NEXT_REDIRECT"));
+
+    await expect(
+      replaceDataListItemsAction("42", validItems),
+    ).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockReplaceItems).not.toHaveBeenCalled();
+  });
+});

--- a/features/data-lists/replace-items/__tests__/replace-data-list-items.action.test.ts
+++ b/features/data-lists/replace-items/__tests__/replace-data-list-items.action.test.ts
@@ -6,11 +6,13 @@ import { revalidatePath } from "next/cache";
 import { DATA_LIST_MAX_LOCALES } from "@/features/data-lists/import-limits";
 import { replaceDataListItemsAction } from "../replace-data-list-items.action";
 
-const { mockReplaceItems, mockRequireHubAccess, mockAuth } = vi.hoisted(() => ({
-  mockReplaceItems: vi.fn(),
-  mockRequireHubAccess: vi.fn(),
-  mockAuth: vi.fn(),
-}));
+const { mockReplaceItems, mockGetById, mockRequireHubAccess, mockAuth } =
+  vi.hoisted(() => ({
+    mockReplaceItems: vi.fn(),
+    mockGetById: vi.fn(),
+    mockRequireHubAccess: vi.fn(),
+    mockAuth: vi.fn(),
+  }));
 
 vi.mock("@/auth", () => ({
   auth: (...args: unknown[]) => mockAuth(...args),
@@ -33,6 +35,7 @@ vi.mock("@/lib/endatix-api", async (importOriginal) => {
     EndatixApi: vi.fn().mockImplementation(function () {
       return {
         dataLists: {
+          getById: mockGetById,
           replaceItems: mockReplaceItems,
         },
       };
@@ -59,6 +62,7 @@ describe("replaceDataListItemsAction", () => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue({ accessToken: "token", isLoggedIn: true });
     mockRequireHubAccess.mockResolvedValue(undefined);
+    mockGetById.mockResolvedValue(ApiResult.success(details));
   });
 
   it("returns validation error for an invalid data list id", async () => {
@@ -69,6 +73,7 @@ describe("replaceDataListItemsAction", () => {
       return;
     }
     expect(result.message).toContain("dataListId");
+    expect(mockGetById).not.toHaveBeenCalled();
     expect(mockReplaceItems).not.toHaveBeenCalled();
     expect(revalidatePath).not.toHaveBeenCalled();
   });
@@ -81,10 +86,11 @@ describe("replaceDataListItemsAction", () => {
       return;
     }
     expect(result.message).toContain("valid culture code");
+    expect(mockGetById).not.toHaveBeenCalled();
     expect(mockReplaceItems).not.toHaveBeenCalled();
   });
 
-  it("rejects empty items via import payload guards before calling the API", async () => {
+  it("rejects empty items via import payload guards before calling replace", async () => {
     const result = await replaceDataListItemsAction("42", []);
 
     expect(Result.isError(result)).toBe(true);
@@ -92,10 +98,11 @@ describe("replaceDataListItemsAction", () => {
       return;
     }
     expect(result.message).toContain("At least one item");
+    expect(mockGetById).toHaveBeenCalledWith("42");
     expect(mockReplaceItems).not.toHaveBeenCalled();
   });
 
-  it("rejects ensureLocales that would exceed the catalog locale cap", async () => {
+  it("rejects ensureLocales that would exceed the server catalog locale cap", async () => {
     const ensureLocales = [
       "fr",
       "de",
@@ -124,7 +131,6 @@ describe("replaceDataListItemsAction", () => {
       "42",
       validItems,
       ensureLocales,
-      1,
     );
 
     expect(Result.isError(result)).toBe(true);
@@ -138,12 +144,10 @@ describe("replaceDataListItemsAction", () => {
   it("normalizes locales, replaces items, and revalidates on success", async () => {
     mockReplaceItems.mockResolvedValue(ApiResult.success(details));
 
-    const result = await replaceDataListItemsAction(
-      "42",
-      validItems,
-      [" FR ", "de"],
-      1,
-    );
+    const result = await replaceDataListItemsAction("42", validItems, [
+      " FR ",
+      "de",
+    ]);
 
     expect(mockReplaceItems).toHaveBeenCalledWith("42", validItems, {
       ensureLocales: ["fr", "de"],
@@ -180,9 +184,9 @@ describe("replaceDataListItemsAction", () => {
   it("propagates requireHubAccess failures", async () => {
     mockRequireHubAccess.mockRejectedValue(new Error("NEXT_REDIRECT"));
 
-    await expect(
-      replaceDataListItemsAction("42", validItems),
-    ).rejects.toThrow("NEXT_REDIRECT");
+    await expect(replaceDataListItemsAction("42", validItems)).rejects.toThrow(
+      "NEXT_REDIRECT",
+    );
     expect(mockReplaceItems).not.toHaveBeenCalled();
   });
 });

--- a/features/data-lists/replace-items/replace-data-list-items.action.ts
+++ b/features/data-lists/replace-items/replace-data-list-items.action.ts
@@ -20,7 +20,6 @@ export async function replaceDataListItemsAction(
   dataListId: string,
   items: DataListChoiceItem[],
   ensureLocales: string[] = [],
-  catalogLocaleCount = 0,
 ): Promise<ReplaceDataListItemsResult> {
   const session = await auth();
   const { requireHubAccess } = await authorization(session);
@@ -38,6 +37,17 @@ export async function replaceDataListItemsAction(
     );
   }
 
+  const api = new EndatixApi(session?.accessToken);
+  const detailsResult = toResult(await api.dataLists.getById(idResult.value), {
+    fallbackMessage: "Failed to load data list",
+    logMessage: "Failed to load data list before replace",
+    loggerName: "data-lists.replaceItems",
+  });
+  if (Result.isError(detailsResult)) {
+    return detailsResult;
+  }
+
+  const catalogLocaleCount = detailsResult.value.availableLocales?.length ?? 0;
   const payloadGuard = guardImportPayload({
     format: "json",
     items,
@@ -48,7 +58,6 @@ export async function replaceDataListItemsAction(
     return payloadGuard;
   }
 
-  const api = new EndatixApi(session?.accessToken);
   const result = toResult(
     await api.dataLists.replaceItems(idResult.value, items, {
       ensureLocales: localesResult.value,

--- a/features/data-lists/replace-items/replace-data-list-items.action.ts
+++ b/features/data-lists/replace-items/replace-data-list-items.action.ts
@@ -2,7 +2,10 @@
 
 import { auth } from "@/auth";
 import { authorization } from "@/features/auth/authorization";
-import { guardImportPayload } from "@/features/data-lists/import-payload-guards";
+import {
+  guardEnsureLocalesCount,
+  guardJsonImportItems,
+} from "@/features/data-lists/import-payload-guards";
 import { EndatixApi } from "@/lib/endatix-api";
 import type {
   DataListChoiceItem,
@@ -37,6 +40,18 @@ export async function replaceDataListItemsAction(
     );
   }
 
+  // Validate payload shape before the details fetch so empty/oversized imports
+  // fail fast without a getById round-trip.
+  const itemsGuard = guardJsonImportItems(items);
+  if (Result.isError(itemsGuard)) {
+    return itemsGuard;
+  }
+
+  const earlyLocalesGuard = guardEnsureLocalesCount(localesResult.value, []);
+  if (Result.isError(earlyLocalesGuard)) {
+    return earlyLocalesGuard;
+  }
+
   const api = new EndatixApi(session?.accessToken);
   const detailsResult = toResult(await api.dataLists.getById(idResult.value), {
     fallbackMessage: "Failed to load data list",
@@ -47,15 +62,12 @@ export async function replaceDataListItemsAction(
     return detailsResult;
   }
 
-  const catalogLocaleCount = detailsResult.value.availableLocales?.length ?? 0;
-  const payloadGuard = guardImportPayload({
-    format: "json",
-    items,
-    ensureLocales: localesResult.value,
-    catalogLocaleCount,
-  });
-  if (Result.isError(payloadGuard)) {
-    return payloadGuard;
+  const localesGuard = guardEnsureLocalesCount(
+    localesResult.value,
+    detailsResult.value.availableLocales ?? [],
+  );
+  if (Result.isError(localesGuard)) {
+    return localesGuard;
   }
 
   const result = toResult(

--- a/features/data-lists/replace-items/replace-data-list-items.action.ts
+++ b/features/data-lists/replace-items/replace-data-list-items.action.ts
@@ -2,6 +2,7 @@
 
 import { auth } from "@/auth";
 import { authorization } from "@/features/auth/authorization";
+import { guardImportPayload } from "@/features/data-lists/import-payload-guards";
 import { EndatixApi } from "@/lib/endatix-api";
 import type {
   DataListChoiceItem,
@@ -10,6 +11,7 @@ import type {
 import { normalizeCultureCodes } from "@/lib/localization";
 import { Result } from "@/lib/result";
 import { toResult } from "@/lib/result/map-api-result-to-result";
+import { validateEndatixId } from "@/lib/utils/type-validators";
 import { revalidatePath } from "next/cache";
 
 export type ReplaceDataListItemsResult = Result<DataListDetails>;
@@ -18,10 +20,16 @@ export async function replaceDataListItemsAction(
   dataListId: string,
   items: DataListChoiceItem[],
   ensureLocales: string[] = [],
+  catalogLocaleCount = 0,
 ): Promise<ReplaceDataListItemsResult> {
   const session = await auth();
   const { requireHubAccess } = await authorization(session);
   await requireHubAccess();
+
+  const idResult = validateEndatixId(dataListId, "dataListId");
+  if (Result.isError(idResult)) {
+    return idResult;
+  }
 
   const localesResult = normalizeCultureCodes(ensureLocales);
   if (!localesResult.ok) {
@@ -30,9 +38,19 @@ export async function replaceDataListItemsAction(
     );
   }
 
+  const payloadGuard = guardImportPayload({
+    format: "json",
+    items,
+    ensureLocales: localesResult.value,
+    catalogLocaleCount,
+  });
+  if (Result.isError(payloadGuard)) {
+    return payloadGuard;
+  }
+
   const api = new EndatixApi(session?.accessToken);
   const result = toResult(
-    await api.dataLists.replaceItems(dataListId, items, {
+    await api.dataLists.replaceItems(idResult.value, items, {
       ensureLocales: localesResult.value,
     }),
     {
@@ -43,7 +61,7 @@ export async function replaceDataListItemsAction(
   );
 
   if (Result.isSuccess(result)) {
-    revalidatePath(`/data-lists/${dataListId}`);
+    revalidatePath(`/data-lists/${idResult.value}`);
   }
 
   return result;

--- a/features/data-lists/replace-items/ui/replace-items-dialog.tsx
+++ b/features/data-lists/replace-items/ui/replace-items-dialog.tsx
@@ -14,7 +14,13 @@ import { toast } from "@/components/ui/toast";
 import type { DataListDetails } from "@/lib/endatix-api/data-lists/types";
 import { Result } from "@/lib/result";
 import { Upload } from "lucide-react";
-import { useEffect, useRef, useState, useTransition } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  useTransition,
+  type ReactNode,
+} from "react";
 import { replaceDataListItemsAction } from "../replace-data-list-items.action";
 import {
   DataListItemsInput,
@@ -23,7 +29,7 @@ import {
 import { DataListValidationPreview } from "../../add-items/data-list-validation-preview";
 import { DataListCsvPreview } from "../../add-items/data-list-csv-preview";
 import { useDataListSource } from "../../add-items/use-data-list-source.hook";
-import { LocaleImportConfirmDialog } from "../../translations/locale-import-confirm-dialog";
+import { LocaleImportConfirmPanel } from "../../translations/locale-import-confirm-dialog";
 import {
   discoverLocalesFromJsonItems,
   filterJsonItemsByLocales,
@@ -46,11 +52,11 @@ interface ReplaceItemsDialogProps {
   onReplaced?: (details: DataListDetails) => void;
 }
 
-type ReplaceStep = 1 | 2;
+type ReplaceStep = 1 | 2 | 3;
 
 /**
  * Replace all items via CSV or JSON upload.
- * Step 1: source · Step 2: preview · then locale confirm.
+ * Step 1: source · Step 2: preview · Step 3: locale confirm.
  */
 export function ReplaceItemsDialog({
   open,
@@ -64,7 +70,6 @@ export function ReplaceItemsDialog({
 }: Readonly<ReplaceItemsDialogProps>) {
   const [step, setStep] = useState<ReplaceStep>(1);
   const [isPending, startTransition] = useTransition();
-  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [pendingDiscovery, setPendingDiscovery] =
     useState<LocaleImportDiscovery | null>(null);
   const advanceAfterUploadRef = useRef(false);
@@ -77,6 +82,7 @@ export function ReplaceItemsDialog({
     csvDiscovery,
     canConfirm,
     hasSourceContent,
+    sourceError,
     validationError: fileValidationError,
     selectedFileName,
     setValidationError,
@@ -88,6 +94,7 @@ export function ReplaceItemsDialog({
     initialFormat,
   });
 
+  const displayError = fileValidationError ?? sourceError;
   const handleFileSelectedWithAdvance = async (
     file: File | null,
   ): Promise<void> => {
@@ -99,7 +106,6 @@ export function ReplaceItemsDialog({
     if (!open) {
       resetFileHandler();
       setStep(1);
-      setIsConfirmOpen(false);
       setPendingDiscovery(null);
       advanceAfterUploadRef.current = false;
     }
@@ -126,11 +132,11 @@ export function ReplaceItemsDialog({
 
   const handleContinue = (): void => {
     if (!canConfirm) {
-      setValidationError(
-        format === "csv"
-          ? "Please provide a valid translations CSV."
-          : "Please fix validation errors before continuing.",
-      );
+      let fallbackError = "Please fix validation errors before continuing.";
+      if (format === "csv") {
+        fallbackError = "Please provide a valid translations CSV.";
+      }
+      setValidationError(sourceError ?? fallbackError);
       return;
     }
 
@@ -150,13 +156,13 @@ export function ReplaceItemsDialog({
           defaultLocale,
         }),
       );
-      setIsConfirmOpen(true);
+      setStep(3);
       return;
     }
 
     if (format === "csv" && csvDiscovery) {
       setPendingDiscovery(csvDiscovery);
-      setIsConfirmOpen(true);
+      setStep(3);
     }
   };
 
@@ -176,6 +182,7 @@ export function ReplaceItemsDialog({
           dataListId,
           csv,
           ensureLocales: selection.ensureLocales,
+          catalogLocaleCount: availableLocales.length,
         });
 
         if (Result.isError(uploadResult)) {
@@ -186,6 +193,7 @@ export function ReplaceItemsDialog({
         onReplaced?.(uploadResult.value);
       } else {
         if (!validation) {
+          toast.error("JSON validation is missing. Please re-upload the file.");
           return;
         }
 
@@ -198,6 +206,7 @@ export function ReplaceItemsDialog({
           dataListId,
           items,
           selection.ensureLocales,
+          availableLocales.length,
         );
 
         if (Result.isError(replaceResult)) {
@@ -208,58 +217,73 @@ export function ReplaceItemsDialog({
         onReplaced?.(replaceResult.value);
       }
 
-      toast.success("Items replaced successfully");
-      setIsConfirmOpen(false);
       onOpenChange(false);
     });
   };
 
-  return (
+  let stepDescription: ReactNode = (
     <>
-      <Dialog open={open} onOpenChange={onOpenChange} modal={!isConfirmOpen}>
-        <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col overflow-hidden p-0">
-          <DialogHeader className="border-b px-6 py-4">
-            <DialogTitle>Replace Items</DialogTitle>
-            <DialogDescription>
-              {step === 1 ? (
-                <>
-                  Upload CSV or JSON to replace all items in{" "}
-                  <span className="font-medium">{title}</span>.
-                </>
-              ) : (
-                "Review the import preview before choosing locales."
-              )}
-            </DialogDescription>
-          </DialogHeader>
+      Upload CSV or JSON to replace all items in{" "}
+      <span className="font-medium">{title}</span>.
+    </>
+  );
+  if (step === 2) {
+    stepDescription = "Review the import preview before choosing locales.";
+  } else if (step === 3) {
+    stepDescription = "Choose which locales to import.";
+  }
 
-          <div className="flex-1 space-y-6 overflow-y-auto px-6 py-4">
-            {step === 1 ? (
-              <>
-                <DataListItemsInput
-                  format={format}
-                  onFormatChange={setFormat}
-                  onFileSelected={handleFileSelectedWithAdvance}
-                  selectedFileName={selectedFileName}
-                  fileInputId="replace-data-list-file-upload"
-                />
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col overflow-hidden p-0">
+        <DialogHeader className="border-b px-6 py-4">
+          <DialogTitle>Replace Items</DialogTitle>
+          <DialogDescription>{stepDescription}</DialogDescription>
+        </DialogHeader>
 
-                {fileValidationError ? (
-                  <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-                    {fileValidationError}
-                  </div>
-                ) : null}
-              </>
-            ) : null}
+        <div className="flex-1 space-y-6 overflow-y-auto px-6 py-4">
+          {step === 1 ? (
+            <>
+              <DataListItemsInput
+                format={format}
+                onFormatChange={setFormat}
+                onFileSelected={handleFileSelectedWithAdvance}
+                selectedFileName={selectedFileName}
+                fileInputId="replace-data-list-file-upload"
+              />
 
-            {step === 2 && format === "json" && validation ? (
-              <DataListValidationPreview validation={validation} />
-            ) : null}
+              {displayError ? (
+                <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+                  {displayError}
+                </div>
+              ) : null}
+            </>
+          ) : null}
 
-            {step === 2 && format === "csv" && csvDiscovery ? (
-              <DataListCsvPreview discovery={csvDiscovery} />
-            ) : null}
-          </div>
+          {step === 2 && format === "json" && validation ? (
+            <DataListValidationPreview validation={validation} />
+          ) : null}
 
+          {step === 2 && format === "csv" && csvDiscovery ? (
+            <DataListCsvPreview discovery={csvDiscovery} />
+          ) : null}
+
+          {step === 3 ? (
+            <LocaleImportConfirmPanel
+              title={
+                format === "csv" ? "Confirm CSV import" : "Confirm JSON import"
+              }
+              mode="replace"
+              discovery={pendingDiscovery}
+              catalogLocaleCount={availableLocales.length}
+              isPending={isPending}
+              onCancel={() => setStep(2)}
+              onConfirm={handleConfirmReplace}
+            />
+          ) : null}
+        </div>
+
+        {step !== 3 ? (
           <DialogFooter className="border-t px-6 py-4">
             {step === 2 ? (
               <Button variant="outline" onClick={() => setStep(1)}>
@@ -294,19 +318,8 @@ export function ReplaceItemsDialog({
               </Button>
             )}
           </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <LocaleImportConfirmDialog
-        open={isConfirmOpen}
-        onOpenChange={setIsConfirmOpen}
-        title={format === "csv" ? "Confirm CSV import" : "Confirm JSON import"}
-        mode="replace"
-        discovery={pendingDiscovery}
-        catalogLocaleCount={availableLocales.length}
-        isPending={isPending}
-        onConfirm={handleConfirmReplace}
-      />
-    </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/features/data-lists/replace-items/ui/replace-items-dialog.tsx
+++ b/features/data-lists/replace-items/ui/replace-items-dialog.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Spinner } from "@/components/loaders/spinner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -182,7 +181,6 @@ export function ReplaceItemsDialog({
           dataListId,
           csv,
           ensureLocales: selection.ensureLocales,
-          catalogLocaleCount: availableLocales.length,
         });
 
         if (Result.isError(uploadResult)) {
@@ -206,7 +204,6 @@ export function ReplaceItemsDialog({
           dataListId,
           items,
           selection.ensureLocales,
-          availableLocales.length,
         );
 
         if (Result.isError(replaceResult)) {
@@ -300,21 +297,9 @@ export function ReplaceItemsDialog({
                 Continue
               </Button>
             ) : (
-              <Button
-                onClick={handleReviewLocales}
-                disabled={!canConfirm || isPending}
-              >
-                {isPending ? (
-                  <>
-                    <Spinner className="mr-1 h-4 w-4" />
-                    Replacing...
-                  </>
-                ) : (
-                  <>
-                    <Upload className="h-4 w-4" />
-                    Review locales
-                  </>
-                )}
+              <Button onClick={handleReviewLocales} disabled={!canConfirm}>
+                <Upload className="h-4 w-4" />
+                Review locales
               </Button>
             )}
           </DialogFooter>

--- a/features/data-lists/replace-items/ui/replace-items-dialog.tsx
+++ b/features/data-lists/replace-items/ui/replace-items-dialog.tsx
@@ -151,7 +151,7 @@ function reportReplaceImportResult(
   onOpenChange(false);
 }
 
-function ReplaceItemsDialogBody(props: {
+interface ReplaceItemsDialogBodyProps {
   step: ReplaceStep;
   format: DataListSourceFormat;
   validation: ParsedValidation | null;
@@ -165,7 +165,11 @@ function ReplaceItemsDialogBody(props: {
   onFileSelected: (file: File | null) => Promise<void>;
   setStep: (step: ReplaceStep) => void;
   onConfirmReplace: (selection: LocaleImportSelection) => void;
-}): ReactNode {
+}
+
+function ReplaceItemsDialogBody(
+  props: Readonly<ReplaceItemsDialogBodyProps>,
+): ReactNode {
   const {
     step,
     format,
@@ -227,7 +231,7 @@ function ReplaceItemsDialogBody(props: {
   return null;
 }
 
-function ReplaceItemsDialogFooter(props: {
+interface ReplaceItemsDialogFooterProps {
   step: ReplaceStep;
   hasSourceContent: boolean;
   canConfirm: boolean;
@@ -235,7 +239,11 @@ function ReplaceItemsDialogFooter(props: {
   onContinue: () => void;
   onReviewLocales: () => void;
   setStep: (step: ReplaceStep) => void;
-}): ReactNode {
+}
+
+function ReplaceItemsDialogFooter(
+  props: Readonly<ReplaceItemsDialogFooterProps>,
+): ReactNode {
   const {
     step,
     hasSourceContent,

--- a/features/data-lists/replace-items/ui/replace-items-dialog.tsx
+++ b/features/data-lists/replace-items/ui/replace-items-dialog.tsx
@@ -158,6 +158,7 @@ interface ReplaceItemsDialogBodyProps {
   csvDiscovery: LocaleImportDiscovery | null;
   pendingDiscovery: LocaleImportDiscovery | null;
   displayError: string | null;
+  displayWarning: string | null;
   selectedFileName: string | null;
   availableLocalesCount: number;
   isPending: boolean;
@@ -177,6 +178,7 @@ function ReplaceItemsDialogBody(
     csvDiscovery,
     pendingDiscovery,
     displayError,
+    displayWarning,
     selectedFileName,
     availableLocalesCount,
     isPending,
@@ -200,6 +202,12 @@ function ReplaceItemsDialogBody(
         {displayError ? (
           <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
             {displayError}
+          </div>
+        ) : null}
+
+        {!displayError && displayWarning ? (
+          <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-sm text-amber-800 dark:text-amber-300">
+            {displayWarning}
           </div>
         ) : null}
       </>
@@ -313,6 +321,7 @@ export function ReplaceItemsDialog({
     canConfirm,
     hasSourceContent,
     sourceError,
+    sourceWarning,
     validationError: fileValidationError,
     selectedFileName,
     setValidationError,
@@ -325,6 +334,7 @@ export function ReplaceItemsDialog({
   });
 
   const displayError = fileValidationError ?? sourceError;
+  const displayWarning = displayError ? null : sourceWarning;
 
   const handleFileSelectedWithAdvance = async (
     file: File | null,
@@ -438,6 +448,7 @@ export function ReplaceItemsDialog({
             csvDiscovery={csvDiscovery}
             pendingDiscovery={pendingDiscovery}
             displayError={displayError}
+            displayWarning={displayWarning}
             selectedFileName={selectedFileName}
             availableLocalesCount={availableLocales.length}
             isPending={isPending}

--- a/features/data-lists/replace-items/ui/replace-items-dialog.tsx
+++ b/features/data-lists/replace-items/ui/replace-items-dialog.tsx
@@ -39,6 +39,7 @@ import type {
   LocaleImportDiscovery,
   LocaleImportSelection,
 } from "../../translations/locale-discovery";
+import type { ParsedValidation } from "../../types";
 
 interface ReplaceItemsDialogProps {
   open: boolean;
@@ -52,6 +53,228 @@ interface ReplaceItemsDialogProps {
 }
 
 type ReplaceStep = 1 | 2 | 3;
+
+function resolveReplaceStepDescription(
+  step: ReplaceStep,
+  title: string,
+): ReactNode {
+  if (step === 2) {
+    return "Review the import preview before choosing locales.";
+  }
+
+  if (step === 3) {
+    return "Choose which locales to import.";
+  }
+
+  return (
+    <>
+      Upload CSV or JSON to replace all items in{" "}
+      <span className="font-medium">{title}</span>.
+    </>
+  );
+}
+
+function resolvePendingDiscovery(args: {
+  format: DataListSourceFormat;
+  validation: ParsedValidation | null;
+  csvDiscovery: LocaleImportDiscovery | null;
+  availableLocales: string[];
+  defaultLocale?: string;
+}): LocaleImportDiscovery | null {
+  const { format, validation, csvDiscovery, availableLocales, defaultLocale } =
+    args;
+
+  if (format === "json" && validation) {
+    return discoverLocalesFromJsonItems(validation.validItems, {
+      availableLocales,
+      defaultLocale,
+    });
+  }
+
+  if (format === "csv" && csvDiscovery) {
+    return csvDiscovery;
+  }
+
+  return null;
+}
+
+async function runReplaceImport(args: {
+  format: DataListSourceFormat;
+  dataListId: string;
+  csvInput: string;
+  validation: ParsedValidation | null;
+  selection: LocaleImportSelection;
+  defaultLocale?: string;
+}): Promise<Result<DataListDetails> | null> {
+  const { format, dataListId, csvInput, validation, selection, defaultLocale } =
+    args;
+
+  if (format === "csv") {
+    return uploadTranslationsCsvAction({
+      dataListId,
+      csv: filterTranslationsCsv(
+        csvInput,
+        selection.includedLocales,
+        defaultLocale,
+      ),
+      ensureLocales: selection.ensureLocales,
+    });
+  }
+
+  if (!validation) {
+    return null;
+  }
+
+  return replaceDataListItemsAction(
+    dataListId,
+    filterJsonItemsByLocales(
+      validation.validItems,
+      selection.includedLocales,
+      defaultLocale,
+    ),
+    selection.ensureLocales,
+  );
+}
+
+function reportReplaceImportResult(
+  importResult: Result<DataListDetails>,
+  onReplaced: ((details: DataListDetails) => void) | undefined,
+  onOpenChange: (open: boolean) => void,
+  failureFallback: string,
+): void {
+  if (Result.isError(importResult)) {
+    toast.error(importResult.message || failureFallback);
+    return;
+  }
+
+  onReplaced?.(importResult.value);
+  onOpenChange(false);
+}
+
+function ReplaceItemsDialogBody(props: {
+  step: ReplaceStep;
+  format: DataListSourceFormat;
+  validation: ParsedValidation | null;
+  csvDiscovery: LocaleImportDiscovery | null;
+  pendingDiscovery: LocaleImportDiscovery | null;
+  displayError: string | null;
+  selectedFileName: string | null;
+  availableLocalesCount: number;
+  isPending: boolean;
+  setFormat: (format: DataListSourceFormat) => void;
+  onFileSelected: (file: File | null) => Promise<void>;
+  setStep: (step: ReplaceStep) => void;
+  onConfirmReplace: (selection: LocaleImportSelection) => void;
+}): ReactNode {
+  const {
+    step,
+    format,
+    validation,
+    csvDiscovery,
+    pendingDiscovery,
+    displayError,
+    selectedFileName,
+    availableLocalesCount,
+    isPending,
+    setFormat,
+    onFileSelected,
+    setStep,
+    onConfirmReplace,
+  } = props;
+
+  if (step === 1) {
+    return (
+      <>
+        <DataListItemsInput
+          format={format}
+          onFormatChange={setFormat}
+          onFileSelected={onFileSelected}
+          selectedFileName={selectedFileName}
+          fileInputId="replace-data-list-file-upload"
+        />
+
+        {displayError ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+            {displayError}
+          </div>
+        ) : null}
+      </>
+    );
+  }
+
+  if (step === 2 && format === "json" && validation) {
+    return <DataListValidationPreview validation={validation} />;
+  }
+
+  if (step === 2 && format === "csv" && csvDiscovery) {
+    return <DataListCsvPreview discovery={csvDiscovery} />;
+  }
+
+  if (step === 3) {
+    return (
+      <LocaleImportConfirmPanel
+        title={format === "csv" ? "Confirm CSV import" : "Confirm JSON import"}
+        mode="replace"
+        discovery={pendingDiscovery}
+        catalogLocaleCount={availableLocalesCount}
+        isPending={isPending}
+        onCancel={() => setStep(2)}
+        onConfirm={onConfirmReplace}
+      />
+    );
+  }
+
+  return null;
+}
+
+function ReplaceItemsDialogFooter(props: {
+  step: ReplaceStep;
+  hasSourceContent: boolean;
+  canConfirm: boolean;
+  onOpenChange: (open: boolean) => void;
+  onContinue: () => void;
+  onReviewLocales: () => void;
+  setStep: (step: ReplaceStep) => void;
+}): ReactNode {
+  const {
+    step,
+    hasSourceContent,
+    canConfirm,
+    onOpenChange,
+    onContinue,
+    onReviewLocales,
+    setStep,
+  } = props;
+
+  if (step === 3) {
+    return null;
+  }
+
+  return (
+    <DialogFooter className="border-t px-6 py-4">
+      {step === 2 ? (
+        <Button variant="outline" onClick={() => setStep(1)}>
+          Back
+        </Button>
+      ) : (
+        <Button variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+      )}
+
+      {step === 1 ? (
+        <Button onClick={onContinue} disabled={!hasSourceContent}>
+          Continue
+        </Button>
+      ) : (
+        <Button onClick={onReviewLocales} disabled={!canConfirm}>
+          <Upload className="h-4 w-4" />
+          Review locales
+        </Button>
+      )}
+    </DialogFooter>
+  );
+}
 
 /**
  * Replace all items via CSV or JSON upload.
@@ -94,6 +317,7 @@ export function ReplaceItemsDialog({
   });
 
   const displayError = fileValidationError ?? sourceError;
+
   const handleFileSelectedWithAdvance = async (
     file: File | null,
   ): Promise<void> => {
@@ -111,11 +335,7 @@ export function ReplaceItemsDialog({
   }, [open, resetFileHandler]);
 
   useEffect(() => {
-    if (!advanceAfterUploadRef.current || step !== 1) {
-      return;
-    }
-
-    if (!hasSourceContent) {
+    if (!advanceAfterUploadRef.current || step !== 1 || !hasSourceContent) {
       return;
     }
 
@@ -131,10 +351,10 @@ export function ReplaceItemsDialog({
 
   const handleContinue = (): void => {
     if (!canConfirm) {
-      let fallbackError = "Please fix validation errors before continuing.";
-      if (format === "csv") {
-        fallbackError = "Please provide a valid translations CSV.";
-      }
+      const fallbackError =
+        format === "csv"
+          ? "Please provide a valid translations CSV."
+          : "Please fix validation errors before continuing.";
       setValidationError(sourceError ?? fallbackError);
       return;
     }
@@ -148,21 +368,19 @@ export function ReplaceItemsDialog({
       return;
     }
 
-    if (format === "json" && validation) {
-      setPendingDiscovery(
-        discoverLocalesFromJsonItems(validation.validItems, {
-          availableLocales,
-          defaultLocale,
-        }),
-      );
-      setStep(3);
+    const discovery = resolvePendingDiscovery({
+      format,
+      validation,
+      csvDiscovery,
+      availableLocales,
+      defaultLocale,
+    });
+    if (!discovery) {
       return;
     }
 
-    if (format === "csv" && csvDiscovery) {
-      setPendingDiscovery(csvDiscovery);
-      setStep(3);
-    }
+    setPendingDiscovery(discovery);
+    setStep(3);
   };
 
   const handleConfirmReplace = (selection: LocaleImportSelection): void => {
@@ -171,139 +389,66 @@ export function ReplaceItemsDialog({
     }
 
     startTransition(async () => {
-      if (format === "csv") {
-        const csv = filterTranslationsCsv(
-          csvInput,
-          selection.includedLocales,
-          defaultLocale,
-        );
-        const uploadResult = await uploadTranslationsCsvAction({
-          dataListId,
-          csv,
-          ensureLocales: selection.ensureLocales,
-        });
+      const importResult = await runReplaceImport({
+        format,
+        dataListId,
+        csvInput,
+        validation,
+        selection,
+        defaultLocale,
+      });
 
-        if (Result.isError(uploadResult)) {
-          toast.error(uploadResult.message || "Failed to import CSV");
-          return;
-        }
-
-        onReplaced?.(uploadResult.value);
-      } else {
-        if (!validation) {
-          toast.error("JSON validation is missing. Please re-upload the file.");
-          return;
-        }
-
-        const items = filterJsonItemsByLocales(
-          validation.validItems,
-          selection.includedLocales,
-          defaultLocale,
-        );
-        const replaceResult = await replaceDataListItemsAction(
-          dataListId,
-          items,
-          selection.ensureLocales,
-        );
-
-        if (Result.isError(replaceResult)) {
-          toast.error(replaceResult.message || "Failed to replace items");
-          return;
-        }
-
-        onReplaced?.(replaceResult.value);
+      if (importResult === null) {
+        toast.error("JSON validation is missing. Please re-upload the file.");
+        return;
       }
 
-      onOpenChange(false);
+      reportReplaceImportResult(
+        importResult,
+        onReplaced,
+        onOpenChange,
+        format === "csv" ? "Failed to import CSV" : "Failed to replace items",
+      );
     });
   };
-
-  let stepDescription: ReactNode = (
-    <>
-      Upload CSV or JSON to replace all items in{" "}
-      <span className="font-medium">{title}</span>.
-    </>
-  );
-  if (step === 2) {
-    stepDescription = "Review the import preview before choosing locales.";
-  } else if (step === 3) {
-    stepDescription = "Choose which locales to import.";
-  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col overflow-hidden p-0">
         <DialogHeader className="border-b px-6 py-4">
           <DialogTitle>Replace Items</DialogTitle>
-          <DialogDescription>{stepDescription}</DialogDescription>
+          <DialogDescription>
+            {resolveReplaceStepDescription(step, title)}
+          </DialogDescription>
         </DialogHeader>
 
         <div className="flex-1 space-y-6 overflow-y-auto px-6 py-4">
-          {step === 1 ? (
-            <>
-              <DataListItemsInput
-                format={format}
-                onFormatChange={setFormat}
-                onFileSelected={handleFileSelectedWithAdvance}
-                selectedFileName={selectedFileName}
-                fileInputId="replace-data-list-file-upload"
-              />
-
-              {displayError ? (
-                <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-                  {displayError}
-                </div>
-              ) : null}
-            </>
-          ) : null}
-
-          {step === 2 && format === "json" && validation ? (
-            <DataListValidationPreview validation={validation} />
-          ) : null}
-
-          {step === 2 && format === "csv" && csvDiscovery ? (
-            <DataListCsvPreview discovery={csvDiscovery} />
-          ) : null}
-
-          {step === 3 ? (
-            <LocaleImportConfirmPanel
-              title={
-                format === "csv" ? "Confirm CSV import" : "Confirm JSON import"
-              }
-              mode="replace"
-              discovery={pendingDiscovery}
-              catalogLocaleCount={availableLocales.length}
-              isPending={isPending}
-              onCancel={() => setStep(2)}
-              onConfirm={handleConfirmReplace}
-            />
-          ) : null}
+          <ReplaceItemsDialogBody
+            step={step}
+            format={format}
+            validation={validation}
+            csvDiscovery={csvDiscovery}
+            pendingDiscovery={pendingDiscovery}
+            displayError={displayError}
+            selectedFileName={selectedFileName}
+            availableLocalesCount={availableLocales.length}
+            isPending={isPending}
+            setFormat={setFormat}
+            onFileSelected={handleFileSelectedWithAdvance}
+            setStep={setStep}
+            onConfirmReplace={handleConfirmReplace}
+          />
         </div>
 
-        {step !== 3 ? (
-          <DialogFooter className="border-t px-6 py-4">
-            {step === 2 ? (
-              <Button variant="outline" onClick={() => setStep(1)}>
-                Back
-              </Button>
-            ) : (
-              <Button variant="outline" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-            )}
-
-            {step === 1 ? (
-              <Button onClick={handleContinue} disabled={!hasSourceContent}>
-                Continue
-              </Button>
-            ) : (
-              <Button onClick={handleReviewLocales} disabled={!canConfirm}>
-                <Upload className="h-4 w-4" />
-                Review locales
-              </Button>
-            )}
-          </DialogFooter>
-        ) : null}
+        <ReplaceItemsDialogFooter
+          step={step}
+          hasSourceContent={hasSourceContent}
+          canConfirm={canConfirm}
+          onOpenChange={onOpenChange}
+          onContinue={handleContinue}
+          onReviewLocales={handleReviewLocales}
+          setStep={setStep}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/features/data-lists/translations/__tests__/locale-discovery.test.ts
+++ b/features/data-lists/translations/__tests__/locale-discovery.test.ts
@@ -67,17 +67,18 @@ describe("locale discovery", () => {
     expect(discovery.canProceed).toBe(false);
   });
 
-  it("rejects case-only duplicate locale columns", () => {
+  it("warns on case-only duplicate locale columns without blocking import", () => {
     const discovery = discoverLocalesFromTranslationsCsv(
       "value,default,es,ES\r\napple,Apple,Manzana,MANZANA\r\n",
       { availableLocales: [], defaultLocale: "en" },
     );
 
-    expect(discovery.canProceed).toBe(false);
-    expect(discovery.invalidLocales).toContain("ES");
+    expect(discovery.canProceed).toBe(true);
+    expect(discovery.invalidLocales).not.toContain("ES");
+    expect(discovery.structuralErrors).toEqual([]);
     expect(
-      discovery.structuralErrors.some((error) =>
-        error.includes("Duplicate locale column 'ES'"),
+      discovery.warnings.some((warning) =>
+        warning.includes("Duplicate locale column 'ES'"),
       ),
     ).toBe(true);
     expect(discovery.newLocales).toEqual(["es"]);
@@ -93,18 +94,18 @@ describe("locale discovery", () => {
     expect(filtered).toBe("value,default,es\r\napple,Apple,Manzana\r\n");
   });
 
-  it("rejects duplicate columns that alias to the default locale", () => {
+  it("warns on duplicate columns that alias to the default locale without blocking", () => {
     const discovery = discoverLocalesFromKeys(
       ["default", "en", "es"],
       { availableLocales: [], defaultLocale: "en" },
       1,
     );
 
-    expect(discovery.canProceed).toBe(false);
-    expect(discovery.invalidLocales).toContain("en");
+    expect(discovery.canProceed).toBe(true);
+    expect(discovery.invalidLocales).not.toContain("en");
     expect(
-      discovery.structuralErrors.some((error) =>
-        error.includes("Duplicate locale column 'en'"),
+      discovery.warnings.some((warning) =>
+        warning.includes("Duplicate locale column 'en'"),
       ),
     ).toBe(true);
     expect(

--- a/features/data-lists/translations/__tests__/locale-discovery.test.ts
+++ b/features/data-lists/translations/__tests__/locale-discovery.test.ts
@@ -75,6 +75,11 @@ describe("locale discovery", () => {
 
     expect(discovery.canProceed).toBe(false);
     expect(discovery.invalidLocales).toContain("ES");
+    expect(
+      discovery.structuralErrors.some((error) =>
+        error.includes("Duplicate locale column 'ES'"),
+      ),
+    ).toBe(true);
     expect(discovery.newLocales).toEqual(["es"]);
     expect(
       discovery.columns.filter((column) => column.key === "es"),
@@ -97,6 +102,11 @@ describe("locale discovery", () => {
 
     expect(discovery.canProceed).toBe(false);
     expect(discovery.invalidLocales).toContain("en");
+    expect(
+      discovery.structuralErrors.some((error) =>
+        error.includes("Duplicate locale column 'en'"),
+      ),
+    ).toBe(true);
     expect(
       discovery.columns.filter((column) => column.kind === "default"),
     ).toHaveLength(1);

--- a/features/data-lists/translations/__tests__/parse-translations-csv.test.ts
+++ b/features/data-lists/translations/__tests__/parse-translations-csv.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   discoverLocalesFromTranslationsCsv,
+  filterTranslationsCsv,
   readCsvRecords,
 } from "../parse-translations-csv";
 
@@ -28,5 +29,55 @@ describe("readCsvRecords", () => {
     expect(discovery.structuralErrors).toContain(
       "Unexpected text after a quoted CSV field.",
     );
+  });
+
+  it("strips a leading BOM", () => {
+    expect(readCsvRecords("\uFEFFvalue,default\r\na,A\r\n")).toEqual([
+      ["value", "default"],
+      ["a", "A"],
+    ]);
+  });
+});
+
+describe("filterTranslationsCsv", () => {
+  const source =
+    "value,default,es,bg\r\napple,Apple,Manzana,Ябълка\r\npear,Pear,Pera,Круша\r\n";
+
+  it("keeps default and selected locale columns", () => {
+    const filtered = filterTranslationsCsv(source, ["default", "es"]);
+
+    expect(readCsvRecords(filtered)).toEqual([
+      ["value", "default", "es"],
+      ["apple", "Apple", "Manzana"],
+      ["pear", "Pear", "Pera"],
+    ]);
+  });
+
+  it("always retains the default column even when omitted from selection", () => {
+    const filtered = filterTranslationsCsv(source, ["bg"]);
+
+    expect(readCsvRecords(filtered)[0]).toEqual(["value", "default", "bg"]);
+  });
+
+  it("maps defaultLocale culture alias to the default catalog column", () => {
+    const withEn = "value,en,es\r\napple,Apple,Manzana\r\npear,Pear,Pera\r\n";
+    const filtered = filterTranslationsCsv(withEn, ["es"], "en");
+
+    expect(readCsvRecords(filtered)).toEqual([
+      ["value", "en", "es"],
+      ["apple", "Apple", "Manzana"],
+      ["pear", "Pear", "Pera"],
+    ]);
+  });
+
+  it("drops duplicate locale columns after the first canonical key", () => {
+    const duplicate =
+      "value,default,ES,es\r\napple,Apple,Manzana1,Manzana2\r\n";
+    const filtered = filterTranslationsCsv(duplicate, ["default", "es"]);
+
+    expect(readCsvRecords(filtered)).toEqual([
+      ["value", "default", "ES"],
+      ["apple", "Apple", "Manzana1"],
+    ]);
   });
 });

--- a/features/data-lists/translations/__tests__/translations-csv.action.test.ts
+++ b/features/data-lists/translations/__tests__/translations-csv.action.test.ts
@@ -119,7 +119,7 @@ describe("uploadTranslationsCsvAction", () => {
       return;
     }
     expect(result.message).toContain("At least one data row");
-    expect(mockGetById).toHaveBeenCalledWith("42");
+    expect(mockGetById).not.toHaveBeenCalled();
     expect(mockUploadTranslationsCsv).not.toHaveBeenCalled();
   });
 

--- a/features/data-lists/translations/__tests__/translations-csv.action.test.ts
+++ b/features/data-lists/translations/__tests__/translations-csv.action.test.ts
@@ -11,12 +11,14 @@ import {
 
 const {
   mockUploadTranslationsCsv,
+  mockGetById,
   mockAddLocale,
   mockSetDefaultLocale,
   mockRequireHubAccess,
   mockAuth,
 } = vi.hoisted(() => ({
   mockUploadTranslationsCsv: vi.fn(),
+  mockGetById: vi.fn(),
   mockAddLocale: vi.fn(),
   mockSetDefaultLocale: vi.fn(),
   mockRequireHubAccess: vi.fn(),
@@ -44,6 +46,7 @@ vi.mock("@/lib/endatix-api", async (importOriginal) => {
     EndatixApi: vi.fn().mockImplementation(function () {
       return {
         dataLists: {
+          getById: mockGetById,
           uploadTranslationsCsv: mockUploadTranslationsCsv,
           addLocale: mockAddLocale,
           setDefaultLocale: mockSetDefaultLocale,
@@ -70,6 +73,7 @@ describe("uploadTranslationsCsvAction", () => {
     vi.clearAllMocks();
     mockAuth.mockResolvedValue({ accessToken: "token", isLoggedIn: true });
     mockRequireHubAccess.mockResolvedValue(undefined);
+    mockGetById.mockResolvedValue(ApiResult.success(details));
   });
 
   it("returns validation error for an invalid data list id", async () => {
@@ -83,6 +87,7 @@ describe("uploadTranslationsCsvAction", () => {
       return;
     }
     expect(result.message).toContain("dataListId");
+    expect(mockGetById).not.toHaveBeenCalled();
     expect(mockUploadTranslationsCsv).not.toHaveBeenCalled();
     expect(revalidatePath).not.toHaveBeenCalled();
   });
@@ -99,6 +104,7 @@ describe("uploadTranslationsCsvAction", () => {
       return;
     }
     expect(result.message).toContain("valid culture code");
+    expect(mockGetById).not.toHaveBeenCalled();
     expect(mockUploadTranslationsCsv).not.toHaveBeenCalled();
   });
 
@@ -113,10 +119,11 @@ describe("uploadTranslationsCsvAction", () => {
       return;
     }
     expect(result.message).toContain("At least one data row");
+    expect(mockGetById).toHaveBeenCalledWith("42");
     expect(mockUploadTranslationsCsv).not.toHaveBeenCalled();
   });
 
-  it("rejects ensureLocales that would exceed the catalog locale cap", async () => {
+  it("rejects ensureLocales that would exceed the server catalog locale cap", async () => {
     const ensureLocales = [
       "fr",
       "de",
@@ -145,7 +152,6 @@ describe("uploadTranslationsCsvAction", () => {
       dataListId: "42",
       csv: validCsv,
       ensureLocales,
-      catalogLocaleCount: 1,
     });
 
     expect(Result.isError(result)).toBe(true);
@@ -163,7 +169,6 @@ describe("uploadTranslationsCsvAction", () => {
       dataListId: "42",
       csv: validCsv,
       ensureLocales: [" FR ", "de"],
-      catalogLocaleCount: 1,
     });
 
     expect(mockUploadTranslationsCsv).toHaveBeenCalledWith("42", validCsv, {

--- a/features/data-lists/translations/__tests__/translations-csv.action.test.ts
+++ b/features/data-lists/translations/__tests__/translations-csv.action.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiResult } from "@/lib/endatix-api";
+import { Result } from "@/lib/result";
+import { revalidatePath } from "next/cache";
+import { DATA_LIST_MAX_LOCALES } from "@/features/data-lists/import-limits";
+import {
+  addDataListLocaleAction,
+  setDataListDefaultLocaleAction,
+  uploadTranslationsCsvAction,
+} from "../translations-csv.action";
+
+const {
+  mockUploadTranslationsCsv,
+  mockAddLocale,
+  mockSetDefaultLocale,
+  mockRequireHubAccess,
+  mockAuth,
+} = vi.hoisted(() => ({
+  mockUploadTranslationsCsv: vi.fn(),
+  mockAddLocale: vi.fn(),
+  mockSetDefaultLocale: vi.fn(),
+  mockRequireHubAccess: vi.fn(),
+  mockAuth: vi.fn(),
+}));
+
+vi.mock("@/auth", () => ({
+  auth: (...args: unknown[]) => mockAuth(...args),
+}));
+
+vi.mock("@/features/auth/authorization", () => ({
+  authorization: vi.fn(async () => ({
+    requireHubAccess: mockRequireHubAccess,
+  })),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/endatix-api", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@/lib/endatix-api")>();
+  return {
+    ...mod,
+    EndatixApi: vi.fn().mockImplementation(function () {
+      return {
+        dataLists: {
+          uploadTranslationsCsv: mockUploadTranslationsCsv,
+          addLocale: mockAddLocale,
+          setDefaultLocale: mockSetDefaultLocale,
+        },
+      };
+    }),
+  };
+});
+
+const details = {
+  id: "42",
+  name: "Countries",
+  isActive: true,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  itemsCount: 1,
+  availableLocales: ["en"],
+  items: [{ id: "1", value: "ch", labels: { default: "Switzerland" } }],
+};
+
+const validCsv = "value,default\r\napple,Apple\r\n";
+
+describe("uploadTranslationsCsvAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ accessToken: "token", isLoggedIn: true });
+    mockRequireHubAccess.mockResolvedValue(undefined);
+  });
+
+  it("returns validation error for an invalid data list id", async () => {
+    const result = await uploadTranslationsCsvAction({
+      dataListId: "not-an-id",
+      csv: validCsv,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain("dataListId");
+    expect(mockUploadTranslationsCsv).not.toHaveBeenCalled();
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("returns error for an invalid ensureLocales culture code", async () => {
+    const result = await uploadTranslationsCsvAction({
+      dataListId: "42",
+      csv: validCsv,
+      ensureLocales: ["!!!"],
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain("valid culture code");
+    expect(mockUploadTranslationsCsv).not.toHaveBeenCalled();
+  });
+
+  it("rejects csv that fails import payload guards before calling the API", async () => {
+    const result = await uploadTranslationsCsvAction({
+      dataListId: "42",
+      csv: "value,default\r\n",
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain("At least one data row");
+    expect(mockUploadTranslationsCsv).not.toHaveBeenCalled();
+  });
+
+  it("rejects ensureLocales that would exceed the catalog locale cap", async () => {
+    const ensureLocales = [
+      "fr",
+      "de",
+      "es",
+      "it",
+      "pt",
+      "nl",
+      "pl",
+      "sv",
+      "da",
+      "fi",
+      "cs",
+      "hu",
+      "ro",
+      "bg",
+      "el",
+      "tr",
+      "ja",
+      "ko",
+      "zh",
+      "ar",
+    ];
+    expect(ensureLocales).toHaveLength(DATA_LIST_MAX_LOCALES);
+
+    const result = await uploadTranslationsCsvAction({
+      dataListId: "42",
+      csv: validCsv,
+      ensureLocales,
+      catalogLocaleCount: 1,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain(String(DATA_LIST_MAX_LOCALES));
+    expect(mockUploadTranslationsCsv).not.toHaveBeenCalled();
+  });
+
+  it("normalizes locales, uploads csv, and revalidates on success", async () => {
+    mockUploadTranslationsCsv.mockResolvedValue(ApiResult.success(details));
+
+    const result = await uploadTranslationsCsvAction({
+      dataListId: "42",
+      csv: validCsv,
+      ensureLocales: [" FR ", "de"],
+      catalogLocaleCount: 1,
+    });
+
+    expect(mockUploadTranslationsCsv).toHaveBeenCalledWith("42", validCsv, {
+      ensureLocales: ["fr", "de"],
+    });
+    expect(Result.isSuccess(result)).toBe(true);
+    if (!Result.isSuccess(result)) {
+      return;
+    }
+    expect(result.value.id).toBe("42");
+    expect(revalidatePath).toHaveBeenCalledWith("/data-lists/42");
+  });
+
+  it("does not revalidate when the API call fails", async () => {
+    mockUploadTranslationsCsv.mockResolvedValue(
+      ApiResult.validationError("CSV parse failed"),
+    );
+
+    const result = await uploadTranslationsCsvAction({
+      dataListId: "42",
+      csv: validCsv,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("propagates requireHubAccess failures", async () => {
+    mockRequireHubAccess.mockRejectedValue(new Error("NEXT_REDIRECT"));
+
+    await expect(
+      uploadTranslationsCsvAction({ dataListId: "42", csv: validCsv }),
+    ).rejects.toThrow("NEXT_REDIRECT");
+    expect(mockUploadTranslationsCsv).not.toHaveBeenCalled();
+  });
+});
+
+describe("addDataListLocaleAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ accessToken: "token", isLoggedIn: true });
+    mockRequireHubAccess.mockResolvedValue(undefined);
+  });
+
+  it("returns validation error for an invalid data list id", async () => {
+    const result = await addDataListLocaleAction("bad-id", "fr");
+
+    expect(Result.isError(result)).toBe(true);
+    expect(mockAddLocale).not.toHaveBeenCalled();
+  });
+
+  it("returns error for an invalid culture code", async () => {
+    const result = await addDataListLocaleAction("42", "!!!");
+
+    expect(Result.isError(result)).toBe(true);
+    if (!Result.isError(result)) {
+      return;
+    }
+    expect(result.message).toContain("valid culture code");
+    expect(mockAddLocale).not.toHaveBeenCalled();
+  });
+
+  it("normalizes locale, calls API, and revalidates on success", async () => {
+    mockAddLocale.mockResolvedValue(ApiResult.success(details));
+
+    const result = await addDataListLocaleAction("42", " FR ");
+
+    expect(mockAddLocale).toHaveBeenCalledWith("42", "fr");
+    expect(Result.isSuccess(result)).toBe(true);
+    expect(revalidatePath).toHaveBeenCalledWith("/data-lists/42");
+  });
+
+  it("does not revalidate when the API call fails", async () => {
+    mockAddLocale.mockResolvedValue(ApiResult.notFoundError("Not found"));
+
+    const result = await addDataListLocaleAction("42", "fr");
+
+    expect(Result.isError(result)).toBe(true);
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+});
+
+describe("setDataListDefaultLocaleAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ accessToken: "token", isLoggedIn: true });
+    mockRequireHubAccess.mockResolvedValue(undefined);
+  });
+
+  it("returns error for an invalid culture code", async () => {
+    const result = await setDataListDefaultLocaleAction("42", "!!!");
+
+    expect(Result.isError(result)).toBe(true);
+    expect(mockSetDefaultLocale).not.toHaveBeenCalled();
+  });
+
+  it("normalizes locale, calls API, and revalidates on success", async () => {
+    mockSetDefaultLocale.mockResolvedValue(ApiResult.success(details));
+
+    const result = await setDataListDefaultLocaleAction("42", " DE ");
+
+    expect(mockSetDefaultLocale).toHaveBeenCalledWith("42", "de");
+    expect(Result.isSuccess(result)).toBe(true);
+    expect(revalidatePath).toHaveBeenCalledWith("/data-lists/42");
+  });
+
+  it("does not revalidate when the API call fails", async () => {
+    mockSetDefaultLocale.mockResolvedValue(
+      ApiResult.validationError("Locale missing"),
+    );
+
+    const result = await setDataListDefaultLocaleAction("42", "fr");
+
+    expect(Result.isError(result)).toBe(true);
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+});

--- a/features/data-lists/translations/locale-discovery.ts
+++ b/features/data-lists/translations/locale-discovery.ts
@@ -6,6 +6,14 @@ import {
   toCatalogLocaleKey,
   tryNormalizeCultureCode,
 } from "@/lib/localization";
+import {
+  DATA_LIST_MAX_ITEMS,
+  DATA_LIST_MAX_LOCALES,
+} from "@/features/data-lists/import-limits";
+import {
+  IMPORT_LOCALES_CATALOG_LIMIT_ERROR,
+  IMPORT_TOO_MANY_ITEMS_ERROR,
+} from "@/features/data-lists/import-validation-messages";
 
 export {
   isValidCultureCode,
@@ -16,11 +24,13 @@ export {
   tryNormalizeCultureCode,
 } from "@/lib/localization";
 
-export const DATA_LIST_MAX_ITEMS = 5_000;
-export const DATA_LIST_MAX_LOCALES = 20;
-export const DATA_LIST_MAX_LABEL_LENGTH = 100;
-export const DATA_LIST_MAX_CSV_CHARS = 2_000_000;
-export const DATA_LIST_MAX_JSON_FILE_BYTES = 5 * 1024 * 1024;
+export {
+  DATA_LIST_MAX_CSV_CHARS,
+  DATA_LIST_MAX_ITEMS,
+  DATA_LIST_MAX_JSON_FILE_BYTES,
+  DATA_LIST_MAX_LABEL_LENGTH,
+  DATA_LIST_MAX_LOCALES,
+} from "@/features/data-lists/import-limits";
 
 export type LocaleDiscoveryOptions = {
   availableLocales: string[];
@@ -242,15 +252,11 @@ export function resolveLocaleImportSelection(
 
   const catalogAfterEnsure = catalogLocaleCount + ensureLocales.length;
   if (catalogAfterEnsure > DATA_LIST_MAX_LOCALES) {
-    errors.push(
-      `Selecting these locales would exceed the catalog limit of ${DATA_LIST_MAX_LOCALES}.`,
-    );
+    errors.push(IMPORT_LOCALES_CATALOG_LIMIT_ERROR);
   }
 
   if (discovery.rowCount > DATA_LIST_MAX_ITEMS) {
-    errors.push(
-      `A data list cannot have more than ${DATA_LIST_MAX_ITEMS.toLocaleString()} items.`,
-    );
+    errors.push(IMPORT_TOO_MANY_ITEMS_ERROR);
   }
 
   return {

--- a/features/data-lists/translations/locale-discovery.ts
+++ b/features/data-lists/translations/locale-discovery.ts
@@ -60,7 +60,10 @@ export type LocaleImportDiscovery = {
   rowCount: number;
   /** True when the payload is structurally usable aside from locale selection. */
   canProceed: boolean;
+  /** Blocking structural problems (empty CSV, bad header, etc.). */
   structuralErrors: string[];
+  /** Non-blocking notices (e.g. duplicate locale columns; first wins). */
+  warnings: string[];
 };
 
 export type LocaleImportSelection = {
@@ -171,9 +174,9 @@ export function discoverLocalesFromKeys(
   const existing = new Set<string>();
   const discoveredNew = new Set<string>();
   const invalid: string[] = [];
+  const warnings: string[] = [];
   const seenCanonicalKeys = new Set<string>();
   const availableLocales = buildAvailableLocaleSet(options.availableLocales);
-  const errors = [...structuralErrors];
 
   for (const raw of keys) {
     const column = classifyLocaleColumn(
@@ -185,12 +188,15 @@ export function discoverLocalesFromKeys(
     columns.push(column);
 
     if (column.kind === "invalid") {
-      invalid.push(column.raw);
+      // Duplicate canonical keys: keep the first column and warn — do not block import.
       if (column.isDuplicate) {
-        errors.push(
+        warnings.push(
           `Duplicate locale column '${column.raw}' — only the first column for this locale is kept.`,
         );
+        continue;
       }
+
+      invalid.push(column.raw);
       continue;
     }
 
@@ -202,15 +208,15 @@ export function discoverLocalesFromKeys(
     discoveredNew.add(column.key);
   }
 
-  const structuralOk = errors.length === 0;
   return {
     columns,
     existingLocales: [...existing],
     newLocales: [...discoveredNew].sort((a, b) => a.localeCompare(b)),
     invalidLocales: invalid,
     rowCount,
-    canProceed: structuralOk && invalid.length === 0,
-    structuralErrors: errors,
+    canProceed: structuralErrors.length === 0 && invalid.length === 0,
+    structuralErrors,
+    warnings,
   };
 }
 

--- a/features/data-lists/translations/locale-discovery.ts
+++ b/features/data-lists/translations/locale-discovery.ts
@@ -45,6 +45,8 @@ export type LocaleColumnDiscovery = {
   /** Normalized key (`default` or lowercase culture). Empty when invalid. */
   key: string;
   kind: LocaleColumnKind;
+  /** True when this column duplicates an earlier canonical locale key. */
+  isDuplicate?: boolean;
 };
 
 export type LocaleImportDiscovery = {
@@ -144,7 +146,7 @@ function classifyLocaleColumn(
 
   const key = toCatalogLocaleKey(normalized, options.defaultLocale);
   if (seenCanonicalKeys.has(key)) {
-    return { raw: trimmed, key: "", kind: "invalid" };
+    return { raw: trimmed, key: "", kind: "invalid", isDuplicate: true };
   }
   seenCanonicalKeys.add(key);
 
@@ -171,6 +173,7 @@ export function discoverLocalesFromKeys(
   const invalid: string[] = [];
   const seenCanonicalKeys = new Set<string>();
   const availableLocales = buildAvailableLocaleSet(options.availableLocales);
+  const errors = [...structuralErrors];
 
   for (const raw of keys) {
     const column = classifyLocaleColumn(
@@ -183,6 +186,11 @@ export function discoverLocalesFromKeys(
 
     if (column.kind === "invalid") {
       invalid.push(column.raw);
+      if (column.isDuplicate) {
+        errors.push(
+          `Duplicate locale column '${column.raw}' — only the first column for this locale is kept.`,
+        );
+      }
       continue;
     }
 
@@ -194,7 +202,7 @@ export function discoverLocalesFromKeys(
     discoveredNew.add(column.key);
   }
 
-  const structuralOk = structuralErrors.length === 0;
+  const structuralOk = errors.length === 0;
   return {
     columns,
     existingLocales: [...existing],
@@ -202,7 +210,7 @@ export function discoverLocalesFromKeys(
     invalidLocales: invalid,
     rowCount,
     canProceed: structuralOk && invalid.length === 0,
-    structuralErrors,
+    structuralErrors: errors,
   };
 }
 

--- a/features/data-lists/translations/locale-import-confirm-dialog.tsx
+++ b/features/data-lists/translations/locale-import-confirm-dialog.tsx
@@ -25,6 +25,7 @@ export type LocaleImportConfirmPanelProps = {
   discovery: LocaleImportDiscovery | null;
   catalogLocaleCount: number;
   isPending?: boolean;
+  cancelLabel?: string;
   onCancel: () => void;
   onConfirm: (selection: LocaleImportSelection) => void;
 };
@@ -76,6 +77,7 @@ export function LocaleImportConfirmPanel({
   discovery,
   catalogLocaleCount,
   isPending = false,
+  cancelLabel = "Back",
   onCancel,
   onConfirm,
 }: Readonly<LocaleImportConfirmPanelProps>) {
@@ -218,7 +220,7 @@ export function LocaleImportConfirmPanel({
 
       <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
         <Button variant="outline" disabled={isPending} onClick={onCancel}>
-          Back
+          {cancelLabel}
         </Button>
         <Button
           disabled={!canConfirm || isPending}

--- a/features/data-lists/translations/locale-import-confirm-dialog.tsx
+++ b/features/data-lists/translations/locale-import-confirm-dialog.tsx
@@ -165,6 +165,17 @@ export function LocaleImportConfirmPanel({
             </div>
           ) : null}
 
+          {discovery.warnings.length > 0 ? (
+            <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-amber-800 dark:text-amber-300">
+              <p className="font-medium">Import notes</p>
+              <ul className="mt-1 list-disc pl-5">
+                {discovery.warnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
           {selectionErrors.length > 0 ? (
             <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-destructive">
               <ul className="list-disc pl-5">

--- a/features/data-lists/translations/locale-import-confirm-dialog.tsx
+++ b/features/data-lists/translations/locale-import-confirm-dialog.tsx
@@ -2,13 +2,6 @@
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { DEFAULT_CATALOG_LOCALE } from "@/lib/localization";
 import { useEffect, useMemo, useState } from "react";
@@ -120,7 +113,7 @@ export function LocaleImportConfirmPanel({
   return (
     <div className="space-y-4 text-sm">
       <div className="space-y-1">
-        <p className="text-base font-semibold leading-none">{title}</p>
+        <p className="text-base leading-none font-semibold">{title}</p>
         <p className="text-sm text-muted-foreground">{copy.description}</p>
       </div>
 
@@ -139,11 +132,16 @@ export function LocaleImportConfirmPanel({
               )}{" "}
               / {DATA_LIST_MAX_LOCALES}
             </p>
-            <p>Label max length: {DATA_LIST_MAX_LABEL_LENGTH}</p>
+            <p>
+              Label max length: {DATA_LIST_MAX_LABEL_LENGTH.toLocaleString()}
+            </p>
           </div>
 
           <p>
-            <span className="font-medium">{discovery.rowCount}</span> row
+            <span className="font-medium">
+              {discovery.rowCount.toLocaleString()}
+            </span>{" "}
+            row
             {discovery.rowCount === 1 ? "" : "s"} {copy.rowOutcome}
           </p>
 
@@ -230,50 +228,5 @@ export function LocaleImportConfirmPanel({
         </Button>
       </div>
     </div>
-  );
-}
-
-export type LocaleImportConfirmDialogProps = {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  title?: string;
-  mode?: "create" | "replace";
-  discovery: LocaleImportDiscovery | null;
-  catalogLocaleCount: number;
-  isPending?: boolean;
-  onConfirm: (selection: LocaleImportSelection) => void;
-};
-
-/** Dialog shell around {@link LocaleImportConfirmPanel} (standalone use). */
-export function LocaleImportConfirmDialog({
-  open,
-  onOpenChange,
-  title = "Confirm import",
-  mode = "replace",
-  discovery,
-  catalogLocaleCount,
-  isPending = false,
-  onConfirm,
-}: Readonly<LocaleImportConfirmDialogProps>) {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader className="sr-only">
-          <DialogTitle>{title}</DialogTitle>
-          <DialogDescription>
-            Review locale columns before importing.
-          </DialogDescription>
-        </DialogHeader>
-        <LocaleImportConfirmPanel
-          title={title}
-          mode={mode}
-          discovery={discovery}
-          catalogLocaleCount={catalogLocaleCount}
-          isPending={isPending}
-          onCancel={() => onOpenChange(false)}
-          onConfirm={onConfirm}
-        />
-      </DialogContent>
-    </Dialog>
   );
 }

--- a/features/data-lists/translations/locale-import-confirm-dialog.tsx
+++ b/features/data-lists/translations/locale-import-confirm-dialog.tsx
@@ -6,7 +6,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -26,15 +25,14 @@ import {
   type LocaleImportSelection,
 } from "./locale-discovery";
 
-export type LocaleImportConfirmDialogProps = {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+export type LocaleImportConfirmPanelProps = {
   title?: string;
   /** Create flow avoids “replace existing” copy; replace keeps current wording. */
   mode?: "create" | "replace";
   discovery: LocaleImportDiscovery | null;
   catalogLocaleCount: number;
   isPending?: boolean;
+  onCancel: () => void;
   onConfirm: (selection: LocaleImportSelection) => void;
 };
 
@@ -76,16 +74,18 @@ function uniqueSelectableColumns(
   });
 }
 
-export function LocaleImportConfirmDialog({
-  open,
-  onOpenChange,
+/**
+ * Locale selection UI shared by create/replace wizards (embedded) and optional dialog shell.
+ */
+export function LocaleImportConfirmPanel({
   title = "Confirm import",
   mode = "replace",
   discovery,
   catalogLocaleCount,
   isPending = false,
+  onCancel,
   onConfirm,
-}: Readonly<LocaleImportConfirmDialogProps>) {
+}: Readonly<LocaleImportConfirmPanelProps>) {
   const [selected, setSelected] = useState<Record<string, boolean>>({});
   const copy = MODE_COPY[mode];
 
@@ -118,122 +118,161 @@ export function LocaleImportConfirmDialog({
   );
 
   return (
+    <div className="space-y-4 text-sm">
+      <div className="space-y-1">
+        <p className="text-base font-semibold leading-none">{title}</p>
+        <p className="text-sm text-muted-foreground">{copy.description}</p>
+      </div>
+
+      {discovery ? (
+        <div className="space-y-4">
+          <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+            <p>
+              Rows: {discovery.rowCount.toLocaleString()} /{" "}
+              {DATA_LIST_MAX_ITEMS.toLocaleString()}
+            </p>
+            <p>
+              Catalog locales after import: up to{" "}
+              {Math.min(
+                catalogLocaleCount + selection.ensureLocales.length,
+                DATA_LIST_MAX_LOCALES,
+              )}{" "}
+              / {DATA_LIST_MAX_LOCALES}
+            </p>
+            <p>Label max length: {DATA_LIST_MAX_LABEL_LENGTH}</p>
+          </div>
+
+          <p>
+            <span className="font-medium">{discovery.rowCount}</span> row
+            {discovery.rowCount === 1 ? "" : "s"} {copy.rowOutcome}
+          </p>
+
+          {discovery.structuralErrors.length > 0 ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-destructive">
+              <p className="font-medium">Cannot import</p>
+              <ul className="mt-1 list-disc pl-5">
+                {discovery.structuralErrors.map((error) => (
+                  <li key={error}>{error}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {discovery.invalidLocales.length > 0 ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-destructive">
+              <p className="font-medium">Invalid locale columns</p>
+              <p className="mt-1">{discovery.invalidLocales.join(", ")}</p>
+            </div>
+          ) : null}
+
+          {selectionErrors.length > 0 ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-destructive">
+              <ul className="list-disc pl-5">
+                {selectionErrors.map((error) => (
+                  <li key={error}>{error}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {selectableColumns.length > 0 ? (
+            <div className="space-y-2">
+              <p className="font-medium">Locale columns</p>
+              <ul className="space-y-2">
+                {selectableColumns.map((column) => {
+                  // Temporary: existing catalog locales cannot be deselected —
+                  // dropping them on replace can leave empty labels in catalog.
+                  const locked =
+                    column.kind === "default" || column.kind === "existing";
+                  const checked = locked || selected[column.key] !== false;
+
+                  return (
+                    <li key={column.key} className="flex items-start gap-2">
+                      <Checkbox
+                        id={`locale-column-${column.key}`}
+                        checked={checked}
+                        disabled={isPending || locked}
+                        onCheckedChange={(value) => {
+                          setSelected((prev) => ({
+                            ...prev,
+                            [column.key]: value === true,
+                          }));
+                        }}
+                      />
+                      <div className="space-y-0.5">
+                        <Label htmlFor={`locale-column-${column.key}`}>
+                          {column.key === DEFAULT_CATALOG_LOCALE
+                            ? "default"
+                            : formatLocaleLabel(column.key)}
+                        </Label>
+                        <p className="text-xs text-muted-foreground">
+                          {COLUMN_KIND_HINT[column.kind]}
+                        </p>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <Button variant="outline" disabled={isPending} onClick={onCancel}>
+          Back
+        </Button>
+        <Button
+          disabled={!canConfirm || isPending}
+          onClick={() => onConfirm(selection)}
+        >
+          {isPending ? "Importing…" : "Confirm import"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export type LocaleImportConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+  mode?: "create" | "replace";
+  discovery: LocaleImportDiscovery | null;
+  catalogLocaleCount: number;
+  isPending?: boolean;
+  onConfirm: (selection: LocaleImportSelection) => void;
+};
+
+/** Dialog shell around {@link LocaleImportConfirmPanel} (standalone use). */
+export function LocaleImportConfirmDialog({
+  open,
+  onOpenChange,
+  title = "Confirm import",
+  mode = "replace",
+  discovery,
+  catalogLocaleCount,
+  isPending = false,
+  onConfirm,
+}: Readonly<LocaleImportConfirmDialogProps>) {
+  return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
-        <DialogHeader>
+        <DialogHeader className="sr-only">
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription>{copy.description}</DialogDescription>
+          <DialogDescription>
+            Review locale columns before importing.
+          </DialogDescription>
         </DialogHeader>
-
-        {discovery ? (
-          <div className="space-y-4 text-sm">
-            <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
-              <p>
-                Rows: {discovery.rowCount.toLocaleString()} /{" "}
-                {DATA_LIST_MAX_ITEMS.toLocaleString()}
-              </p>
-              <p>
-                Catalog locales after import: up to{" "}
-                {Math.min(
-                  catalogLocaleCount + selection.ensureLocales.length,
-                  DATA_LIST_MAX_LOCALES,
-                )}{" "}
-                / {DATA_LIST_MAX_LOCALES}
-              </p>
-              <p>Label max length: {DATA_LIST_MAX_LABEL_LENGTH}</p>
-            </div>
-
-            <p>
-              <span className="font-medium">{discovery.rowCount}</span> row
-              {discovery.rowCount === 1 ? "" : "s"} {copy.rowOutcome}
-            </p>
-
-            {discovery.structuralErrors.length > 0 ? (
-              <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-destructive">
-                <p className="font-medium">Cannot import</p>
-                <ul className="mt-1 list-disc pl-5">
-                  {discovery.structuralErrors.map((error) => (
-                    <li key={error}>{error}</li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-
-            {discovery.invalidLocales.length > 0 ? (
-              <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-destructive">
-                <p className="font-medium">Invalid locale columns</p>
-                <p className="mt-1">{discovery.invalidLocales.join(", ")}</p>
-              </div>
-            ) : null}
-
-            {selectionErrors.length > 0 ? (
-              <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-destructive">
-                <ul className="list-disc pl-5">
-                  {selectionErrors.map((error) => (
-                    <li key={error}>{error}</li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-
-            {selectableColumns.length > 0 ? (
-              <div className="space-y-2">
-                <p className="font-medium">Locale columns</p>
-                <ul className="space-y-2">
-                  {selectableColumns.map((column) => {
-                    // Temporary: existing catalog locales cannot be deselected —
-                    // dropping them on replace can leave empty labels in catalog.
-                    const locked =
-                      column.kind === "default" || column.kind === "existing";
-                    const checked = locked || selected[column.key] !== false;
-
-                    return (
-                      <li key={column.key} className="flex items-start gap-2">
-                        <Checkbox
-                          id={`locale-column-${column.key}`}
-                          checked={checked}
-                          disabled={isPending || locked}
-                          onCheckedChange={(value) => {
-                            setSelected((prev) => ({
-                              ...prev,
-                              [column.key]: value === true,
-                            }));
-                          }}
-                        />
-                        <div className="space-y-0.5">
-                          <Label htmlFor={`locale-column-${column.key}`}>
-                            {column.key === DEFAULT_CATALOG_LOCALE
-                              ? "default"
-                              : formatLocaleLabel(column.key)}
-                          </Label>
-                          <p className="text-xs text-muted-foreground">
-                            {COLUMN_KIND_HINT[column.kind]}
-                          </p>
-                        </div>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-            ) : null}
-          </div>
-        ) : null}
-
-        <DialogFooter>
-          <Button
-            variant="outline"
-            disabled={isPending}
-            onClick={() => onOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            disabled={!canConfirm || isPending}
-            onClick={() => onConfirm(selection)}
-          >
-            {isPending ? "Importing…" : "Confirm import"}
-          </Button>
-        </DialogFooter>
+        <LocaleImportConfirmPanel
+          title={title}
+          mode={mode}
+          discovery={discovery}
+          catalogLocaleCount={catalogLocaleCount}
+          isPending={isPending}
+          onCancel={() => onOpenChange(false)}
+          onConfirm={onConfirm}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/features/data-lists/translations/parse-translations-csv.ts
+++ b/features/data-lists/translations/parse-translations-csv.ts
@@ -99,8 +99,8 @@ export function discoverLocalesFromTranslationsCsv(
 
 /**
  * Keeps `value` plus selected locale columns (by normalized key). Drops deselected columns.
- * When the header has duplicate canonical locale keys, only the first column is kept
- * (discovery already blocks import with a structural error for duplicates).
+ * When the header has duplicate canonical locale keys, only the first column is kept.
+ * Discovery surfaces that as a non-blocking warning so import can proceed.
  */
 export function filterTranslationsCsv(
   csv: string,

--- a/features/data-lists/translations/parse-translations-csv.ts
+++ b/features/data-lists/translations/parse-translations-csv.ts
@@ -99,6 +99,8 @@ export function discoverLocalesFromTranslationsCsv(
 
 /**
  * Keeps `value` plus selected locale columns (by normalized key). Drops deselected columns.
+ * When the header has duplicate canonical locale keys, only the first column is kept
+ * (discovery already blocks import with a structural error for duplicates).
  */
 export function filterTranslationsCsv(
   csv: string,

--- a/features/data-lists/translations/parse-translations-csv.ts
+++ b/features/data-lists/translations/parse-translations-csv.ts
@@ -1,3 +1,7 @@
+import {
+  IMPORT_CSV_TOO_LARGE_ERROR,
+  IMPORT_TOO_MANY_ITEMS_ERROR,
+} from "@/features/data-lists/import-validation-messages";
 import { DEFAULT_CATALOG_LOCALE } from "@/lib/localization";
 import {
   DATA_LIST_MAX_CSV_CHARS,
@@ -24,7 +28,7 @@ export function discoverLocalesFromTranslationsCsv(
 
   if (csv.length > DATA_LIST_MAX_CSV_CHARS) {
     return discoverLocalesFromKeys([], options, 0, [
-      `CSV exceeds the maximum size of ${DATA_LIST_MAX_CSV_CHARS.toLocaleString()} characters.`,
+      IMPORT_CSV_TOO_LARGE_ERROR,
     ]);
   }
 
@@ -82,9 +86,7 @@ export function discoverLocalesFromTranslationsCsv(
   }
 
   if (dataRows.length > DATA_LIST_MAX_ITEMS) {
-    structuralErrors.push(
-      `A translations CSV cannot have more than ${DATA_LIST_MAX_ITEMS.toLocaleString()} rows.`,
-    );
+    structuralErrors.push(IMPORT_TOO_MANY_ITEMS_ERROR);
   }
 
   return discoverLocalesFromKeys(

--- a/features/data-lists/translations/translations-csv.action.ts
+++ b/features/data-lists/translations/translations-csv.action.ts
@@ -2,7 +2,10 @@
 
 import { auth } from "@/auth";
 import { authorization } from "@/features/auth/authorization";
-import { guardImportPayload } from "@/features/data-lists/import-payload-guards";
+import {
+  guardEnsureLocalesCount,
+  guardTranslationsCsvPayload,
+} from "@/features/data-lists/import-payload-guards";
 import { EndatixApi } from "@/lib/endatix-api";
 import type { DataListDetails } from "@/lib/endatix-api/data-lists/types";
 import {
@@ -53,6 +56,18 @@ export async function uploadTranslationsCsvAction(
     );
   }
 
+  // Validate CSV shape before the details fetch so empty/oversized imports
+  // fail fast without a getById round-trip.
+  const csvGuard = guardTranslationsCsvPayload(input.csv);
+  if (Result.isError(csvGuard)) {
+    return csvGuard;
+  }
+
+  const earlyLocalesGuard = guardEnsureLocalesCount(localesResult.value, []);
+  if (Result.isError(earlyLocalesGuard)) {
+    return earlyLocalesGuard;
+  }
+
   const api = new EndatixApi(session?.accessToken);
   const detailsResult = toResult(await api.dataLists.getById(idResult.value), {
     fallbackMessage: "Failed to load data list",
@@ -63,15 +78,12 @@ export async function uploadTranslationsCsvAction(
     return detailsResult;
   }
 
-  const catalogLocaleCount = detailsResult.value.availableLocales?.length ?? 0;
-  const payloadGuard = guardImportPayload({
-    format: "csv",
-    csv: input.csv,
-    ensureLocales: localesResult.value,
-    catalogLocaleCount,
-  });
-  if (Result.isError(payloadGuard)) {
-    return payloadGuard;
+  const localesGuard = guardEnsureLocalesCount(
+    localesResult.value,
+    detailsResult.value.availableLocales ?? [],
+  );
+  if (Result.isError(localesGuard)) {
+    return localesGuard;
   }
 
   const result = toResult(

--- a/features/data-lists/translations/translations-csv.action.ts
+++ b/features/data-lists/translations/translations-csv.action.ts
@@ -22,7 +22,6 @@ export type UploadTranslationsCsvInput = {
   dataListId: string;
   csv: string;
   ensureLocales?: string[];
-  catalogLocaleCount?: number;
 };
 
 function normalizeLocaleInput(locale: string): Result<string> {
@@ -54,17 +53,27 @@ export async function uploadTranslationsCsvAction(
     );
   }
 
+  const api = new EndatixApi(session?.accessToken);
+  const detailsResult = toResult(await api.dataLists.getById(idResult.value), {
+    fallbackMessage: "Failed to load data list",
+    logMessage: "Failed to load data list before translations CSV upload",
+    loggerName: "data-lists.translationsCsv",
+  });
+  if (Result.isError(detailsResult)) {
+    return detailsResult;
+  }
+
+  const catalogLocaleCount = detailsResult.value.availableLocales?.length ?? 0;
   const payloadGuard = guardImportPayload({
     format: "csv",
     csv: input.csv,
     ensureLocales: localesResult.value,
-    catalogLocaleCount: input.catalogLocaleCount ?? 0,
+    catalogLocaleCount,
   });
   if (Result.isError(payloadGuard)) {
     return payloadGuard;
   }
 
-  const api = new EndatixApi(session?.accessToken);
   const result = toResult(
     await api.dataLists.uploadTranslationsCsv(idResult.value, input.csv, {
       ensureLocales: localesResult.value,

--- a/features/data-lists/translations/translations-csv.action.ts
+++ b/features/data-lists/translations/translations-csv.action.ts
@@ -2,6 +2,7 @@
 
 import { auth } from "@/auth";
 import { authorization } from "@/features/auth/authorization";
+import { guardImportPayload } from "@/features/data-lists/import-payload-guards";
 import { EndatixApi } from "@/lib/endatix-api";
 import type { DataListDetails } from "@/lib/endatix-api/data-lists/types";
 import {
@@ -10,6 +11,7 @@ import {
 } from "@/lib/localization";
 import { Result } from "@/lib/result";
 import { toResult } from "@/lib/result/map-api-result-to-result";
+import { validateEndatixId } from "@/lib/utils/type-validators";
 import { revalidatePath } from "next/cache";
 
 export type UploadTranslationsCsvResult = Result<DataListDetails>;
@@ -20,6 +22,7 @@ export type UploadTranslationsCsvInput = {
   dataListId: string;
   csv: string;
   ensureLocales?: string[];
+  catalogLocaleCount?: number;
 };
 
 function normalizeLocaleInput(locale: string): Result<string> {
@@ -39,6 +42,11 @@ export async function uploadTranslationsCsvAction(
   const { requireHubAccess } = await authorization(session);
   await requireHubAccess();
 
+  const idResult = validateEndatixId(input.dataListId, "dataListId");
+  if (Result.isError(idResult)) {
+    return idResult;
+  }
+
   const localesResult = normalizeCultureCodes(input.ensureLocales ?? []);
   if (!localesResult.ok) {
     return Result.error(
@@ -46,9 +54,19 @@ export async function uploadTranslationsCsvAction(
     );
   }
 
+  const payloadGuard = guardImportPayload({
+    format: "csv",
+    csv: input.csv,
+    ensureLocales: localesResult.value,
+    catalogLocaleCount: input.catalogLocaleCount ?? 0,
+  });
+  if (Result.isError(payloadGuard)) {
+    return payloadGuard;
+  }
+
   const api = new EndatixApi(session?.accessToken);
   const result = toResult(
-    await api.dataLists.uploadTranslationsCsv(input.dataListId, input.csv, {
+    await api.dataLists.uploadTranslationsCsv(idResult.value, input.csv, {
       ensureLocales: localesResult.value,
     }),
     {
@@ -59,7 +77,7 @@ export async function uploadTranslationsCsvAction(
   );
 
   if (Result.isSuccess(result)) {
-    revalidatePath(`/data-lists/${input.dataListId}`);
+    revalidatePath(`/data-lists/${idResult.value}`);
   }
 
   return result;
@@ -73,6 +91,11 @@ export async function addDataListLocaleAction(
   const { requireHubAccess } = await authorization(session);
   await requireHubAccess();
 
+  const idResult = validateEndatixId(dataListId, "dataListId");
+  if (Result.isError(idResult)) {
+    return idResult;
+  }
+
   const localeResult = normalizeLocaleInput(locale);
   if (Result.isError(localeResult)) {
     return localeResult;
@@ -80,7 +103,7 @@ export async function addDataListLocaleAction(
 
   const api = new EndatixApi(session?.accessToken);
   const result = toResult(
-    await api.dataLists.addLocale(dataListId, localeResult.value),
+    await api.dataLists.addLocale(idResult.value, localeResult.value),
     {
       fallbackMessage: "Failed to add locale",
       logMessage: "Failed to add locale",
@@ -89,37 +112,7 @@ export async function addDataListLocaleAction(
   );
 
   if (Result.isSuccess(result)) {
-    revalidatePath(`/data-lists/${dataListId}`);
-  }
-
-  return result;
-}
-
-export async function removeDataListLocaleAction(
-  dataListId: string,
-  locale: string,
-): Promise<DataListLocaleMutationResult> {
-  const session = await auth();
-  const { requireHubAccess } = await authorization(session);
-  await requireHubAccess();
-
-  const localeResult = normalizeLocaleInput(locale);
-  if (Result.isError(localeResult)) {
-    return localeResult;
-  }
-
-  const api = new EndatixApi(session?.accessToken);
-  const result = toResult(
-    await api.dataLists.removeLocale(dataListId, localeResult.value),
-    {
-      fallbackMessage: "Failed to remove locale",
-      logMessage: "Failed to remove locale",
-      loggerName: "data-lists.locales",
-    },
-  );
-
-  if (Result.isSuccess(result)) {
-    revalidatePath(`/data-lists/${dataListId}`);
+    revalidatePath(`/data-lists/${idResult.value}`);
   }
 
   return result;
@@ -133,6 +126,11 @@ export async function setDataListDefaultLocaleAction(
   const { requireHubAccess } = await authorization(session);
   await requireHubAccess();
 
+  const idResult = validateEndatixId(dataListId, "dataListId");
+  if (Result.isError(idResult)) {
+    return idResult;
+  }
+
   const localeResult = normalizeLocaleInput(defaultLocale);
   if (Result.isError(localeResult)) {
     return localeResult;
@@ -140,7 +138,7 @@ export async function setDataListDefaultLocaleAction(
 
   const api = new EndatixApi(session?.accessToken);
   const result = toResult(
-    await api.dataLists.setDefaultLocale(dataListId, localeResult.value),
+    await api.dataLists.setDefaultLocale(idResult.value, localeResult.value),
     {
       fallbackMessage: "Failed to set default locale",
       logMessage: "Failed to set default locale",
@@ -149,7 +147,7 @@ export async function setDataListDefaultLocaleAction(
   );
 
   if (Result.isSuccess(result)) {
-    revalidatePath(`/data-lists/${dataListId}`);
+    revalidatePath(`/data-lists/${idResult.value}`);
   }
 
   return result;

--- a/features/data-lists/utils.ts
+++ b/features/data-lists/utils.ts
@@ -11,20 +11,28 @@ import {
 import { DATA_LIST_ITEM_MAX_LENGTH } from "@/lib/survey-features/data-lists/constants";
 import {
   discoverLocalesFromKeys,
+  DATA_LIST_MAX_CSV_CHARS,
+  DATA_LIST_MAX_ITEMS,
+  DATA_LIST_MAX_JSON_FILE_BYTES,
   type LocaleDiscoveryOptions,
   type LocaleImportDiscovery,
 } from "./translations/locale-discovery";
 import { JsonErrorAnnotation, ParsedValidation } from "./types";
 
 export { DATA_LIST_MAX_JSON_FILE_BYTES as MAX_FILE_SIZE_BYTES } from "./translations/locale-discovery";
+export { DATA_LIST_MAX_CSV_CHARS } from "./translations/locale-discovery";
 export const MAX_PREVIEW_ERRORS = 20;
 
-export const FILE_SIZE_ERROR = "File is too large. Max file size is 5MB.";
+export const FILE_SIZE_ERROR = `File is too large. Max file size is ${
+  DATA_LIST_MAX_JSON_FILE_BYTES / (1024 * 1024)
+}MB.`;
+export const CSV_FILE_SIZE_ERROR = `File is too large. Max CSV size is ${DATA_LIST_MAX_CSV_CHARS.toLocaleString()} characters.`;
 export const READ_ERROR = "Failed to read the selected file.";
 export const JSON_REQUIRED_ERROR = "JSON content is required.";
 export const INVALID_JSON_ERROR = "Invalid JSON format.";
 export const ARRAY_REQUIRED_ERROR = "JSON root must be an array of objects.";
 export const AT_LEAST_ONE_ERROR = "At least one item is required.";
+export const TOO_MANY_ITEMS_ERROR = `A data list cannot have more than ${DATA_LIST_MAX_ITEMS.toLocaleString()} items.`;
 
 const createErrorResponse = (error: string, row = 0): ParsedValidation => ({
   validItems: [],
@@ -246,6 +254,10 @@ export function validateJsonInput(
 
   if (parsed.length === 0) {
     return createErrorResponse(AT_LEAST_ONE_ERROR);
+  }
+
+  if (parsed.length > DATA_LIST_MAX_ITEMS) {
+    return createErrorResponse(TOO_MANY_ITEMS_ERROR);
   }
 
   const errors: string[] = [];

--- a/features/data-lists/utils.ts
+++ b/features/data-lists/utils.ts
@@ -32,7 +32,7 @@ export const MAX_PREVIEW_ERRORS = 20;
 export const FILE_SIZE_ERROR = `File is too large. Max file size is ${
   DATA_LIST_MAX_JSON_FILE_BYTES / (1024 * 1024)
 }MB.`;
-export const CSV_FILE_SIZE_ERROR = `File is too large. Max CSV size is ${DATA_LIST_MAX_CSV_CHARS.toLocaleString()} characters.`;
+export const CSV_FILE_SIZE_ERROR = `File is too large. Max CSV size is ${DATA_LIST_MAX_CSV_CHARS.toLocaleString("en-US")} characters.`;
 export const READ_ERROR = "Failed to read the selected file.";
 export const JSON_REQUIRED_ERROR = "JSON content is required.";
 export const INVALID_JSON_ERROR = "Invalid JSON format.";

--- a/features/data-lists/utils.ts
+++ b/features/data-lists/utils.ts
@@ -18,6 +18,12 @@ import {
   type LocaleImportDiscovery,
 } from "./translations/locale-discovery";
 import { JsonErrorAnnotation, ParsedValidation } from "./types";
+import {
+  IMPORT_AT_LEAST_ONE_ITEM_ERROR as AT_LEAST_ONE_ERROR,
+  IMPORT_TOO_MANY_ITEMS_ERROR as TOO_MANY_ITEMS_ERROR,
+} from "./import-validation-messages";
+
+export { AT_LEAST_ONE_ERROR, TOO_MANY_ITEMS_ERROR };
 
 export { DATA_LIST_MAX_JSON_FILE_BYTES as MAX_FILE_SIZE_BYTES } from "./translations/locale-discovery";
 export { DATA_LIST_MAX_CSV_CHARS } from "./translations/locale-discovery";
@@ -31,8 +37,6 @@ export const READ_ERROR = "Failed to read the selected file.";
 export const JSON_REQUIRED_ERROR = "JSON content is required.";
 export const INVALID_JSON_ERROR = "Invalid JSON format.";
 export const ARRAY_REQUIRED_ERROR = "JSON root must be an array of objects.";
-export const AT_LEAST_ONE_ERROR = "At least one item is required.";
-export const TOO_MANY_ITEMS_ERROR = `A data list cannot have more than ${DATA_LIST_MAX_ITEMS.toLocaleString()} items.`;
 
 const createErrorResponse = (error: string, row = 0): ParsedValidation => ({
   validItems: [],

--- a/features/data-lists/view-list-details/ui/data-list-items-table.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-items-table.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/table";
 import { formatLocaleLabel } from "@/features/data-lists/translations/locale-discovery";
 import type { DataListItem } from "@/lib/endatix-api/data-lists/types";
+import { resolveCatalogDefaultLabelText } from "@/lib/localization";
 import { cn } from "@/lib/utils";
 import {
   flexRender,
@@ -55,7 +56,10 @@ function buildColumns(
       cell: ({ row }: { row: { original: DataListItemRow } }) => {
         const text =
           column === "default"
-            ? row.original.labels.default
+            ? resolveCatalogDefaultLabelText(
+                row.original.labels,
+                defaultLocale,
+              )
             : row.original.labels[column];
         return text?.trim() ? text : "—";
       },

--- a/features/data-lists/view-list-details/ui/locale-catalog-panel.tsx
+++ b/features/data-lists/view-list-details/ui/locale-catalog-panel.tsx
@@ -27,7 +27,11 @@ export function LocaleCatalogPanel({
   const availableLocales = details.availableLocales ?? [];
   const dataListIdResult = validateEndatixId(String(details.id), "dataListId");
   const hasValidDataListId = Result.isSuccess(dataListIdResult);
-  const controlsDisabled = isPending || isRemovePending || !hasValidDataListId;
+  const controlsDisabled =
+    isPending ||
+    isRemovePending ||
+    localePendingRemoval !== null ||
+    !hasValidDataListId;
 
   const requireDataListId = (): string | null => {
     if (Result.isError(dataListIdResult)) {

--- a/features/data-lists/view-list-details/ui/locale-catalog-panel.tsx
+++ b/features/data-lists/view-list-details/ui/locale-catalog-panel.tsx
@@ -5,12 +5,10 @@ import type { DataListDetails } from "@/lib/endatix-api/data-lists/types";
 import { Result } from "@/lib/result";
 import { validateEndatixId } from "@/lib/utils/type-validators";
 import { X } from "lucide-react";
-import { useTransition } from "react";
-import {
-  removeDataListLocaleAction,
-  setDataListDefaultLocaleAction,
-} from "@/features/data-lists/translations/translations-csv.action";
+import { useState, useTransition } from "react";
+import { setDataListDefaultLocaleAction } from "@/features/data-lists/translations/translations-csv.action";
 import { formatLocaleLabel } from "@/features/data-lists/translations/locale-discovery";
+import { RemoveLocaleConfirmDialog } from "@/features/data-lists/remove-locale";
 
 type LocaleCatalogPanelProps = {
   details: DataListDetails;
@@ -22,41 +20,30 @@ export function LocaleCatalogPanel({
   onUpdated,
 }: Readonly<LocaleCatalogPanelProps>) {
   const [isPending, startTransition] = useTransition();
+  const [localePendingRemoval, setLocalePendingRemoval] = useState<
+    string | null
+  >(null);
   const availableLocales = details.availableLocales ?? [];
   const dataListIdResult = validateEndatixId(String(details.id), "dataListId");
+  const hasValidDataListId = Result.isSuccess(dataListIdResult);
 
-  const handleRemove = (locale: string): void => {
+  const requireDataListId = (): string | null => {
     if (Result.isError(dataListIdResult)) {
       toast.error(dataListIdResult.message);
-      return;
+      return null;
     }
 
-    startTransition(async () => {
-      const result = await removeDataListLocaleAction(
-        dataListIdResult.value,
-        locale,
-      );
-      if (Result.isError(result)) {
-        toast.error(result.message);
-        return;
-      }
-
-      onUpdated(result.value);
-      toast.success(`Removed locale ${locale}`);
-    });
+    return dataListIdResult.value;
   };
 
   const handleSetDefault = (locale: string): void => {
-    if (Result.isError(dataListIdResult)) {
-      toast.error(dataListIdResult.message);
+    const dataListId = requireDataListId();
+    if (dataListId === null) {
       return;
     }
 
     startTransition(async () => {
-      const result = await setDataListDefaultLocaleAction(
-        dataListIdResult.value,
-        locale,
-      );
+      const result = await setDataListDefaultLocaleAction(dataListId, locale);
       if (Result.isError(result)) {
         toast.error(result.message);
         return;
@@ -67,54 +54,78 @@ export function LocaleCatalogPanel({
     });
   };
 
+  const handleRequestRemove = (locale: string): void => {
+    if (requireDataListId() === null) {
+      return;
+    }
+
+    setLocalePendingRemoval(locale);
+  };
+
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-border/40 bg-surface-container-lowest px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-      <div className="min-w-0">
-        <p className="text-sm font-medium">Locales</p>
-        <p className="text-xs text-muted-foreground">
-          Default: {details.defaultLocale ?? "—"} · New cultures are added
-          during CSV/JSON import
-        </p>
+    <>
+      <div className="flex flex-col gap-3 rounded-xl border border-border/40 bg-surface-container-lowest px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-medium">Locales</p>
+          <p className="text-xs text-muted-foreground">
+            Default: {details.defaultLocale ?? "—"} · New cultures are added
+            during CSV/JSON import
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {details.defaultLocale ? (
+            <span className="inline-flex items-center gap-1 rounded-md bg-surface-container-low px-2 py-1 text-xs">
+              {formatLocaleLabel(details.defaultLocale)} (default)
+            </span>
+          ) : null}
+          {availableLocales.length === 0 ? (
+            <span className="text-xs text-muted-foreground">
+              No additional locales yet
+            </span>
+          ) : (
+            availableLocales.map((locale) => (
+              <span
+                key={locale}
+                className="inline-flex items-center gap-1 rounded-md border border-border/50 px-2 py-1 text-xs"
+              >
+                <button
+                  type="button"
+                  className="hover:underline"
+                  disabled={isPending || !hasValidDataListId}
+                  title="Set as default"
+                  onClick={() => handleSetDefault(locale)}
+                >
+                  {formatLocaleLabel(locale)}
+                </button>
+                <button
+                  type="button"
+                  className="text-muted-foreground hover:text-destructive"
+                  disabled={isPending || !hasValidDataListId}
+                  aria-label={`Remove ${locale}`}
+                  onClick={() => handleRequestRemove(locale)}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))
+          )}
+        </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        {details.defaultLocale ? (
-          <span className="inline-flex items-center gap-1 rounded-md bg-surface-container-low px-2 py-1 text-xs">
-            {formatLocaleLabel(details.defaultLocale)} (default)
-          </span>
-        ) : null}
-        {availableLocales.length === 0 ? (
-          <span className="text-xs text-muted-foreground">
-            No additional locales yet
-          </span>
-        ) : (
-          availableLocales.map((locale) => (
-            <span
-              key={locale}
-              className="inline-flex items-center gap-1 rounded-md border border-border/50 px-2 py-1 text-xs"
-            >
-              <button
-                type="button"
-                className="hover:underline"
-                disabled={isPending}
-                title="Set as default"
-                onClick={() => handleSetDefault(locale)}
-              >
-                {formatLocaleLabel(locale)}
-              </button>
-              <button
-                type="button"
-                className="text-muted-foreground hover:text-destructive"
-                disabled={isPending}
-                aria-label={`Remove ${locale}`}
-                onClick={() => handleRemove(locale)}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </span>
-          ))
-        )}
-      </div>
-    </div>
+      {hasValidDataListId ? (
+        <RemoveLocaleConfirmDialog
+          open={localePendingRemoval !== null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setLocalePendingRemoval(null);
+            }
+          }}
+          dataListId={dataListIdResult.value}
+          locale={localePendingRemoval}
+          onRemoved={onUpdated}
+        />
+      ) : null}
+    </>
   );
 }

--- a/features/data-lists/view-list-details/ui/locale-catalog-panel.tsx
+++ b/features/data-lists/view-list-details/ui/locale-catalog-panel.tsx
@@ -20,12 +20,14 @@ export function LocaleCatalogPanel({
   onUpdated,
 }: Readonly<LocaleCatalogPanelProps>) {
   const [isPending, startTransition] = useTransition();
+  const [isRemovePending, setIsRemovePending] = useState(false);
   const [localePendingRemoval, setLocalePendingRemoval] = useState<
     string | null
   >(null);
   const availableLocales = details.availableLocales ?? [];
   const dataListIdResult = validateEndatixId(String(details.id), "dataListId");
   const hasValidDataListId = Result.isSuccess(dataListIdResult);
+  const controlsDisabled = isPending || isRemovePending || !hasValidDataListId;
 
   const requireDataListId = (): string | null => {
     if (Result.isError(dataListIdResult)) {
@@ -55,7 +57,7 @@ export function LocaleCatalogPanel({
   };
 
   const handleRequestRemove = (locale: string): void => {
-    if (requireDataListId() === null) {
+    if (requireDataListId() === null || controlsDisabled) {
       return;
     }
 
@@ -92,7 +94,7 @@ export function LocaleCatalogPanel({
                 <button
                   type="button"
                   className="hover:underline"
-                  disabled={isPending || !hasValidDataListId}
+                  disabled={controlsDisabled}
                   title="Set as default"
                   onClick={() => handleSetDefault(locale)}
                 >
@@ -101,7 +103,7 @@ export function LocaleCatalogPanel({
                 <button
                   type="button"
                   className="text-muted-foreground hover:text-destructive"
-                  disabled={isPending || !hasValidDataListId}
+                  disabled={controlsDisabled}
                   aria-label={`Remove ${locale}`}
                   onClick={() => handleRequestRemove(locale)}
                 >
@@ -124,6 +126,7 @@ export function LocaleCatalogPanel({
           dataListId={dataListIdResult.value}
           locale={localePendingRemoval}
           onRemoved={onUpdated}
+          onPendingChange={setIsRemovePending}
         />
       ) : null}
     </>


### PR DESCRIPTION
# feat(h844): Add delete locale dialog for UX confirmation and proper test coverage

## Description
Stabilizes Hub data-list create / replace / import after the h831 management UI (#831 / #840). Addresses [endatix-hub#844](): no orphaned empty lists, aligned limits, server-side guards, clearer UX, and high-value action tests.

- **Create + import atomicity** — `createDataListWithImportAction` creates then imports (CSV/JSON); on import failure it deletes the list so callers never leave empty orphans.
- **Shared import policy** — `import-limits`, `import-validation-messages`, and `import-payload-guards` (`guardImportPayload`) used by create-with-import, CSV upload, and replace; client discovery reuses the same caps/copy.
- **CSV / JSON limits** — picker and server aligned to `DATA_LIST_MAX_CSV_CHARS`; JSON max items enforced in `validateJsonInput`; locale catalog cap guarded on the server.
- **UX** — locale confirm as an in-dialog step (no nested modal unlock); single replace success toast; remove-locale confirm dialog; items table uses `resolveCatalogDefaultLabelText`; clearer `sourceError` / max-items messaging.
- **Hardening** — `validateEndatixId` on data-list export BFF; shared max-label constant.
- **Tests** — guards, create-with-import (incl. rollback + telemetry on delete failure), upload/replace/locale actions, remove-locale UI/action, CSV filter/discovery coverage.


## Related Issues
- closes #844 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [x] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="549" height="254" alt="image" src="https://github.com/user-attachments/assets/969d4681-e05d-44bf-8147-5669772229a8" />
<img width="517" height="535" alt="image" src="https://github.com/user-attachments/assets/3299185a-c9f0-4e1a-9e98-7457b21ef6f9" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a guided three-step workflow for creating and replacing data lists, including upload, preview, and locale confirmation.
  - Added locale removal with a confirmation dialog and clear success or error feedback.
  - Added format-specific CSV and JSON import limits and validation messages.
  - Added support for importing validated CSV or JSON content in a single operation.

- **Bug Fixes**
  - Improved validation for invalid IDs, oversized files, excessive items, malformed imports, and locale-limit violations.
  - Improved default-label display and preserved clearer source errors during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->