### PR TITLE
fix(h859): Removed `withbasepath` from server side redirect

### DIFF
--- a/features/auth/use-cases/signout/__tests__/signout.action.test.ts
+++ b/features/auth/use-cases/signout/__tests__/signout.action.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SIGNIN_PATH } from "../../../infrastructure/auth-constants";
+import { logoutAction } from "../signout.action";
 
 const mockRedirect = vi.fn();
 const mockSignOut = vi.fn();
@@ -35,9 +36,11 @@ describe("logoutAction", () => {
     mockResolveFederatedLogoutUrl.mockReturnValue(null);
   });
 
-  it("should redirect to signin without manually prefixing basePath", async () => {
-    const { logoutAction } = await import("../signout.action");
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
 
+  it("should redirect to signin without manually prefixing basePath", async () => {
     await expect(logoutAction()).rejects.toThrow(`Redirect to ${SIGNIN_PATH}`);
 
     expect(mockSignOut).toHaveBeenCalledWith({ redirect: false });
@@ -45,11 +48,29 @@ describe("logoutAction", () => {
     expect(mockRedirect).not.toHaveBeenCalledWith("/app/signin");
   });
 
+  it("should pass the auth token to resolveFederatedLogoutUrl", async () => {
+    const token = { provider: "keycloak", access_token: "token" };
+    mockGetAuthJwtFromRequest.mockResolvedValue(token);
+
+    await expect(logoutAction()).rejects.toThrow(`Redirect to ${SIGNIN_PATH}`);
+
+    expect(mockResolveFederatedLogoutUrl).toHaveBeenCalledWith(token);
+  });
+
+  it("should redirect to signin when federated logout resolution throws", async () => {
+    mockResolveFederatedLogoutUrl.mockImplementation(() => {
+      throw new Error("resolver failed");
+    });
+
+    await expect(logoutAction()).rejects.toThrow(`Redirect to ${SIGNIN_PATH}`);
+
+    expect(mockRedirect).toHaveBeenCalledWith(SIGNIN_PATH);
+    expect(mockRedirect).not.toHaveBeenCalledWith("/app/signin");
+  });
+
   it("should redirect to federated logout URL when available", async () => {
     const federatedLogoutUrl = "https://idp.example.com/logout";
     mockResolveFederatedLogoutUrl.mockReturnValue(federatedLogoutUrl);
-
-    const { logoutAction } = await import("../signout.action");
 
     await expect(logoutAction()).rejects.toThrow(
       `Redirect to ${federatedLogoutUrl}`,

--- a/features/auth/use-cases/signout/__tests__/signout.action.test.ts
+++ b/features/auth/use-cases/signout/__tests__/signout.action.test.ts
@@ -1,107 +1,61 @@
-// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SIGNIN_PATH } from "../../../infrastructure/auth-constants";
 
-import type { JWT } from "next-auth/jwt";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SIGNIN_PATH } from "@/features/auth/infrastructure/auth-constants";
-import { logoutAction } from "../signout.action";
-import { signOut } from "@/auth";
-import { getAuthJwtFromRequest } from "@/features/auth/infrastructure/auth-jwt.utils";
-import { resolveFederatedLogoutUrl } from "@/features/auth/infrastructure/auth-logout.utils";
-import { redirect } from "next/navigation";
+const mockRedirect = vi.fn();
+const mockSignOut = vi.fn();
+const mockGetAuthJwtFromRequest = vi.fn();
+const mockResolveFederatedLogoutUrl = vi.fn();
 
-const mocks = vi.hoisted(() => ({
-  signOut: vi.fn(),
-  getAuthJwtFromRequest: vi.fn(),
-  resolveFederatedLogoutUrl: vi.fn(),
-  redirect: vi.fn((path: string) => {
+vi.mock("next/navigation", () => ({
+  redirect: (path: string) => {
+    mockRedirect(path);
     throw new Error(`Redirect to ${path}`);
-  }),
+  },
 }));
 
 vi.mock("@/auth", () => ({
-  signOut: mocks.signOut,
+  signOut: (...args: unknown[]) => mockSignOut(...args),
 }));
 
-vi.mock("@/features/auth/infrastructure/auth-jwt.utils", () => ({
-  getAuthJwtFromRequest: mocks.getAuthJwtFromRequest,
+vi.mock("../../../infrastructure/auth-jwt.utils", () => ({
+  getAuthJwtFromRequest: () => mockGetAuthJwtFromRequest(),
 }));
 
-vi.mock("@/features/auth/infrastructure/auth-logout.utils", () => ({
-  resolveFederatedLogoutUrl: mocks.resolveFederatedLogoutUrl,
-}));
-
-vi.mock("next/navigation", () => ({
-  redirect: mocks.redirect,
+vi.mock("../../../infrastructure/auth-logout.utils", () => ({
+  resolveFederatedLogoutUrl: (...args: unknown[]) =>
+    mockResolveFederatedLogoutUrl(...args),
 }));
 
 describe("logoutAction", () => {
-  const token = { provider: "keycloak", id_token: "id-token" } as JWT;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.NEXT_PUBLIC_BASE_PATH;
-    vi.mocked(getAuthJwtFromRequest).mockResolvedValue(token);
-    vi.mocked(resolveFederatedLogoutUrl).mockReturnValue(null);
-    vi.mocked(signOut).mockResolvedValue(undefined);
+    vi.stubEnv("NEXT_PUBLIC_BASE_PATH", "/app");
+    mockSignOut.mockResolvedValue(undefined);
+    mockGetAuthJwtFromRequest.mockResolvedValue(null);
+    mockResolveFederatedLogoutUrl.mockReturnValue(null);
   });
 
-  afterEach(() => {
-    delete process.env.NEXT_PUBLIC_BASE_PATH;
+  it("should redirect to signin without manually prefixing basePath", async () => {
+    const { logoutAction } = await import("../signout.action");
+
+    await expect(logoutAction()).rejects.toThrow(`Redirect to ${SIGNIN_PATH}`);
+
+    expect(mockSignOut).toHaveBeenCalledWith({ redirect: false });
+    expect(mockRedirect).toHaveBeenCalledWith(SIGNIN_PATH);
+    expect(mockRedirect).not.toHaveBeenCalledWith("/app/signin");
   });
 
-  it("reads the JWT, resolves federated logout, clears the session, and redirects", async () => {
-    const federatedLogoutUrl =
-      "https://keycloak.endatix.test/realms/endatix/protocol/openid-connect/logout?id_token_hint=id-token";
-    vi.mocked(resolveFederatedLogoutUrl).mockReturnValue(federatedLogoutUrl);
+  it("should redirect to federated logout URL when available", async () => {
+    const federatedLogoutUrl = "https://idp.example.com/logout";
+    mockResolveFederatedLogoutUrl.mockReturnValue(federatedLogoutUrl);
+
+    const { logoutAction } = await import("../signout.action");
 
     await expect(logoutAction()).rejects.toThrow(
       `Redirect to ${federatedLogoutUrl}`,
     );
 
-    expect(getAuthJwtFromRequest).toHaveBeenCalledOnce();
-    expect(resolveFederatedLogoutUrl).toHaveBeenCalledWith(token);
-    expect(signOut).toHaveBeenCalledWith({ redirect: false });
-    expect(redirect).toHaveBeenCalledWith(federatedLogoutUrl);
-  });
-
-  it("redirects to sign in when no federated logout URL is returned", async () => {
-    await expect(logoutAction()).rejects.toThrow(`Redirect to ${SIGNIN_PATH}`);
-
-    expect(getAuthJwtFromRequest).toHaveBeenCalledOnce();
-    expect(resolveFederatedLogoutUrl).toHaveBeenCalledWith(token);
-    expect(signOut).toHaveBeenCalledWith({ redirect: false });
-    expect(redirect).toHaveBeenCalledWith(SIGNIN_PATH);
-  });
-
-  it("applies the base path to the local sign-in fallback redirect", async () => {
-    process.env.NEXT_PUBLIC_BASE_PATH = "/hub";
-
-    await expect(logoutAction()).rejects.toThrow("Redirect to /hub/signin");
-
-    expect(getAuthJwtFromRequest).toHaveBeenCalledOnce();
-    expect(resolveFederatedLogoutUrl).toHaveBeenCalledWith(token);
-    expect(signOut).toHaveBeenCalledWith({ redirect: false });
-    expect(redirect).toHaveBeenCalledWith("/hub/signin");
-  });
-
-  it("clears the local session and falls back when federated logout resolution fails", async () => {
-    const error = new Error("Federated logout unavailable");
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.mocked(resolveFederatedLogoutUrl).mockImplementation(() => {
-      throw error;
-    });
-
-    await expect(logoutAction()).rejects.toThrow(`Redirect to ${SIGNIN_PATH}`);
-
-    expect(getAuthJwtFromRequest).toHaveBeenCalledOnce();
-    expect(resolveFederatedLogoutUrl).toHaveBeenCalledWith(token);
-    expect(signOut).toHaveBeenCalledWith({ redirect: false });
-    expect(redirect).toHaveBeenCalledWith(SIGNIN_PATH);
-    expect(warnSpy).toHaveBeenCalledWith(
-      "Failed to resolve federated logout URL",
-      error,
-    );
-
-    warnSpy.mockRestore();
+    expect(mockRedirect).toHaveBeenCalledWith(federatedLogoutUrl);
+    expect(mockRedirect).not.toHaveBeenCalledWith(SIGNIN_PATH);
   });
 });

--- a/features/auth/use-cases/signout/signout.action.ts
+++ b/features/auth/use-cases/signout/signout.action.ts
@@ -4,11 +4,9 @@ import { signOut } from "@/auth";
 import { getAuthJwtFromRequest } from "../../infrastructure/auth-jwt.utils";
 import { resolveFederatedLogoutUrl } from "../../infrastructure/auth-logout.utils";
 import { SIGNIN_PATH } from "../../infrastructure/auth-constants";
-import { withBasePath } from "@/lib/hosting/base-path";
 import { redirect } from "next/navigation";
 
 type ExternalRedirectUrl = `${string}:${string}`;
-type InternalRedirectUrl = Parameters<typeof redirect>[0];
 
 /**
  * Signs out the user and redirects to the federated logout URL if available, otherwise redirects to the signin page.
@@ -29,10 +27,5 @@ export async function logoutAction() {
     redirect(federatedLogoutUrl as ExternalRedirectUrl);
   }
 
-  redirect(
-    withBasePath(
-      SIGNIN_PATH,
-      process.env.NEXT_PUBLIC_BASE_PATH,
-    ) as InternalRedirectUrl,
-  );
+  redirect(SIGNIN_PATH);
 }


### PR DESCRIPTION
## Description

**Root cause:** In `logoutAction`, the post-sign-out redirect used `withBasePath(SIGNIN_PATH, NEXT_PUBLIC_BASE_PATH)` before calling Next.js `redirect()`. With `basePath` set in `next.config.ts` (from `NEXT_PUBLIC_BASE_PATH=/app`), `redirect()` already prepends the base path. That produced `/app` + `/app/signin` → `/app/app/signin`.

**Fix:** Use `redirect(SIGNIN_PATH)` directly, consistent with other server-side redirects (`error-handler.ts`, `unauthorized/page.tsx`, etc.). `withBasePath` is still correct in `proxy.ts` because `NextResponse.redirect()` does not apply `basePath` automatically.

```32:32:hub/features/auth/use-cases/signout/signout.action.ts
  redirect(SIGNIN_PATH);
```

Added a unit test that verifies the redirect target stays `/signin` (not `/app/signin`) when `NEXT_PUBLIC_BASE_PATH=/app`, so Next.js can apply the prefix once. 

## Related Issues
closes #859 

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sign-out behavior to redirect consistently to the sign-in page.
  * Federated logout redirects continue to be supported when available.
  * Simplified redirect handling to avoid unexpected path variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->