### PR TITLE
fix(h856): Drag-to-categorize widget icon intermittently failing to load

### DIFF
--- a/features/forms/ui/editor/form-editor.tsx
+++ b/features/forms/ui/editor/form-editor.tsx
@@ -4,6 +4,7 @@ import { toast } from "@/components/ui/toast";
 import { customQuestions } from "@/customizations/questions/question-registry";
 import { useStorageWithCreator } from "@/features/asset-storage/client";
 import { useThemeManagement } from "@/features/public-form/application/use-theme-management.hook";
+import { useDesignerRuntime } from "@/lib/designer-runtime";
 import { registerAudioQuestionUI } from "@/lib/questions/audio-recorder";
 import addRandomizeGroupFeature from "@/lib/questions/features/group-randomization";
 import {
@@ -14,24 +15,24 @@ import { questionLoaderModule } from "@/lib/questions/question-loader-module";
 import { Result } from "@/lib/result";
 import { useSurveyExtensions } from "@/lib/survey-extensions/ui/use-survey-extensions";
 import { useAnyAnswered } from "@/lib/survey-features/any-answered";
-import { useSurveyDesigner } from "@/lib/survey-features/designer/design-survey.context";
-import { JSON_CHANGED_TYPE } from "@/lib/survey-features/json-editor/json-editor-state";
-import {
-  JsonEditorState,
-  useJsonEditor,
-} from "@/lib/survey-features/json-editor/use-json-editor.hook";
-import { useFormDiagnostics } from "@/lib/survey-features/form-diagnostics";
-import { useQuestionLoops } from "@/lib/survey-features/question-loops";
-import { useRichTextEditing } from "@/lib/survey-features/rich-text";
-import { useLoopAwareSummaryTableEditing } from "@/lib/survey-features/summary-table";
-import { resolveCreatorThemeCssVariables } from "@/lib/themes/resolve-creator-theme-css-variables";
-import { useEndatixCreatorTheme } from "@/lib/themes/use-endatix-themes";
 import {
   ConvertInlineChoicesDialog,
   useConvertInlineChoicesUi,
   useDataLists,
   useDataListsLoader,
 } from "@/lib/survey-features/data-lists";
+import { useSurveyDesigner } from "@/lib/survey-features/designer/design-survey.context";
+import { useFormDiagnostics } from "@/lib/survey-features/form-diagnostics";
+import { JSON_CHANGED_TYPE } from "@/lib/survey-features/json-editor/json-editor-state";
+import {
+  JsonEditorState,
+  useJsonEditor,
+} from "@/lib/survey-features/json-editor/use-json-editor.hook";
+import { useQuestionLoops } from "@/lib/survey-features/question-loops";
+import { useRichTextEditing } from "@/lib/survey-features/rich-text";
+import { useLoopAwareSummaryTableEditing } from "@/lib/survey-features/summary-table";
+import { resolveCreatorThemeCssVariables } from "@/lib/themes/resolve-creator-theme-css-variables";
+import { useEndatixCreatorTheme } from "@/lib/themes/use-endatix-themes";
 import { CreateCustomQuestionRequest } from "@/services/api";
 import "ace-builds/src-noconflict/ace";
 import "ace-builds/src-noconflict/ext-searchbox";
@@ -61,14 +62,13 @@ import "survey-creator-core/i18n";
 import "survey-creator-core/survey-creator-core.css";
 import { SurveyCreator, SurveyCreatorComponent } from "survey-creator-react";
 import { createCustomQuestionAction } from "../../application/actions/create-custom-question.action";
+import { updateFormDefinitionJsonAction } from "../../application/actions/update-form-definition-json.action";
+import { updateFormThemeAction } from "../../application/actions/update-form-theme.action";
+import { StoredTheme } from "../../domain/models/theme";
 import {
   customizeQuestionClassesOnCreator,
   loadBuiltInCustomQuestionClasses,
 } from "./survey-creator-custom-questions";
-import { updateFormDefinitionJsonAction } from "../../application/actions/update-form-definition-json.action";
-import { updateFormThemeAction } from "../../application/actions/update-form-theme.action";
-import { StoredTheme } from "../../domain/models/theme";
-import { useDesignerRuntime } from "@/lib/designer-runtime";
 
 Serializer.addProperty("theme", {
   name: "id",
@@ -104,7 +104,16 @@ translations.pehelp.fileNamesPrefix =
   "<b>Note:</b> The expression is evaluated for each submission prior to donwloading the files provided by the respondent. The unique question's name, for which the file was uploaded is always added to the filename.<br/><br/>" +
   "For more information on how to write expression, see <a target='_blank' class='hover:underline' href='https://surveyjs.io/survey-creator/documentation/end-user-guide/expression-syntax'>Expression Syntax</a>.";
 
-const downloadSettingsIcon = `<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 24 24"><defs><style>.st0{fill:none;stroke:#000;stroke-linecap:round;stroke-linejoin:round}</style></defs><path class="st0" d="M20 20c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-7.9c-.7 0-1.3-.3-1.7-.9l-.8-1.2c-.4-.6-1-.9-1.7-.9H4c-1.1 0-2 .9-2 2v13c0 1.1.9 2 2 2zm-8-10v6"/><path class="st0" d="m15 13-3 3-3-3"/></svg>`;
+// Drawn as solid-fill paths (SurveyJS's own "icon-pg-*-24x24" property-grid
+// tab icons are fill-based outlines, not strokes — a stroked path renders
+// visibly bolder next to them at the same nominal width, especially at
+// corners). Folder outline uses the hole trick (outer subpath + reversed
+// inner subpath), with its 5 convex corners given a 1-unit radius fillet —
+// the inner subpath's arcs use the opposite sweep flag from the outer's
+// since it's traced in reverse for the fill-rule hole. The step where the
+// tab meets the body is a concave corner and stays sharp. The arrow reuses
+// the same solid stem+triangle shape as DRAG_CATEGORIZE_SVG.
+const downloadSettingsIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3 21A1 1 0 0 1 2 20L2 4A1 1 0 0 1 3 3L8 3A1 1 0 0 1 9 4L9 5L21 5A1 1 0 0 1 22 6L22 20A1 1 0 0 1 21 21ZM3.5 18.5A1 1 0 0 0 4.5 19.5L19.5 19.5A1 1 0 0 0 20.5 18.5L20.5 7.5A1 1 0 0 0 19.5 6.5L7.5 6.5L7.5 5.5A1 1 0 0 0 6.5 4.5L4.5 4.5A1 1 0 0 0 3.5 5.5Z"></path><path d="M13 9V12H15L12 16L9 12H11V9H13Z"></path></svg>`;
 SvgRegistry.registerIcon("icon-download-settings", downloadSettingsIcon);
 const questionLoopsIcon =
   '<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 32 32"><defs><style>.st0{fill:none;stroke:#000;stroke-linecap:round;stroke-linejoin:round;stroke-width:2px}</style></defs><path class="st0" d="M3.3 18.3V28h25.4V9.7H9.6"/><path class="st0" d="M14.4 15.5 8.6 9.7 14.7 4"/></svg>';
@@ -715,3 +724,4 @@ function FormEditor({
 }
 export default FormEditor;
 export type { FormEditorProps };
+

--- a/lib/questions/drag-categorize/__tests__/drag-categorize.creator.test.ts
+++ b/lib/questions/drag-categorize/__tests__/drag-categorize.creator.test.ts
@@ -1,4 +1,4 @@
-import { ItemValue, SvgRegistry } from "survey-core";
+import { ItemValue } from "survey-core";
 import { getLocaleStrings, SurveyCreatorModel } from "survey-creator-core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import {
@@ -95,17 +95,6 @@ describe("bindDragCategorizeToCreator", () => {
       DRAG_CATEGORIZE_DISPLAY_NAME,
     );
     expect(toolboxItem?.title).toBe(DRAG_CATEGORIZE_DISPLAY_NAME);
-  });
-
-  it("registers a toolbox icon the Creator theme can tint", () => {
-    // Arrange & Act
-    createBoundCreator();
-    const icon = SvgRegistry.icons[DRAG_CATEGORIZE_TYPE];
-
-    // Assert — the toolbox tints icons via `fill`, so hard-coded fill/stroke
-    // attributes would render the icon black next to the built-in ones.
-    expect(icon).toBeDefined();
-    expect(icon).not.toMatch(/(fill|stroke)=/);
   });
 
   it("gives new questions two default zones via the toolbox item", () => {

--- a/lib/questions/drag-categorize/__tests__/drag-categorize.extension.test.ts
+++ b/lib/questions/drag-categorize/__tests__/drag-categorize.extension.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { QuestionFactory, Serializer } from "survey-core";
+import { QuestionFactory, Serializer, SvgRegistry } from "survey-core";
 import { SurveyCreatorModel } from "survey-creator-core";
 import { describe, expect, it } from "vitest";
 import { DRAG_CATEGORIZE_TYPE } from "../constants";
@@ -20,6 +20,18 @@ describe("dragCategorizeExtension", () => {
     expect(
       QuestionFactory.Instance.getAllTypes(),
     ).toContain(DRAG_CATEGORIZE_TYPE);
+  });
+
+  it("registers a toolbox icon the Creator theme can tint, before any Creator exists", () => {
+    // Arrange & Act — no SurveyCreatorModel involved: this must not need the
+    // lazy-loaded creator.ts bindings to be visible in the toolbox.
+    dragCategorizeExtension.onInit?.();
+    const icon = SvgRegistry.icons[DRAG_CATEGORIZE_TYPE];
+
+    // Assert — the toolbox tints icons via `fill`, so hard-coded fill/stroke
+    // attributes would render the icon black next to the built-in ones.
+    expect(icon).toBeDefined();
+    expect(icon).not.toMatch(/(fill|stroke)=/);
   });
 
   it("is safe to initialize more than once", () => {

--- a/lib/questions/drag-categorize/drag-categorize.creator.ts
+++ b/lib/questions/drag-categorize/drag-categorize.creator.ts
@@ -1,4 +1,3 @@
-import { SvgRegistry } from "survey-core";
 import { getLocaleStrings } from "survey-creator-core";
 import type { SurveyCreatorModel } from "survey-creator-core";
 import {
@@ -8,14 +7,16 @@ import {
   ZONES_PROPERTY,
 } from "./constants";
 import { registerDragCategorizeQuestion } from "./drag-categorize.component";
-import { DRAG_CATEGORIZE_SVG } from "./drag-categorize.icon";
 
 const CREATOR_BOUND_KEY = "__endatixDragCategorizeCreatorBound";
 
-/** Designer globals (icon, display name, pehelp). Called from bindDragCategorizeToCreator. */
+/**
+ * Designer globals (display name, pehelp). Called from bindDragCategorizeToCreator.
+ * The toolbox icon is registered eagerly in drag-categorize.extension.ts's
+ * onInit instead of here — see the comment there for why.
+ */
 export function registerDragCategorizeQuestionUI(): void {
   registerDragCategorizeQuestion();
-  SvgRegistry.registerIcon(DRAG_CATEGORIZE_TYPE, DRAG_CATEGORIZE_SVG);
 
   const translations = getLocaleStrings("en");
 

--- a/lib/questions/drag-categorize/drag-categorize.extension.ts
+++ b/lib/questions/drag-categorize/drag-categorize.extension.ts
@@ -1,8 +1,10 @@
+import { SvgRegistry } from "survey-core";
 import type { ExtensionModule } from "@/lib/survey-extensions/types";
 // Not the feature barrel — keeps survey-creator-core out of this chunk.
 import { registerCarryForwardForQuestionType } from "@/lib/survey-features/carry-forward/infrastructure/registry";
 import { DRAG_CATEGORIZE_TYPE } from "./constants";
 import { registerDragCategorizeQuestion } from "./drag-categorize.component";
+import { DRAG_CATEGORIZE_SVG } from "./drag-categorize.icon";
 
 /** Thin ExtensionModule adapter. See add-survey-feature skill §11. */
 const dragCategorizeExtension: ExtensionModule = {
@@ -10,6 +12,13 @@ const dragCategorizeExtension: ExtensionModule = {
     registerDragCategorizeQuestion();
     // After register: Serializer.addProperty needs the class. Flag-gated with other CF types.
     registerCarryForwardForQuestionType(DRAG_CATEGORIZE_TYPE);
+    // Registered here (not in the lazy-loaded creator.ts) so the toolbox
+    // icon is in SvgRegistry before the Creator ever mounts — the icon is
+    // a dependency-free string, it doesn't need to wait behind
+    // survey-creator-core. registerIcons (plural) also fires
+    // onIconsChanged, so an already-mounted SvgBundleComponent repaints if
+    // this somehow still runs late — registerIcon (singular) does not.
+    SvgRegistry.registerIcons({ [DRAG_CATEGORIZE_TYPE]: DRAG_CATEGORIZE_SVG });
   },
   onCreatorReady: async (creator) => {
     const { bindDragCategorizeToCreator } = await import(

--- a/lib/questions/drag-categorize/drag-categorize.icon.ts
+++ b/lib/questions/drag-categorize/drag-categorize.icon.ts
@@ -14,7 +14,7 @@ export const DRAG_CATEGORIZE_SVG = `
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <path d="M10 1H3C2.45 1 2 1.45 2 2V4C2 4.55 2.45 5 3 5H10C10.55 5 11 4.55 11 4V2C11 1.45 10.55 1 10 1Z"></path>
   <path d="M7.5 6V8H9.5L6.5 11.5L3.5 8H5.5V6H7.5Z"></path>
-  <path d="M11 13H2V22H11V13ZM9 20H4V15H9V20Z"></path>
-  <path d="M22 13H13V22H22V13ZM20 20H15V15H20V20Z"></path>
+  <path d="M11 13H2V22H11V13ZM10 21H3V14H10V21Z"></path>
+  <path d="M22 13H13V22H22V13ZM21 21H14V14H21V21Z"></path>
 </svg>
 `.trim();


### PR DESCRIPTION
## Description

**Fix intermittent/missing toolbox and tab icons for Drag to Categorize**

- Fixed the "Drag to Categorize" toolbox icon intermittently failing to render. Root cause: the icon's `SvgRegistry` registration lived behind an unawaited dynamic `import()` (deferred to keep `survey-creator-core` out of the respondent bundle), racing against the Creator's one-time icon-bundle snapshot on mount. Losing that race left the icon permanently blank for the session - a refresh only "fixed" it by luck of the chunk being warm-cached.
- Icon registration now happens synchronously in the extension's `onInit`, before any Creator instance exists, eliminating the race. The heavier Creator-only bindings (toolbox placement, zone naming) stay lazy-loaded as before.
- Switched to `SvgRegistry.registerIcons` (plural) as defense-in-depth - unlike the singular `registerIcon`, it fires `onIconsChanged`, so an already-mounted icon bundle would self-heal instead of staying stuck if this ever races again.
- Thinned the toolbox icon's zone-box borders (2→1 unit stroke-equivalent), which were rendering roughly double the visual weight of built-in toolbox icons at the same scale.

**Fix Download Settings property-grid tab icon weight**

- Redrew the "Download Settings" tab icon as solid-fill outline paths instead of an SVG stroke - SurveyJS's own property-grid tab icons (`icon-pg-*`) are fill-based, not stroke-based, so a stroked path reads bolder next to them regardless of stroke-width tuning.
- Reuses the same hole-trick outline + arrow-glyph technique as the Drag to Categorize icon, with a subtle 1-unit corner radius on the folder's outer corners to match the built-ins' softer style.

**Testing**

- Added/updated unit coverage for icon registration timing (asserts the icon is registered by `onInit()` alone, independent of any `SurveyCreatorModel`).

## Related Issues
closes #856 

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the drag-and-categorize toolbox icon with a refreshed folder-and-download design.
  * Improved icon registration so it is available reliably during extension initialization and updates existing displays.

* **Bug Fixes**
  * Refined the drag-and-categorize icon’s category zones with larger inner cutouts for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->