### PR TITLE
fix(h854): CSS issues with carousel

### DIFF
--- a/lib/survey-features/matrix-carousel/__tests__/matrix-carousel-renderer.test.tsx
+++ b/lib/survey-features/matrix-carousel/__tests__/matrix-carousel-renderer.test.tsx
@@ -3,9 +3,23 @@ import React from "react";
 import { Model } from "survey-core";
 import { Survey } from "survey-react-ui";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { registerMatrixCarouselSchema } from "../infrastructure/registry";
 import { registerMatrixCarouselRenderer } from "../infrastructure/matrix-carousel-renderer";
 import { bindMatrixCarouselToSurvey } from "../infrastructure/survey-bindings";
+
+// Read as a plain file, not a module import — Vitest's asset pipeline
+// doesn't reliably expose external-stylesheet content as a string import in
+// this project's config, and reading the raw source directly sidesteps that
+// entirely. process.cwd() is the hub package root Vitest always runs from.
+const footerCssSource = readFileSync(
+  path.join(
+    process.cwd(),
+    "lib/survey-features/matrix-carousel/infrastructure/matrix-carousel.styles.css",
+  ),
+  "utf-8",
+);
 
 // StoragePresignedImage internally calls useAssetStorage(), which throws
 // without an <AssetStorageContext.Provider> ancestor. None of this file's
