### PR TITLE
fix(h852): coerce lazy carry-forward sources to Selected mode

### DIFF
--- a/lib/survey-features/carry-forward/__tests__/creator-help.test.ts
+++ b/lib/survey-features/carry-forward/__tests__/creator-help.test.ts
@@ -1,5 +1,5 @@
 import { getLocaleStrings } from "survey-creator-core";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CARRY_FORWARD_ENABLED_PROPERTY,
   CARRY_FORWARD_MAX_CHOICES_PROPERTY,
@@ -7,6 +7,15 @@ import {
   CARRY_FORWARD_PRIORITY_ITEMS_PROPERTY,
   CARRY_FORWARD_SOURCES_PROPERTY,
 } from "../constants";
+
+const withBasePathMock = vi.hoisted(() =>
+  vi.fn((path: string) => path),
+);
+
+vi.mock("@/lib/hosting", () => ({
+  withBasePath: withBasePathMock,
+}));
+
 import {
   registerAdvancedCarryForwardCreatorHelp,
   resetAdvancedCarryForwardCreatorHelpForTests,
@@ -15,6 +24,8 @@ import {
 describe("registerAdvancedCarryForwardCreatorHelp", () => {
   beforeEach(() => {
     resetAdvancedCarryForwardCreatorHelpForTests();
+    withBasePathMock.mockReset();
+    withBasePathMock.mockImplementation((path: string) => path);
   });
 
   it("registers pehelp text for priority items and max choices", () => {
@@ -30,12 +41,15 @@ describe("registerAdvancedCarryForwardCreatorHelp", () => {
     ).toContain("earlier choice questions");
     expect(
       translations.pehelp[CARRY_FORWARD_SOURCES_PROPERTY],
-    ).toContain("data list");
+    ).toContain('href="/data-lists"');
     expect(translations.pehelp[CARRY_FORWARD_MODE_PROPERTY]).toContain(
       "Selected",
     );
     expect(translations.pehelp[CARRY_FORWARD_MODE_PROPERTY]).toContain(
       "Lazy-loaded sources",
+    );
+    expect(translations.pehelp[CARRY_FORWARD_MODE_PROPERTY]).toContain(
+      'href="/data-lists"',
     );
     expect(
       translations.pehelp[CARRY_FORWARD_PRIORITY_ITEMS_PROPERTY],
@@ -43,6 +57,22 @@ describe("registerAdvancedCarryForwardCreatorHelp", () => {
     expect(
       translations.pehelp[CARRY_FORWARD_MAX_CHOICES_PROPERTY],
     ).toContain("Priority items are always included");
+  });
+
+  it("builds the Data Lists pehelp link via withBasePath for subfolder deploys", () => {
+    withBasePathMock.mockImplementation((path: string) => `/hub${path}`);
+
+    registerAdvancedCarryForwardCreatorHelp();
+
+    const translations = getLocaleStrings("en");
+
+    expect(withBasePathMock).toHaveBeenCalledWith("/data-lists");
+    expect(translations.pehelp[CARRY_FORWARD_MODE_PROPERTY]).toContain(
+      'href="/hub/data-lists"',
+    );
+    expect(translations.pehelp[CARRY_FORWARD_SOURCES_PROPERTY]).toContain(
+      'href="/hub/data-lists"',
+    );
   });
 
   it("clears pehelp text on reset instead of leaving it from a prior register", () => {

--- a/lib/survey-features/carry-forward/__tests__/creator-help.test.ts
+++ b/lib/survey-features/carry-forward/__tests__/creator-help.test.ts
@@ -28,8 +28,14 @@ describe("registerAdvancedCarryForwardCreatorHelp", () => {
     expect(
       translations.pehelp[CARRY_FORWARD_SOURCES_PROPERTY],
     ).toContain("earlier choice questions");
+    expect(
+      translations.pehelp[CARRY_FORWARD_SOURCES_PROPERTY],
+    ).toContain("data list");
     expect(translations.pehelp[CARRY_FORWARD_MODE_PROPERTY]).toContain(
       "Selected",
+    );
+    expect(translations.pehelp[CARRY_FORWARD_MODE_PROPERTY]).toContain(
+      "Lazy-loaded sources",
     );
     expect(
       translations.pehelp[CARRY_FORWARD_PRIORITY_ITEMS_PROPERTY],

--- a/lib/survey-features/carry-forward/__tests__/creator-help.test.ts
+++ b/lib/survey-features/carry-forward/__tests__/creator-help.test.ts
@@ -42,6 +42,9 @@ describe("registerAdvancedCarryForwardCreatorHelp", () => {
     expect(
       translations.pehelp[CARRY_FORWARD_SOURCES_PROPERTY],
     ).toContain('href="/data-lists"');
+    expect(
+      translations.pehelp[CARRY_FORWARD_SOURCES_PROPERTY],
+    ).toContain("always contribute only the respondent's selected options");
     expect(translations.pehelp[CARRY_FORWARD_MODE_PROPERTY]).toContain(
       "Selected",
     );
@@ -50,6 +53,15 @@ describe("registerAdvancedCarryForwardCreatorHelp", () => {
     );
     expect(translations.pehelp[CARRY_FORWARD_MODE_PROPERTY]).toContain(
       'href="/data-lists"',
+    );
+    expect(translations.pehelp[CARRY_FORWARD_MODE_PROPERTY]).toContain(
+      "including selections that are not on the currently loaded page",
+    );
+    expect(translations.pehelp[CARRY_FORWARD_MODE_PROPERTY]).toContain(
+      "even if this setting is All or Unselected",
+    );
+    expect(translations.pehelp[CARRY_FORWARD_MODE_PROPERTY]).toContain(
+      "Inline (fully loaded) sources still honor All and Unselected",
     );
     expect(
       translations.pehelp[CARRY_FORWARD_PRIORITY_ITEMS_PROPERTY],

--- a/lib/survey-features/carry-forward/__tests__/sync-carry-forward-target.test.ts
+++ b/lib/survey-features/carry-forward/__tests__/sync-carry-forward-target.test.ts
@@ -608,6 +608,78 @@ describe("syncSingleCarryForwardTarget", () => {
     ]);
   });
 
+  it("honors All for inline sources while forcing Selected for lazy sources", () => {
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "checkbox",
+          name: "inlineBrands",
+          choices: ["A", "B", "C"],
+        },
+        {
+          type: "tagbox",
+          name: "lazyCountries",
+          choicesLazyLoadEnabled: true,
+          choices: ["Algeria", "Jordan"],
+        },
+        {
+          type: "checkbox",
+          name: "target",
+          choices: ["legacy"],
+          edxCarryForwardEnabled: true,
+          edxCarryForwardSources: ["inlineBrands", "lazyCountries"],
+          edxCarryForwardMode: "all",
+        },
+      ],
+    });
+    survey.setValue("inlineBrands", ["A"]);
+    survey.setValue("lazyCountries", ["Mexico"]);
+    const target = survey.getQuestionByName(
+      "target",
+    ) as AdvancedCarryForwardQuestion;
+
+    // Act
+    syncSingleCarryForwardTarget(survey, target);
+
+    // Assert — full inline catalog + lazy selected Mexico (not the lazy page)
+    expect(target.choices.map((item) => item.value)).toEqual([
+      "A",
+      "B",
+      "C",
+      "Mexico",
+    ]);
+  });
+
+  it("yields no choices for a lazy source in All mode when nothing is selected", () => {
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "tagbox",
+          name: "countries",
+          choicesLazyLoadEnabled: true,
+          choices: ["Algeria", "Jordan"],
+        },
+        {
+          type: "checkbox",
+          name: "target",
+          choices: ["legacy"],
+          edxCarryForwardEnabled: true,
+          edxCarryForwardSources: ["countries"],
+          edxCarryForwardMode: "all",
+        },
+      ],
+    });
+    const target = survey.getQuestionByName(
+      "target",
+    ) as AdvancedCarryForwardQuestion;
+
+    // Act
+    syncSingleCarryForwardTarget(survey, target);
+
+    // Assert — does not copy the loaded page as All used to
+    expect(target.choices.map((item) => item.value)).toEqual([]);
+  });
+
   it("carries lazy-load selectedItemValues labels into Selected Only target", () => {
     const survey = new SurveyModel({
       elements: [

--- a/lib/survey-features/carry-forward/__tests__/sync-carry-forward-target.test.ts
+++ b/lib/survey-features/carry-forward/__tests__/sync-carry-forward-target.test.ts
@@ -501,6 +501,113 @@ describe("syncSingleCarryForwardTarget", () => {
     ]);
   });
 
+  it("forces Selected contribution for lazy sources when mode is All", () => {
+    // Arrange — visible page is Algeria/Jordan; only Mexico is selected (off-page)
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "tagbox",
+          name: "countries",
+          choicesLazyLoadEnabled: true,
+          choices: ["Algeria", "Jordan"],
+        },
+        {
+          type: "checkbox",
+          name: "target",
+          choices: ["legacy"],
+          edxCarryForwardEnabled: true,
+          edxCarryForwardSources: ["countries"],
+          edxCarryForwardMode: "all",
+        },
+      ],
+    });
+    survey.setValue("countries", ["Mexico"]);
+    const target = survey.getQuestionByName(
+      "target",
+    ) as AdvancedCarryForwardQuestion;
+
+    // Act
+    syncSingleCarryForwardTarget(survey, target);
+
+    // Assert — does not copy the whole visible page as All would
+    expect(target.choices.map((item) => item.value)).toEqual(["Mexico"]);
+  });
+
+  it("forces Selected contribution for lazy sources when mode is Unselected", () => {
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "tagbox",
+          name: "countries",
+          choicesLazyLoadEnabled: true,
+          choices: ["Algeria", "Jordan"],
+        },
+        {
+          type: "checkbox",
+          name: "target",
+          choices: ["legacy"],
+          edxCarryForwardEnabled: true,
+          edxCarryForwardSources: ["countries"],
+          edxCarryForwardMode: "unselected",
+        },
+      ],
+    });
+    survey.setValue("countries", ["Jordan", "Mexico"]);
+    const target = survey.getQuestionByName(
+      "target",
+    ) as AdvancedCarryForwardQuestion;
+
+    // Act
+    syncSingleCarryForwardTarget(survey, target);
+
+    // Assert — unselected page items (Algeria) are not carried; selected are
+    expect(target.choices.map((item) => item.value)).toEqual([
+      "Jordan",
+      "Mexico",
+    ]);
+  });
+
+  it("honors Unselected for inline sources while forcing Selected for lazy sources", () => {
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "checkbox",
+          name: "inlineBrands",
+          choices: ["A", "B", "C"],
+        },
+        {
+          type: "tagbox",
+          name: "lazyCountries",
+          choicesLazyLoadEnabled: true,
+          choices: ["Algeria", "Jordan"],
+        },
+        {
+          type: "checkbox",
+          name: "target",
+          choices: ["legacy"],
+          edxCarryForwardEnabled: true,
+          edxCarryForwardSources: ["inlineBrands", "lazyCountries"],
+          edxCarryForwardMode: "unselected",
+        },
+      ],
+    });
+    survey.setValue("inlineBrands", ["A"]);
+    survey.setValue("lazyCountries", ["Mexico"]);
+    const target = survey.getQuestionByName(
+      "target",
+    ) as AdvancedCarryForwardQuestion;
+
+    // Act
+    syncSingleCarryForwardTarget(survey, target);
+
+    // Assert — inline unselected B/C + lazy selected Mexico
+    expect(target.choices.map((item) => item.value)).toEqual([
+      "B",
+      "C",
+      "Mexico",
+    ]);
+  });
+
   it("carries lazy-load selectedItemValues labels into Selected Only target", () => {
     const survey = new SurveyModel({
       elements: [

--- a/lib/survey-features/carry-forward/infrastructure/creator-help.ts
+++ b/lib/survey-features/carry-forward/infrastructure/creator-help.ts
@@ -20,11 +20,15 @@ export function registerAdvancedCarryForwardCreatorHelp(): void {
     "Enable this option if you need to build this question's choice list from one or more earlier questions while prioritizing specific choices or limiting their number.";
 
   translations.pehelp[CARRY_FORWARD_SOURCES_PROPERTY] =
-    "Select one or more earlier choice questions to copy options from. Only select-based questions appear here, and the current question is excluded.";
+    "Select one or more earlier choice questions to copy options from. Only select-based questions appear here, and the current question is excluded. " +
+    "Sources that load choices on demand (for example, Choices from data list) always contribute only the respondent's selected options, even when the destination mode is All or Unselected.";
 
   translations.pehelp[CARRY_FORWARD_MODE_PROPERTY] =
     'Choose from: "All" - copies all choice options from the selected questions; "Selected" - dynamically copies only selected choice options; "Unselected" - dynamically copies only unselected choice options. ' +
-    "For ranking source questions, Selected and Unselected follow the ranking value (often the full ranked list), not a partial checkbox-style selection.";
+    "For ranking source questions, Selected and Unselected follow the ranking value (often the full ranked list), not a partial checkbox-style selection.<br/><br/>" +
+    "<b>Note:</b> Lazy-loaded sources (such as large data lists) cannot load the full catalog in the browser. " +
+    "Those sources always contribute <em>Selected</em> options only — including selections that are not on the currently loaded page — even if this setting is All or Unselected. " +
+    "Inline (fully loaded) sources still honor All and Unselected.";
 
   translations.pehelp[CARRY_FORWARD_PRIORITY_ITEMS_PROPERTY] =
     "Pins these choices to the top of the destination list in the order shown. " +

--- a/lib/survey-features/carry-forward/infrastructure/creator-help.ts
+++ b/lib/survey-features/carry-forward/infrastructure/creator-help.ts
@@ -1,4 +1,5 @@
 import { getLocaleStrings } from "survey-creator-core";
+import { withBasePath } from "@/lib/hosting";
 import {
   CARRY_FORWARD_ENABLED_PROPERTY,
   CARRY_FORWARD_MAX_CHOICES_PROPERTY,
@@ -9,24 +10,36 @@ import {
 
 let isCreatorHelpRegistered = false;
 
+/** Hub Data Lists page — basePath-aware for subfolder deploys. */
+function dataListsHelpLinkHtml(): string {
+  const href = withBasePath("/data-lists");
+  return (
+    `<a target="_blank" rel="noopener noreferrer" class="hover:underline" href="${href}">` +
+    "Data Lists</a>"
+  );
+}
+
 export function registerAdvancedCarryForwardCreatorHelp(): void {
   if (isCreatorHelpRegistered) {
     return;
   }
 
   const translations = getLocaleStrings("en");
+  const dataListsLink = dataListsHelpLinkHtml();
 
   translations.pehelp[CARRY_FORWARD_ENABLED_PROPERTY] =
     "Enable this option if you need to build this question's choice list from one or more earlier questions while prioritizing specific choices or limiting their number.";
 
   translations.pehelp[CARRY_FORWARD_SOURCES_PROPERTY] =
     "Select one or more earlier choice questions to copy options from. Only select-based questions appear here, and the current question is excluded. " +
-    "Sources that load choices on demand (for example, Choices from data list) always contribute only the respondent's selected options, even when the destination mode is All or Unselected.";
+    `Sources that load choices on demand (for example, ${dataListsLink}) always contribute only the respondent's selected options, even when the destination mode is All or Unselected.`;
 
   translations.pehelp[CARRY_FORWARD_MODE_PROPERTY] =
     'Choose from: "All" - copies all choice options from the selected questions; "Selected" - dynamically copies only selected choice options; "Unselected" - dynamically copies only unselected choice options. ' +
     "For ranking source questions, Selected and Unselected follow the ranking value (often the full ranked list), not a partial checkbox-style selection.<br/><br/>" +
-    "<b>Note:</b> Lazy-loaded sources (such as large data lists) cannot load the full catalog in the browser. " +
+    "<b>Note:</b> Lazy-loaded sources (such as large " +
+    dataListsLink +
+    ") cannot load the full catalog in the browser. " +
     "Those sources always contribute <em>Selected</em> options only — including selections that are not on the currently loaded page — even if this setting is All or Unselected. " +
     "Inline (fully loaded) sources still honor All and Unselected.";
 

--- a/lib/survey-features/carry-forward/use-cases/compute-carry-forward-items.ts
+++ b/lib/survey-features/carry-forward/use-cases/compute-carry-forward-items.ts
@@ -2,6 +2,7 @@ import type { Question, ItemValue } from "survey-core";
 import { extractUniqueChoicesBy, getChoicesFromSourceQuestion } from "@/lib/utils/survey";
 import { limitCarryForwardChoices, parseCarryForwardMaxChoices } from "../utils/limit-carry-forward-choices";
 import { resolveCarryForwardSelectionMode } from "../utils/map-carry-forward-mode";
+import { resolveEffectiveCarryForwardModeForSource } from "../utils/resolve-effective-carry-forward-mode";
 import { splitByPriority } from "../utils/split-by-priority";
 import { getCarryForwardSourceQuestions } from "../utils/carry-forward-target-query";
 import type { AdvancedCarryForwardModeInput } from "../carry-forward-mode-values";
@@ -38,7 +39,10 @@ export function computeCarryForwardAggregatedItems(
   const sourceQuestions = getCarryForwardSourceQuestions(survey, target);
   const selectionMode = resolveCarryForwardSelectionMode(target.edxCarryForwardMode);
   const aggregatedChoices = extractUniqueChoicesBy(sourceQuestions, (source) =>
-    getChoicesFromSourceQuestion(source, selectionMode),
+    getChoicesFromSourceQuestion(
+      source,
+      resolveEffectiveCarryForwardModeForSource(source, selectionMode),
+    ),
   );
   const { priority, rest } = splitByPriority(
     aggregatedChoices,

--- a/lib/survey-features/carry-forward/utils/__tests__/resolve-effective-carry-forward-mode.test.ts
+++ b/lib/survey-features/carry-forward/utils/__tests__/resolve-effective-carry-forward-mode.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { SourceSelectionModes } from "@/lib/survey-features/question-loops/types";
+import type { QuestionSelectBase } from "survey-core";
+import {
+  isLazyLoadedChoiceSource,
+  resolveEffectiveCarryForwardModeForSource,
+} from "../resolve-effective-carry-forward-mode";
+
+function sourceWith(lazy: boolean | undefined): QuestionSelectBase {
+  return { choicesLazyLoadEnabled: lazy } as QuestionSelectBase & {
+    choicesLazyLoadEnabled?: boolean;
+  };
+}
+
+describe("isLazyLoadedChoiceSource", () => {
+  it("is true only when choicesLazyLoadEnabled is true", () => {
+    expect(isLazyLoadedChoiceSource(sourceWith(true))).toBe(true);
+    expect(isLazyLoadedChoiceSource(sourceWith(false))).toBe(false);
+    expect(isLazyLoadedChoiceSource(sourceWith(undefined))).toBe(false);
+  });
+});
+
+describe("resolveEffectiveCarryForwardModeForSource", () => {
+  it("forces Selected Only for lazy sources when All or Unselected is requested", () => {
+    const lazy = sourceWith(true);
+
+    expect(
+      resolveEffectiveCarryForwardModeForSource(
+        lazy,
+        SourceSelectionModes.All,
+      ),
+    ).toBe(SourceSelectionModes.SelectedOnly);
+    expect(
+      resolveEffectiveCarryForwardModeForSource(
+        lazy,
+        SourceSelectionModes.UnselectedOnly,
+      ),
+    ).toBe(SourceSelectionModes.SelectedOnly);
+  });
+
+  it("keeps Selected Only when already requested on a lazy source", () => {
+    expect(
+      resolveEffectiveCarryForwardModeForSource(
+        sourceWith(true),
+        SourceSelectionModes.SelectedOnly,
+      ),
+    ).toBe(SourceSelectionModes.SelectedOnly);
+  });
+
+  it("honors All / Selected / Unselected for inline (non-lazy) sources", () => {
+    const inline = sourceWith(false);
+
+    expect(
+      resolveEffectiveCarryForwardModeForSource(
+        inline,
+        SourceSelectionModes.All,
+      ),
+    ).toBe(SourceSelectionModes.All);
+    expect(
+      resolveEffectiveCarryForwardModeForSource(
+        inline,
+        SourceSelectionModes.SelectedOnly,
+      ),
+    ).toBe(SourceSelectionModes.SelectedOnly);
+    expect(
+      resolveEffectiveCarryForwardModeForSource(
+        inline,
+        SourceSelectionModes.UnselectedOnly,
+      ),
+    ).toBe(SourceSelectionModes.UnselectedOnly);
+  });
+});

--- a/lib/survey-features/carry-forward/utils/index.ts
+++ b/lib/survey-features/carry-forward/utils/index.ts
@@ -10,6 +10,10 @@ export {
 } from "./carry-forward-graph";
 export { resolveCarryForwardSelectionMode } from "./map-carry-forward-mode";
 export {
+  isLazyLoadedChoiceSource,
+  resolveEffectiveCarryForwardModeForSource,
+} from "./resolve-effective-carry-forward-mode";
+export {
   limitCarryForwardChoices,
   parseCarryForwardMaxChoices,
 } from "./limit-carry-forward-choices";

--- a/lib/survey-features/carry-forward/utils/resolve-effective-carry-forward-mode.ts
+++ b/lib/survey-features/carry-forward/utils/resolve-effective-carry-forward-mode.ts
@@ -1,0 +1,39 @@
+import type { QuestionSelectBase } from "survey-core";
+import {
+  SourceSelectionModes,
+  type SourceSelectionMode,
+} from "@/lib/survey-features/question-loops/types";
+
+type LazyChoiceSource = QuestionSelectBase & {
+  choicesLazyLoadEnabled?: boolean;
+};
+
+/**
+ * True when the source loads choices on demand (e.g. data-list binding).
+ * Full catalogs are never materialized in `visibleChoices`, so All /
+ * Unselected cannot be computed accurately.
+ */
+export function isLazyLoadedChoiceSource(
+  source: QuestionSelectBase,
+): boolean {
+  return (source as LazyChoiceSource).choicesLazyLoadEnabled === true;
+}
+
+/**
+ * Per-source effective mode for carry-forward aggregation.
+ * Lazy-loaded sources always contribute Selected Only so off-page
+ * selections stay correct without eagerly loading the full catalog.
+ */
+export function resolveEffectiveCarryForwardModeForSource(
+  source: QuestionSelectBase,
+  requestedMode: SourceSelectionMode,
+): SourceSelectionMode {
+  if (
+    isLazyLoadedChoiceSource(source) &&
+    requestedMode !== SourceSelectionModes.SelectedOnly
+  ) {
+    return SourceSelectionModes.SelectedOnly;
+  }
+
+  return requestedMode;
+}


### PR DESCRIPTION
## Summary
- Force each lazy-loaded carry-forward source (`choicesLazyLoadEnabled`) to contribute **Selected** options only, even when the destination mode is All or Unselected—so large data-list catalogs no longer silently copy the current SurveyJS page.
- Inline sources still honor All / Unselected; mixed sources compose correctly.
- Document the constraint in Creator pehelp for sources and mode properties.

Closes #852

## Test plan
- [x] Unit tests for `resolveEffectiveCarryForwardModeForSource`
- [x] Sync tests: lazy + All / Unselected → selected (incl. off-page); mixed inline unselected + lazy selected
- [x] Creator help tests assert lazy-source copy
- [ ] Manual: data-list source (large list) + CF destination mode All → destination shows only selected items
- [ ] Manual: mixed inline + data-list sources under Unselected mode

## Notes
End-user docs (`carry-forward.mdx`) and `docs/agent-glossary.md` are updated in the monorepo workspace and will ship via the docs/endatix path (not this Hub PR).

### Screenshot
<img width="450" height="316" alt="image" src="https://github.com/user-attachments/assets/45f03bde-c875-4cef-bc14-aa886c7dbea5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Carry-forward logic now supports lazy-loaded choice sources, retaining only selected values when required.
  - Carry-forward help text now explains lazy-loaded source behavior and includes base-path-aware Data Lists links.
  - Inline sources continue to honor their configured selection modes.

- **Bug Fixes**
  - Corrected carry-forward mode handling when multiple sources use different source types.
  - Improved link generation for deployments hosted in subfolders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->