@@ -531,6 +545,54 @@ describe("MatrixCarouselRenderer", () => {
     // Assert — old observer torn down, a fresh one observing all 3 new slides
     expect(disconnectSpy).toHaveBeenCalled();
     expect(observeSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("computes the Next-scroll target from getBoundingClientRect deltas, not target.offsetLeft, so it isn't thrown off by whichever ancestor happens to be offsetLeft's positioned reference", () => {
+    // Arrange — jsdom has no real layout engine (getBoundingClientRect is
+    // {0,0,0,0} by default), so this stubs both APIs to reproduce the exact
+    // real-browser bug confirmed via a live scratch-preview render: a
+    // slide's offsetLeft resolves relative to its offsetParent — the
+    // nearest ancestor with a non-static position, which turned out to be
+    // the surrounding .sd-question wrapper (SurveyJS's own theme gives it
+    // position:relative), NOT .sv-matrixcarousel__strip (which sets no
+    // position at all) — so offsetLeft included that wrapper's own title/
+    // padding above the strip, a confirmed ~40px overshoot that scrolled
+    // past the slide's true boundary and clipped its left edge from view.
+    // getBoundingClientRect is always relative to the viewport, immune to
+    // that ambiguity — this test locks in that the fix actually uses it.
+    const model = new Model(carouselSurveyJson());
+    const { container, getByText } = render(<Survey model={model} />);
+    const strip = container.querySelector(".sv-matrixcarousel__strip") as HTMLElement;
+    const slide1 = strip.children[1] as HTMLElement;
+
+    vi.spyOn(strip, "getBoundingClientRect").mockReturnValue({ left: 100 } as DOMRect);
+    vi.spyOn(slide1, "getBoundingClientRect").mockReturnValue({ left: 500 } as DOMRect);
+    Object.defineProperty(slide1, "offsetLeft", { value: 999, configurable: true });
+    // jsdom doesn't implement Element.prototype.scrollTo at all (there's
+    // nothing to spy on until one exists) — a plain assignment on the
+    // instance stands in for it.
+    const scrollToSpy = vi.fn();
+    strip.scrollTo = scrollToSpy;
+
+    // Act
+    fireEvent.click(getByText("Next"));
+
+    // Assert — 500 - 100 + scrollLeft(0) = 400 (the rect-based delta), not
+    // offsetLeft's 999.
+    expect(scrollToSpy).toHaveBeenCalledWith(expect.objectContaining({ left: 400 }));
+  });
+
+  it("resets the theme's edge-alignment negative margin on the footer's action bar and provides its own gap, so Previous/Next and the progress text aren't flush against each other", () => {
+    // jsdom's CSS engine doesn't reliably compute cascaded flexbox gap/
+    // margin from an external stylesheet the way a real browser does — this
+    // was verified visually in a real browser instead (gaps went from 0px/
+    // 0px to 36px/8px after this rule was added). This test only guards
+    // against the rule being silently deleted or renamed later, not against
+    // a specific pixel value.
+    expect(footerCssSource).toMatch(/\.sv-matrixcarousel__footer-row\s*\{[^}]*gap:/);
+    expect(footerCssSource).toMatch(
+      /\.sv-matrixcarousel__footer-row \.sd-action-bar\s*\{[^}]*margin:\s*0[^}]*gap:/,
+    );
   });
 
   it("clears the model's visibleRowsChangedCallback on unmount, so no detached-component closure lingers", () => {

--- a/lib/survey-features/matrix-carousel/__tests__/matrix-carousel-renderer.test.tsx
+++ b/lib/survey-features/matrix-carousel/__tests__/matrix-carousel-renderer.test.tsx
@@ -9,10 +9,8 @@ import { registerMatrixCarouselSchema } from "../infrastructure/registry";
 import { registerMatrixCarouselRenderer } from "../infrastructure/matrix-carousel-renderer";
 import { bindMatrixCarouselToSurvey } from "../infrastructure/survey-bindings";
 
-// Read as a plain file, not a module import — Vitest's asset pipeline
-// doesn't reliably expose external-stylesheet content as a string import in
-// this project's config, and reading the raw source directly sidesteps that
-// entirely. process.cwd() is the hub package root Vitest always runs from.
+// Read as a plain file — Vitest's asset pipeline doesn't reliably expose
+// stylesheet content as a string import in this project's config.
 const footerCssSource = readFileSync(
   path.join(
     process.cwd(),
@@ -548,18 +546,10 @@ describe("MatrixCarouselRenderer", () => {
   });
 
   it("computes the Next-scroll target from getBoundingClientRect deltas, not target.offsetLeft, so it isn't thrown off by whichever ancestor happens to be offsetLeft's positioned reference", () => {
-    // Arrange — jsdom has no real layout engine (getBoundingClientRect is
-    // {0,0,0,0} by default), so this stubs both APIs to reproduce the exact
-    // real-browser bug confirmed via a live scratch-preview render: a
-    // slide's offsetLeft resolves relative to its offsetParent — the
-    // nearest ancestor with a non-static position, which turned out to be
-    // the surrounding .sd-question wrapper (SurveyJS's own theme gives it
-    // position:relative), NOT .sv-matrixcarousel__strip (which sets no
-    // position at all) — so offsetLeft included that wrapper's own title/
-    // padding above the strip, a confirmed ~40px overshoot that scrolled
-    // past the slide's true boundary and clipped its left edge from view.
-    // getBoundingClientRect is always relative to the viewport, immune to
-    // that ambiguity — this test locks in that the fix actually uses it.
+    // Arrange — jsdom has no real layout engine, so this stubs
+    // getBoundingClientRect/offsetLeft to reproduce the real-browser bug:
+    // offsetLeft resolved to an ancestor other than the strip, overscrolling
+    // by a confirmed ~40px. Locks in that the fix uses rect deltas instead.
     const model = new Model(carouselSurveyJson());
     const { container, getByText } = render(<Survey model={model} />);
     const strip = container.querySelector(".sv-matrixcarousel__strip") as HTMLElement;
@@ -568,9 +558,7 @@ describe("MatrixCarouselRenderer", () => {
     vi.spyOn(strip, "getBoundingClientRect").mockReturnValue({ left: 100 } as DOMRect);
     vi.spyOn(slide1, "getBoundingClientRect").mockReturnValue({ left: 500 } as DOMRect);
     Object.defineProperty(slide1, "offsetLeft", { value: 999, configurable: true });
-    // jsdom doesn't implement Element.prototype.scrollTo at all (there's
-    // nothing to spy on until one exists) — a plain assignment on the
-    // instance stands in for it.
+    // jsdom has no Element.prototype.scrollTo to spy on — assign a stub instead.
     const scrollToSpy = vi.fn();
     strip.scrollTo = scrollToSpy;
 
@@ -583,12 +571,9 @@ describe("MatrixCarouselRenderer", () => {
   });
 
   it("resets the theme's edge-alignment negative margin on the footer's action bar and provides its own gap, so Previous/Next and the progress text aren't flush against each other", () => {
-    // jsdom's CSS engine doesn't reliably compute cascaded flexbox gap/
-    // margin from an external stylesheet the way a real browser does — this
-    // was verified visually in a real browser instead (gaps went from 0px/
-    // 0px to 36px/8px after this rule was added). This test only guards
-    // against the rule being silently deleted or renamed later, not against
-    // a specific pixel value.
+    // jsdom can't reliably compute cascaded flexbox gap from an external
+    // stylesheet — verified visually instead (0px/0px -> 36px/8px). This
+    // just guards against the rule being deleted or renamed later.
     expect(footerCssSource).toMatch(/\.sv-matrixcarousel__footer-row\s*\{[^}]*gap:/);
     expect(footerCssSource).toMatch(
       /\.sv-matrixcarousel__footer-row \.sd-action-bar\s*\{[^}]*margin:\s*0[^}]*gap:/,

--- a/lib/survey-features/matrix-carousel/infrastructure/matrix-carousel-renderer.tsx
+++ b/lib/survey-features/matrix-carousel/infrastructure/matrix-carousel-renderer.tsx
@@ -344,12 +344,32 @@ export class MatrixCarouselRenderer extends SurveyQuestionMatrix {
       return;
     }
 
-    if (Math.abs(strip.scrollLeft - target.offsetLeft) <= SCROLL_EPSILON_PX) {
+    // getBoundingClientRect-based delta, not target.offsetLeft. offsetLeft is
+    // relative to target.offsetParent — the nearest ANCESTOR with a non-
+    // static position — which is NOT necessarily the strip: neither
+    // .sv-matrixcarousel nor .sv-matrixcarousel__strip sets position:
+    // relative, so the search continues past them. Confirmed in a real
+    // render: offsetParent for a slide resolves to the surrounding
+    // .sd-question wrapper (SurveyJS's own theme gives it position:
+    // relative), so offsetLeft included that wrapper's own title/padding
+    // above the strip — a constant ~40px overshoot in testing, scrolling
+    // past the true slide boundary and clipping its left edge from view.
+    // Measuring both rects in viewport coordinates and taking the
+    // difference sidesteps offsetParent entirely: it's always relative to
+    // the strip's own scrollable viewport, regardless of which ancestor
+    // elsewhere on the page happens to be positioned (which is also why
+    // this only surfaced on the live respondent runner, not Creator's
+    // Preview tab — different surrounding DOM changes what offsetLeft
+    // resolves to, but never changes this computation).
+    const targetLeft =
+      target.getBoundingClientRect().left - strip.getBoundingClientRect().left + strip.scrollLeft;
+
+    if (Math.abs(strip.scrollLeft - targetLeft) <= SCROLL_EPSILON_PX) {
       return;
     }
 
     this.isProgrammaticScroll = true;
-    strip.scrollTo({ left: target.offsetLeft, behavior: "smooth" });
+    strip.scrollTo({ left: targetLeft, behavior: "smooth" });
     strip.addEventListener("scrollend", this.clearProgrammaticScrollFlag, { once: true });
     this.programmaticScrollTimeout = setTimeout(
       this.clearProgrammaticScrollFlag,

--- a/lib/survey-features/matrix-carousel/infrastructure/matrix-carousel-renderer.tsx
+++ b/lib/survey-features/matrix-carousel/infrastructure/matrix-carousel-renderer.tsx
@@ -344,23 +344,10 @@ export class MatrixCarouselRenderer extends SurveyQuestionMatrix {
       return;
     }
 
-    // getBoundingClientRect-based delta, not target.offsetLeft. offsetLeft is
-    // relative to target.offsetParent — the nearest ANCESTOR with a non-
-    // static position — which is NOT necessarily the strip: neither
-    // .sv-matrixcarousel nor .sv-matrixcarousel__strip sets position:
-    // relative, so the search continues past them. Confirmed in a real
-    // render: offsetParent for a slide resolves to the surrounding
-    // .sd-question wrapper (SurveyJS's own theme gives it position:
-    // relative), so offsetLeft included that wrapper's own title/padding
-    // above the strip — a constant ~40px overshoot in testing, scrolling
-    // past the true slide boundary and clipping its left edge from view.
-    // Measuring both rects in viewport coordinates and taking the
-    // difference sidesteps offsetParent entirely: it's always relative to
-    // the strip's own scrollable viewport, regardless of which ancestor
-    // elsewhere on the page happens to be positioned (which is also why
-    // this only surfaced on the live respondent runner, not Creator's
-    // Preview tab — different surrounding DOM changes what offsetLeft
-    // resolves to, but never changes this computation).
+    // getBoundingClientRect-based delta, not target.offsetLeft — offsetLeft
+    // resolves relative to offsetParent (nearest positioned ancestor), which
+    // turned out to be the surrounding .sd-question wrapper, not the strip,
+    // causing a confirmed ~40px overscroll that clipped the slide's left edge.
     const targetLeft =
       target.getBoundingClientRect().left - strip.getBoundingClientRect().left + strip.scrollLeft;
 

--- a/lib/survey-features/matrix-carousel/infrastructure/matrix-carousel.styles.css
+++ b/lib/survey-features/matrix-carousel/infrastructure/matrix-carousel.styles.css
@@ -63,3 +63,35 @@
   flex-direction: column;
   padding: 0.5rem;
 }
+
+/* PanelDynamic's own theme puts its progress text in a separate
+   .sd-paneldynamic__progress-container sibling next to the action bar, with
+   spacing coming from that container's own margin-left:auto. Our layout is
+   simpler — progress text sits directly beside the action bar in one row —
+   so that structural difference matters here: gap provides the text-to-
+   button spacing directly, since the theme's progress-text margin-right
+   isn't reliably visible in this shape (see below). */
+.sv-matrixcarousel__footer-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* .sd-paneldynamic__buttons-container .sd-action-bar (theme CSS) stretches
+   the action bar past its container via a negative left/right margin, to
+   align each button's own hit-padding with the row's outer edge — a trick
+   that assumes the action bar is the row's only content. In our row the
+   progress text sits directly before it, so that negative left margin was
+   silently cancelling the gap above (and the negative right margin let the
+   bar overflow the container on the other side). Resetting margin/width
+   here — scoped to our own footer-row, not the shared sd-action-bar class
+   used app-wide — lets the action bar size to its own content instead.
+   gap between Previous/Next themselves: sd-action-bar has none of its own
+   (confirmed against the installed theme CSS — no gap, no per-button
+   margin outside PanelDynamic's own icon-rotated prev/next classes, which
+   don't apply to our text-labeled buttons). */
+.sv-matrixcarousel__footer-row .sd-action-bar {
+  margin: 0;
+  width: auto;
+  gap: 0.5rem;
+}

--- a/lib/survey-features/matrix-carousel/infrastructure/matrix-carousel.styles.css
+++ b/lib/survey-features/matrix-carousel/infrastructure/matrix-carousel.styles.css
@@ -64,32 +64,18 @@
   padding: 0.5rem;
 }
 
-/* PanelDynamic's own theme puts its progress text in a separate
-   .sd-paneldynamic__progress-container sibling next to the action bar, with
-   spacing coming from that container's own margin-left:auto. Our layout is
-   simpler — progress text sits directly beside the action bar in one row —
-   so that structural difference matters here: gap provides the text-to-
-   button spacing directly, since the theme's progress-text margin-right
-   isn't reliably visible in this shape (see below). */
+/* PanelDynamic puts progress text in a separate sibling container with its
+   own margin-left:auto; our simpler single-row layout needs its own gap. */
 .sv-matrixcarousel__footer-row {
   display: flex;
   align-items: center;
   gap: 0.75rem;
 }
 
-/* .sd-paneldynamic__buttons-container .sd-action-bar (theme CSS) stretches
-   the action bar past its container via a negative left/right margin, to
-   align each button's own hit-padding with the row's outer edge — a trick
-   that assumes the action bar is the row's only content. In our row the
-   progress text sits directly before it, so that negative left margin was
-   silently cancelling the gap above (and the negative right margin let the
-   bar overflow the container on the other side). Resetting margin/width
-   here — scoped to our own footer-row, not the shared sd-action-bar class
-   used app-wide — lets the action bar size to its own content instead.
-   gap between Previous/Next themselves: sd-action-bar has none of its own
-   (confirmed against the installed theme CSS — no gap, no per-button
-   margin outside PanelDynamic's own icon-rotated prev/next classes, which
-   don't apply to our text-labeled buttons). */
+/* Undoes the theme's sd-action-bar negative margin (designed for
+   PanelDynamic's own layout, where it's the row's only content) — here it
+   was cancelling the gap above. Scoped to our footer-row, not the shared
+   class. sd-action-bar has no gap of its own between buttons either. */
 .sv-matrixcarousel__footer-row .sd-action-bar {
   margin: 0;
   width: auto;


### PR DESCRIPTION
## Description

- Fixed carousel slides rendering clipped on the left after clicking Next on the live survey link — the scroll-position calculation used `offsetLeft`, which resolves relative to the nearest positioned ancestor (turned out to be SurveyJS's own `.sd-question` wrapper, not the carousel strip), causing a confirmed ~40px overscroll. Switched to a `getBoundingClientRect`-based delta that's independent of surrounding page structure.
- Fixed missing spacing between the Previous/Next buttons and the progress text in the carousel footer — the theme's own edge-alignment CSS assumes a different DOM layout than ours and was silently canceling the intended gap. Added explicit spacing scoped to the carousel's own footer.

## Related Issues
closes #854 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matrix Carousel navigation so Next scrolling remains accurate across different layouts and positioning.
  * Preserved smooth scrolling behavior while avoiding unnecessary movement.

* **Style**
  * Updated carousel footer layout to align progress text and action buttons consistently.
  * Added spacing between Previous and Next buttons and corrected action bar spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->