### PR TITLE
feat(h842): Implemented height mode for embedded forms

### DIFF
--- a/app/(public)/embed/[formId]/page.tsx
+++ b/app/(public)/embed/[formId]/page.tsx
@@ -3,6 +3,7 @@ import "@/features/public-form/ui/already-responded-standalone.css";
 import {
   DEFAULT_FILL_BACKGROUND_COLOR,
   isFillHeightMode,
+  isValidEmbedId,
 } from "@/features/embed-form/height-mode";
 import { PublicSurveyContent } from "@/features/public-form/ui/public-survey-content";
 import { PublicSurveySkeleton } from "@/features/public-form/ui/public-survey-skeleton";
@@ -22,8 +23,10 @@ async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
   const { formId } = await params;
   const { token: urlToken, heightMode, embedId } = await searchParams;
   // Only apply fill-mode layout when this looks like a genuine embed.js load
-  // (it always sets embedId), not a direct/manual ?heightMode=fill visit.
-  const isFillMode = isFillHeightMode(heightMode) && Boolean(embedId);
+  // (it always sets a well-formed embedId), not a direct/manual
+  // ?heightMode=fill visit — same predicate the client-side messaging
+  // context uses, so server and client agree on when fill mode is active.
+  const isFillMode = isFillHeightMode(heightMode) && isValidEmbedId(embedId);
 
   if (urlToken) {
     if (!hasShareContinuationTokenPermission(urlToken)) {

--- a/app/(public)/embed/[formId]/page.tsx
+++ b/app/(public)/embed/[formId]/page.tsx
@@ -1,5 +1,9 @@
 import { NotFoundComponent } from "@/components/error-handling/not-found/not-found-component";
 import "@/features/public-form/ui/already-responded-standalone.css";
+import {
+  DEFAULT_FILL_BACKGROUND_COLOR,
+  isFillHeightMode,
+} from "@/features/embed-form/height-mode";
 import { PublicSurveyContent } from "@/features/public-form/ui/public-survey-content";
 import { PublicSurveySkeleton } from "@/features/public-form/ui/public-survey-skeleton";
 import { hasShareContinuationTokenPermission } from "@/lib/utils";
@@ -7,12 +11,19 @@ import { Suspense } from "react";
 
 type EmbedSurveyPage = {
   params: Promise<{ formId: string }>;
-  searchParams: Promise<{ token?: string }>;
+  searchParams: Promise<{
+    token?: string;
+    heightMode?: string;
+    embedId?: string;
+  }>;
 };
 
 async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
   const { formId } = await params;
-  const { token: urlToken } = await searchParams;
+  const { token: urlToken, heightMode, embedId } = await searchParams;
+  // Only apply fill-mode layout when this looks like a genuine embed.js load
+  // (it always sets embedId), not a direct/manual ?heightMode=fill visit.
+  const isFillMode = isFillHeightMode(heightMode) && Boolean(embedId);
 
   if (urlToken) {
     if (!hasShareContinuationTokenPermission(urlToken)) {
@@ -31,8 +42,12 @@ async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
     <div
       style={{
         width: "100%",
+        height: isFillMode ? "100%" : undefined,
       }}
     >
+      {isFillMode && (
+        <style>{`html, body { height: 100%; margin: 0; background-color: ${DEFAULT_FILL_BACKGROUND_COLOR}; }`}</style>
+      )}
       <Suspense fallback={<PublicSurveySkeleton variant="embed" />}>
         <PublicSurveyContent
           formId={formId}

--- a/app/(public)/embed/[formId]/page.tsx
+++ b/app/(public)/embed/[formId]/page.tsx
@@ -3,7 +3,6 @@ import "@/features/public-form/ui/already-responded-standalone.css";
 import {
   DEFAULT_FILL_BACKGROUND_COLOR,
   isFillHeightMode,
-  isValidEmbedId,
 } from "@/features/embed-form/height-mode";
 import { PublicSurveyContent } from "@/features/public-form/ui/public-survey-content";
 import { PublicSurveySkeleton } from "@/features/public-form/ui/public-survey-skeleton";
@@ -12,21 +11,19 @@ import { Suspense } from "react";
 
 type EmbedSurveyPage = {
   params: Promise<{ formId: string }>;
-  searchParams: Promise<{
-    token?: string;
-    heightMode?: string;
-    embedId?: string;
-  }>;
+  searchParams: Promise<{ token?: string; heightMode?: string }>;
 };
 
 async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
   const { formId } = await params;
-  const { token: urlToken, heightMode, embedId } = await searchParams;
-  // Only apply fill-mode layout when this looks like a genuine embed.js load
-  // (it always sets a well-formed embedId), not a direct/manual
-  // ?heightMode=fill visit — same predicate the client-side messaging
-  // context uses, so server and client agree on when fill mode is active.
-  const isFillMode = isFillHeightMode(heightMode) && isValidEmbedId(embedId);
+  const { token: urlToken, heightMode } = await searchParams;
+  // Fill-mode layout/paint is cosmetic only (a loading-phase default, later
+  // refined once the survey's real theme is known — see survey-component.tsx),
+  // so it's fine to key it off heightMode alone here. Whether this is a
+  // genuine embed.js load vs. a manually-typed URL isn't this page's call to
+  // make — that check belongs to embed-messaging-context.ts, where embedId
+  // is actually used for something (routing postMessage traffic).
+  const isFillMode = isFillHeightMode(heightMode);
 
   if (urlToken) {
     if (!hasShareContinuationTokenPermission(urlToken)) {
@@ -42,14 +39,9 @@ async function EmbedSurveyPage({ params, searchParams }: EmbedSurveyPage) {
   }
 
   return (
-    <div
-      style={{
-        width: "100%",
-        height: isFillMode ? "100%" : undefined,
-      }}
-    >
+    <div style={{ width: "100%" }}>
       {isFillMode && (
-        <style>{`html, body { height: 100%; margin: 0; background-color: ${DEFAULT_FILL_BACKGROUND_COLOR}; }`}</style>
+        <style>{`html, body { margin: 0; background-color: ${DEFAULT_FILL_BACKGROUND_COLOR}; }`}</style>
       )}
       <Suspense fallback={<PublicSurveySkeleton variant="embed" />}>
         <PublicSurveyContent

--- a/e2e/tests/embed/embed-form.spec.ts
+++ b/e2e/tests/embed/embed-form.spec.ts
@@ -139,3 +139,69 @@ test.describe("Embed Form Behavior (Real Environment)", () => {
     expect(page.url()).toContain("endatix.com");
   });
 });
+
+test.describe("Embed Form Height Modes (Real Environment)", () => {
+  const TEST_FORM_ID = process.env.E2E_EMBED_FORM_ID || "0";
+  const CONTAINER_HEIGHT_PX = 900;
+
+  test.beforeEach(async ({ page, baseURL }) => {
+    // Mock a host page whose script sits inside a fixed-height container,
+    // matching the customer scenario from endatix-hub#842.
+    await page.route(`${baseURL}/__mock_host_fill__`, async (route) => {
+      await route.fulfill({
+        contentType: "text/html",
+        body: `
+              <!DOCTYPE html>
+              <html>
+                <head>
+                  <title>Test Host Page (Fill Mode)</title>
+                  <style>
+                    body { padding: 50px; background: #f0f0f0; font-family: sans-serif; }
+                  </style>
+                </head>
+                <body>
+                  <h1>My External Website</h1>
+                  <div style="height: ${CONTAINER_HEIGHT_PX}px; border: 1px solid #ccc;">
+                    <script
+                      src="${baseURL}/embed/v1/embed.js"
+                      data-form-id="${TEST_FORM_ID}"
+                      data-height-mode="fill">
+                    </script>
+                  </div>
+                </body>
+              </html>
+            `,
+      });
+    });
+
+    await page.goto(`${baseURL}/__mock_host_fill__`);
+  });
+
+  test("fills a fixed-height parent container when content is shorter", async ({
+    page,
+  }) => {
+    const iframeLocator = page.locator(`iframe[id^="edxf-${TEST_FORM_ID}"]`);
+    const frame = page.frameLocator(`iframe[id^="edxf-${TEST_FORM_ID}"]`);
+    await expect(frame.locator(".sd-root-modern")).toBeVisible();
+
+    // The browser resolves `min-height: 100%` against the 900px container natively;
+    // give layout a moment to settle before measuring.
+    await expect
+      .poll(async () => {
+        const box = await iframeLocator.boundingBox();
+        return box?.height ?? 0;
+      })
+      .toBeGreaterThanOrEqual(CONTAINER_HEIGHT_PX - 5);
+
+    // The outer iframe box filling the container isn't enough on its own —
+    // the document inside it must also paint that space, or the host page's
+    // own background shows through below the (much shorter) survey content.
+    const frameElement = await iframeLocator.elementHandle();
+    const frameDocument = await frameElement?.contentFrame();
+    const bodyBackground = await frameDocument?.evaluate(
+      () => getComputedStyle(document.body).backgroundColor,
+    );
+    expect(bodyBackground).not.toBe("rgba(0, 0, 0, 0)");
+    expect(bodyBackground).toBeTruthy();
+  });
+});

--- a/e2e/tests/embed/embed-form.spec.ts
+++ b/e2e/tests/embed/embed-form.spec.ts
@@ -184,6 +184,15 @@ test.describe("Embed Form Height Modes (Real Environment)", () => {
     const frame = page.frameLocator(`iframe[id^="edxf-${TEST_FORM_ID}"]`);
     await expect(frame.locator(".sd-root-modern")).toBeVisible();
 
+    // Confirm this test's own premise: if the seeded form's content isn't
+    // actually shorter than the container, ">= container height" would
+    // trivially pass in plain auto mode too and this test would prove
+    // nothing about fill mode specifically.
+    const contentHeight = await frame
+      .locator(".sd-root-modern")
+      .evaluate((el) => el.getBoundingClientRect().height);
+    expect(contentHeight).toBeLessThan(CONTAINER_HEIGHT_PX);
+
     // The browser resolves `min-height: 100%` against the 900px container natively;
     // give layout a moment to settle before measuring.
     await expect
@@ -192,6 +201,11 @@ test.describe("Embed Form Height Modes (Real Environment)", () => {
         return box?.height ?? 0;
       })
       .toBeGreaterThanOrEqual(CONTAINER_HEIGHT_PX - 5);
+
+    // Upper bound too: proves the iframe settled at the container's height,
+    // not merely "grew to at least" it for some unrelated reason.
+    const finalHeight = (await iframeLocator.boundingBox())?.height ?? 0;
+    expect(finalHeight).toBeLessThan(CONTAINER_HEIGHT_PX + 20);
 
     // The outer iframe box filling the container isn't enough on its own —
     // the document inside it must also paint that space, or the host page's
@@ -203,5 +217,44 @@ test.describe("Embed Form Height Modes (Real Environment)", () => {
     );
     expect(bodyBackground).not.toBe("rgba(0, 0, 0, 0)");
     expect(bodyBackground).toBeTruthy();
+  });
+
+  test("grows past the container when content is taller, and shrinks back down when content shrinks again", async ({
+    page,
+  }) => {
+    const iframeLocator = page.locator(`iframe[id^="edxf-${TEST_FORM_ID}"]`);
+    const frame = page.frameLocator(`iframe[id^="edxf-${TEST_FORM_ID}"]`);
+    await expect(frame.locator(".sd-root-modern")).toBeVisible();
+
+    const frameElement = await iframeLocator.elementHandle();
+    const frameDocument = await frameElement?.contentFrame();
+
+    // Simulate navigating to a page tall enough to exceed the container —
+    // same content-height change EmbedHeightReporter's MutationObserver
+    // would see from a real multi-page form, without depending on the
+    // seeded form having a page that happens to be this tall.
+    await frameDocument?.evaluate(() => {
+      const spacer = document.createElement("div");
+      spacer.id = "__e2e_grow_spacer__";
+      spacer.style.height = "1600px";
+      document.body.appendChild(spacer);
+    });
+
+    await expect
+      .poll(async () => (await iframeLocator.boundingBox())?.height ?? 0)
+      .toBeGreaterThan(CONTAINER_HEIGHT_PX + 100);
+
+    // Simulate navigating back to a short page. This is the case #842's
+    // own design goal (and this PR's CSS-only approach) explicitly targets:
+    // the used height must track content again, not stay pinned at the
+    // tallest height ever seen — the same ratchet problem the issue's own
+    // proposed Math.max(content, container) implementation would have had.
+    await frameDocument?.evaluate(() => {
+      document.getElementById("__e2e_grow_spacer__")?.remove();
+    });
+
+    await expect
+      .poll(async () => (await iframeLocator.boundingBox())?.height ?? 0)
+      .toBeLessThan(CONTAINER_HEIGHT_PX + 20);
   });
 });

--- a/features/embed-form/height-mode.ts
+++ b/features/embed-form/height-mode.ts
@@ -4,17 +4,3 @@ export const DEFAULT_FILL_BACKGROUND_COLOR = "#f3f3f3";
 export function isFillHeightMode(value: string | null | undefined): boolean {
   return value === "fill";
 }
-
-const EMBED_ID_PATTERN = /^[a-zA-Z0-9:_-]{1,128}$/;
-
-/**
- * Same format check the parent-page SDK's generated embedId always matches
- * (see createEmbedId in src/embed/embed.ts). Shared so the server-rendered
- * embed page and the client-side messaging context agree on what counts as
- * a genuine embed.js load, not just "some non-empty string was in the URL".
- */
-export function isValidEmbedId(
-  value: string | null | undefined,
-): value is string {
-  return typeof value === "string" && EMBED_ID_PATTERN.test(value);
-}

--- a/features/embed-form/height-mode.ts
+++ b/features/embed-form/height-mode.ts
@@ -4,3 +4,17 @@ export const DEFAULT_FILL_BACKGROUND_COLOR = "#f3f3f3";
 export function isFillHeightMode(value: string | null | undefined): boolean {
   return value === "fill";
 }
+
+const EMBED_ID_PATTERN = /^[a-zA-Z0-9:_-]{1,128}$/;
+
+/**
+ * Same format check the parent-page SDK's generated embedId always matches
+ * (see createEmbedId in src/embed/embed.ts). Shared so the server-rendered
+ * embed page and the client-side messaging context agree on what counts as
+ * a genuine embed.js load, not just "some non-empty string was in the URL".
+ */
+export function isValidEmbedId(
+  value: string | null | undefined,
+): value is string {
+  return typeof value === "string" && EMBED_ID_PATTERN.test(value);
+}

--- a/features/embed-form/height-mode.ts
+++ b/features/embed-form/height-mode.ts
@@ -1,0 +1,6 @@
+/** Neutral fallback used before the survey's own theme is known (or if it never defines a dim background), so fill mode never leaves a transparent gap. */
+export const DEFAULT_FILL_BACKGROUND_COLOR = "#f3f3f3";
+
+export function isFillHeightMode(value: string | null | undefined): boolean {
+  return value === "fill";
+}

--- a/features/embed-form/types.ts
+++ b/features/embed-form/types.ts
@@ -9,6 +9,7 @@ export type EmbedMessageType =
 export interface EmbedMessagingContext {
   embedId?: string;
   parentOrigin?: string;
+  heightMode?: "auto" | "fill";
 }
 
 export interface EmbedFormInfo {

--- a/features/embed-form/ui/__tests__/embed-messaging-context.test.ts
+++ b/features/embed-form/ui/__tests__/embed-messaging-context.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getEmbedMessagingContext } from "../embed-messaging-context";
+
+function setUrl(search: string): void {
+  window.history.replaceState(null, "", `/embed/123${search}`);
+}
+
+describe("getEmbedMessagingContext", () => {
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("returns an empty context when no relevant query params are present", () => {
+    setUrl("");
+
+    expect(getEmbedMessagingContext()).toEqual({
+      embedId: undefined,
+      parentOrigin: undefined,
+      heightMode: undefined,
+    });
+  });
+
+  it("parses a valid embedId", () => {
+    setUrl("?embedId=edxf-123-0-abc123");
+
+    expect(getEmbedMessagingContext().embedId).toBe("edxf-123-0-abc123");
+  });
+
+  it("rejects an embedId with disallowed characters", () => {
+    setUrl(`?embedId=${encodeURIComponent("<script>alert(1)</script>")}`);
+
+    expect(getEmbedMessagingContext().embedId).toBeUndefined();
+  });
+
+  it("parses a valid http(s) parentOrigin", () => {
+    setUrl(
+      `?parentOrigin=${encodeURIComponent("https://customer.example")}`,
+    );
+
+    expect(getEmbedMessagingContext().parentOrigin).toBe(
+      "https://customer.example",
+    );
+  });
+
+  it("rejects a non-http(s) parentOrigin", () => {
+    setUrl(`?parentOrigin=${encodeURIComponent("javascript:alert(1)")}`);
+
+    expect(getEmbedMessagingContext().parentOrigin).toBeUndefined();
+  });
+
+  it("rejects a malformed parentOrigin", () => {
+    setUrl("?parentOrigin=not-a-url");
+
+    expect(getEmbedMessagingContext().parentOrigin).toBeUndefined();
+  });
+
+  it("parses heightMode=fill", () => {
+    setUrl("?heightMode=fill");
+
+    expect(getEmbedMessagingContext().heightMode).toBe("fill");
+  });
+
+  it("treats an invalid heightMode value as absent (auto)", () => {
+    setUrl("?heightMode=bogus");
+
+    expect(getEmbedMessagingContext().heightMode).toBeUndefined();
+  });
+
+  it("is case-sensitive for heightMode", () => {
+    setUrl("?heightMode=Fill");
+
+    expect(getEmbedMessagingContext().heightMode).toBeUndefined();
+  });
+
+  it("parses all three params together", () => {
+    setUrl(
+      "?embedId=edxf-123-0-abc123&parentOrigin=" +
+        encodeURIComponent("https://customer.example") +
+        "&heightMode=fill",
+    );
+
+    expect(getEmbedMessagingContext()).toEqual({
+      embedId: "edxf-123-0-abc123",
+      parentOrigin: "https://customer.example",
+      heightMode: "fill",
+    });
+  });
+});

--- a/features/embed-form/ui/__tests__/embed-messaging-context.test.ts
+++ b/features/embed-form/ui/__tests__/embed-messaging-context.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { getEmbedMessagingContext } from "../embed-messaging-context";
+import {
+  getEmbedMessagingContext,
+  isValidEmbedId,
+} from "../embed-messaging-context";
 
 function setUrl(search: string): void {
   window.history.replaceState(null, "", `/embed/123${search}`);
@@ -84,5 +87,37 @@ describe("getEmbedMessagingContext", () => {
       parentOrigin: "https://customer.example",
       heightMode: "fill",
     });
+  });
+});
+
+describe("isValidEmbedId", () => {
+  it("accepts an embedId matching the SDK's generated format", () => {
+    expect(isValidEmbedId("edxf-123-0-abc123")).toBe(true);
+  });
+
+  it("accepts alphanumeric, colon, underscore, and hyphen characters", () => {
+    expect(isValidEmbedId("Az09:_-")).toBe(true);
+  });
+
+  it("rejects undefined and null", () => {
+    expect(isValidEmbedId(undefined)).toBe(false);
+    expect(isValidEmbedId(null)).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isValidEmbedId("")).toBe(false);
+  });
+
+  it("rejects disallowed characters", () => {
+    expect(isValidEmbedId("<script>alert(1)</script>")).toBe(false);
+    expect(isValidEmbedId("has spaces")).toBe(false);
+  });
+
+  it("rejects a string longer than 128 characters", () => {
+    expect(isValidEmbedId("a".repeat(129))).toBe(false);
+  });
+
+  it("accepts a string exactly 128 characters long", () => {
+    expect(isValidEmbedId("a".repeat(128))).toBe(true);
   });
 });

--- a/features/embed-form/ui/embed-messaging-context.ts
+++ b/features/embed-form/ui/embed-messaging-context.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { isFillHeightMode } from "../height-mode";
+import { isFillHeightMode, isValidEmbedId } from "../height-mode";
 import type { EmbedMessagingContext } from "../types";
 
 export const EMBED_ID_QUERY_PARAM = "embedId";
@@ -23,11 +23,7 @@ function parseHttpOrigin(value: string | null): string | undefined {
 }
 
 function parseEmbedId(value: string | null): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  return /^[a-zA-Z0-9:_-]{1,128}$/.test(value) ? value : undefined;
+  return isValidEmbedId(value) ? value : undefined;
 }
 
 function parseHeightMode(value: string | null): "auto" | "fill" | undefined {

--- a/features/embed-form/ui/embed-messaging-context.ts
+++ b/features/embed-form/ui/embed-messaging-context.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { isFillHeightMode, isValidEmbedId } from "../height-mode";
+import { isFillHeightMode } from "../height-mode";
 import type { EmbedMessagingContext } from "../types";
 
 export const EMBED_ID_QUERY_PARAM = "embedId";
@@ -20,6 +20,21 @@ function parseHttpOrigin(value: string | null): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+const EMBED_ID_PATTERN = /^[a-zA-Z0-9:_-]{1,128}$/;
+
+/**
+ * Charset/length allowlist for the embedId the parent-page SDK generates
+ * (see createEmbedId in src/embed/embed.ts) to tell multiple embed
+ * instances on one page apart and route postMessage traffic to the right
+ * one. This is untrusted query input, not a security gate — it exists for
+ * messaging, not to prove "the SDK was here" for other purposes.
+ */
+export function isValidEmbedId(
+  value: string | null | undefined,
+): value is string {
+  return typeof value === "string" && EMBED_ID_PATTERN.test(value);
 }
 
 function parseEmbedId(value: string | null): string | undefined {

--- a/features/embed-form/ui/embed-messaging-context.ts
+++ b/features/embed-form/ui/embed-messaging-context.ts
@@ -1,9 +1,11 @@
 "use client";
 
+import { isFillHeightMode } from "../height-mode";
 import type { EmbedMessagingContext } from "../types";
 
 export const EMBED_ID_QUERY_PARAM = "embedId";
 const PARENT_ORIGIN_QUERY_PARAM = "parentOrigin";
+const HEIGHT_MODE_QUERY_PARAM = "heightMode";
 
 function parseHttpOrigin(value: string | null): string | undefined {
   if (!value) {
@@ -28,6 +30,10 @@ function parseEmbedId(value: string | null): string | undefined {
   return /^[a-zA-Z0-9:_-]{1,128}$/.test(value) ? value : undefined;
 }
 
+function parseHeightMode(value: string | null): "auto" | "fill" | undefined {
+  return isFillHeightMode(value) ? "fill" : undefined;
+}
+
 export function getEmbedMessagingContext(): EmbedMessagingContext {
   if (globalThis.window === undefined) {
     return {};
@@ -42,5 +48,6 @@ export function getEmbedMessagingContext(): EmbedMessagingContext {
   return {
     embedId: parseEmbedId(searchParams.get(EMBED_ID_QUERY_PARAM)),
     parentOrigin: parseHttpOrigin(searchParams.get(PARENT_ORIGIN_QUERY_PARAM)),
+    heightMode: parseHeightMode(searchParams.get(HEIGHT_MODE_QUERY_PARAM)),
   };
 }

--- a/features/forms/ui/__tests__/share-dialog.test.tsx
+++ b/features/forms/ui/__tests__/share-dialog.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ShareDialog } from "../share-dialog";
+
+describe("ShareDialog", () => {
+  async function openEmbedCodeTab() {
+    render(<ShareDialog formId="123" open onOpenChange={() => {}} />);
+
+    // Radix's TabsTrigger switches tabs on mousedown, not click.
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /embed code/i }), {
+      button: 0,
+    });
+
+    // Wait for a signal unique to the embed-code panel (the height-mode
+    // radio group) before touching the textarea, since the "share link"
+    // panel also renders a read-only textbox-role input.
+    await screen.findByRole("radiogroup");
+
+    return screen.getByRole("textbox") as HTMLTextAreaElement;
+  }
+
+  it("omits data-height-mode from the default auto-resize snippet", async () => {
+    const textarea = await openEmbedCodeTab();
+
+    expect(textarea.value).toContain('data-form-id="123"');
+    expect(textarea.value).not.toContain("data-height-mode");
+  });
+
+  it('adds data-height-mode="fill" when Fill container is selected', async () => {
+    await openEmbedCodeTab();
+
+    fireEvent.click(screen.getByRole("radio", { name: /fill container/i }));
+
+    await waitFor(() => {
+      const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+      expect(textarea.value).toContain('data-height-mode="fill"');
+    });
+  });
+
+  it("wraps the script in a sized container when Fill container is selected", async () => {
+    await openEmbedCodeTab();
+
+    fireEvent.click(screen.getByRole("radio", { name: /fill container/i }));
+
+    await waitFor(() => {
+      const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+      expect(textarea.value).toMatch(/<div style="height: \d+px;">/);
+      expect(textarea.value).toContain("</div>");
+    });
+  });
+
+  it("does not wrap the script in the default auto-resize snippet", async () => {
+    const textarea = await openEmbedCodeTab();
+
+    expect(textarea.value).not.toContain("<div");
+  });
+
+  it("removes data-height-mode again when switching back to Auto-resize", async () => {
+    await openEmbedCodeTab();
+
+    fireEvent.click(screen.getByRole("radio", { name: /fill container/i }));
+    await waitFor(() => {
+      const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+      expect(textarea.value).toContain("data-height-mode");
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: /auto-resize/i }));
+    await waitFor(() => {
+      const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+      expect(textarea.value).not.toContain("data-height-mode");
+      expect(textarea.value).not.toContain("<div");
+    });
+  });
+});

--- a/features/forms/ui/__tests__/share-dialog.test.tsx
+++ b/features/forms/ui/__tests__/share-dialog.test.tsx
@@ -26,33 +26,19 @@ describe("ShareDialog", () => {
     expect(textarea.value).not.toContain("data-height-mode");
   });
 
-  it('adds data-height-mode="fill" when Fill container is selected', async () => {
+  it('adds data-height-mode="fill" when Fill container is selected, without wrapping the script', async () => {
     await openEmbedCodeTab();
 
     fireEvent.click(screen.getByRole("radio", { name: /fill container/i }));
 
     await waitFor(() => {
       const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+      // No wrapper div: customers embedding fill mode into their own
+      // existing sized container shouldn't have to strip one out first.
       expect(textarea.value).toContain('data-height-mode="fill"');
+      expect(textarea.value).not.toContain("<div");
+      expect(textarea.value.trim().startsWith("<script")).toBe(true);
     });
-  });
-
-  it("wraps the script in a sized container when Fill container is selected", async () => {
-    await openEmbedCodeTab();
-
-    fireEvent.click(screen.getByRole("radio", { name: /fill container/i }));
-
-    await waitFor(() => {
-      const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
-      expect(textarea.value).toMatch(/<div style="height: \d+px;">/);
-      expect(textarea.value).toContain("</div>");
-    });
-  });
-
-  it("does not wrap the script in the default auto-resize snippet", async () => {
-    const textarea = await openEmbedCodeTab();
-
-    expect(textarea.value).not.toContain("<div");
   });
 
   it("removes data-height-mode again when switching back to Auto-resize", async () => {
@@ -68,7 +54,6 @@ describe("ShareDialog", () => {
     await waitFor(() => {
       const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
       expect(textarea.value).not.toContain("data-height-mode");
-      expect(textarea.value).not.toContain("<div");
     });
   });
 });

--- a/features/forms/ui/share-dialog.tsx
+++ b/features/forms/ui/share-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -7,6 +8,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { Code, Link2 } from "lucide-react";
@@ -21,6 +24,27 @@ interface ShareDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+type EmbedHeightMode = "auto" | "fill";
+
+const HEIGHT_MODE_OPTIONS: Array<{
+  value: EmbedHeightMode;
+  title: string;
+  description: string;
+}> = [
+  {
+    value: "auto",
+    title: "Auto-resize",
+    description:
+      "Iframe height matches form content. Recommended for most pages.",
+  },
+  {
+    value: "fill",
+    title: "Fill container",
+    description:
+      "Iframe fills the height of its parent container. Place the script inside a container with a fixed height.",
+  },
+];
+
 const sharePath = (formId: string): string => withBasePath(`/share/${formId}`);
 const embedScriptPath = withBasePath("/embed/v1/embed.js");
 
@@ -32,16 +56,31 @@ const getShareUrl = (formId: string): string => {
   return path;
 };
 
-const getEmbedCode = (formId: string): string => {
-  if (globalThis.window !== undefined) {
-    return `<script src="${globalThis.window.location.origin}${embedScriptPath}" data-form-id="${formId}"></script>`;
+const FILL_MODE_WRAPPER_HEIGHT_PX = 800;
+
+const getEmbedCode = (formId: string, heightMode: EmbedHeightMode): string => {
+  if (globalThis.window === undefined) {
+    return ``;
   }
-  return ``;
+  const heightModeAttr =
+    heightMode === "fill" ? ` data-height-mode="fill"` : "";
+  const scriptTag = `<script src="${globalThis.window.location.origin}${embedScriptPath}" data-form-id="${formId}"${heightModeAttr}></script>`;
+
+  if (heightMode !== "fill") {
+    return scriptTag;
+  }
+
+  // Fill mode only fills a container with an explicit height, so the copied
+  // snippet needs to include one — otherwise pasting it as-is reproduces
+  // the exact gap this mode exists to fix. Height is a starting point the
+  // customer should adjust to their own layout.
+  return `<div style="height: ${FILL_MODE_WRAPPER_HEIGHT_PX}px;">\n  ${scriptTag}\n</div>`;
 };
 
 export function ShareDialog({ formId, open, onOpenChange }: ShareDialogProps) {
+  const [heightMode, setHeightMode] = useState<EmbedHeightMode>("auto");
   const shareUrl = getShareUrl(formId);
-  const embedCode = getEmbedCode(formId);
+  const embedCode = getEmbedCode(formId, heightMode);
 
   const handleTabChange = (value: string) => {
     if (value === "embed-code" && !embedCode) {
@@ -104,6 +143,33 @@ export function ShareDialog({ formId, open, onOpenChange }: ShareDialogProps) {
                   </p>
                 </div>
               </div>
+              <RadioGroup
+                value={heightMode}
+                onValueChange={(value) =>
+                  setHeightMode(value as EmbedHeightMode)
+                }
+                className="gap-2"
+              >
+                {HEIGHT_MODE_OPTIONS.map((option) => {
+                  const inputId = `embed-height-mode-${option.value}`;
+                  return (
+                    <div
+                      key={option.value}
+                      className="flex items-start gap-2 rounded-md border border-border/60 bg-muted/30 p-3 has-[[data-state=checked]]:border-primary"
+                    >
+                      <RadioGroupItem id={inputId} value={option.value} />
+                      <div className="space-y-1">
+                        <Label htmlFor={inputId} className="font-normal">
+                          {option.title}
+                        </Label>
+                        <p className="text-xs text-muted-foreground">
+                          {option.description}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </RadioGroup>
               <div className="relative">
                 <Textarea
                   readOnly

--- a/features/forms/ui/share-dialog.tsx
+++ b/features/forms/ui/share-dialog.tsx
@@ -56,25 +56,13 @@ const getShareUrl = (formId: string): string => {
   return path;
 };
 
-const FILL_MODE_WRAPPER_HEIGHT_PX = 800;
-
 const getEmbedCode = (formId: string, heightMode: EmbedHeightMode): string => {
   if (globalThis.window === undefined) {
     return ``;
   }
   const heightModeAttr =
     heightMode === "fill" ? ` data-height-mode="fill"` : "";
-  const scriptTag = `<script src="${globalThis.window.location.origin}${embedScriptPath}" data-form-id="${formId}"${heightModeAttr}></script>`;
-
-  if (heightMode !== "fill") {
-    return scriptTag;
-  }
-
-  // Fill mode only fills a container with an explicit height, so the copied
-  // snippet needs to include one — otherwise pasting it as-is reproduces
-  // the exact gap this mode exists to fix. Height is a starting point the
-  // customer should adjust to their own layout.
-  return `<div style="height: ${FILL_MODE_WRAPPER_HEIGHT_PX}px;">\n  ${scriptTag}\n</div>`;
+  return `<script src="${globalThis.window.location.origin}${embedScriptPath}" data-form-id="${formId}"${heightModeAttr}></script>`;
 };
 
 export function ShareDialog({ formId, open, onOpenChange }: ShareDialogProps) {

--- a/features/public-form/ui/__tests__/survey-component.test.tsx
+++ b/features/public-form/ui/__tests__/survey-component.test.tsx
@@ -521,6 +521,73 @@ describe("SurveyComponent - Embed Fill Mode", () => {
     );
   });
 
+  it("restores the prior background on unmount", async () => {
+    // Arrange: something (e.g. an earlier fill-mode instance, or an inline
+    // style already on the page) had set a background before this mounts.
+    document.documentElement.style.backgroundColor = "rgb(10, 20, 30)";
+    document.body.style.backgroundColor = "rgb(10, 20, 30)";
+    mockGetEmbedMessagingContext.mockReturnValue({
+      heightMode: "fill",
+      embedId: "embed-1",
+    });
+    Object.defineProperty(realSurveyModel, "themeVariables", {
+      configurable: true,
+      value: { "--sjs-general-backcolor-dim": "rgb(9, 8, 7)" },
+    });
+
+    // Act
+    let result!: ReturnType<typeof renderSurveyComponent>;
+    await act(async () => {
+      result = renderSurveyComponent({ isEmbed: true });
+    });
+    expect(document.body.style.backgroundColor).toBe("rgb(9, 8, 7)");
+
+    await act(async () => {
+      result.unmount();
+    });
+
+    // Assert
+    expect(document.body.style.backgroundColor).toBe("rgb(10, 20, 30)");
+    expect(document.documentElement.style.backgroundColor).toBe(
+      "rgb(10, 20, 30)",
+    );
+  });
+
+  it("restores the prior background on a fill-to-auto transition", async () => {
+    // Arrange
+    document.documentElement.style.backgroundColor = "rgb(10, 20, 30)";
+    document.body.style.backgroundColor = "rgb(10, 20, 30)";
+    mockGetEmbedMessagingContext.mockReturnValue({
+      heightMode: "fill",
+      embedId: "embed-1",
+    });
+    Object.defineProperty(realSurveyModel, "themeVariables", {
+      configurable: true,
+      value: { "--sjs-general-backcolor-dim": "rgb(9, 8, 7)" },
+    });
+
+    // Act: mount in fill mode.
+    const result = renderSurveyComponent({ isEmbed: true });
+    await act(async () => {});
+    expect(document.body.style.backgroundColor).toBe("rgb(9, 8, 7)");
+
+    // Act: same instance, but the embed context no longer reports fill mode.
+    mockGetEmbedMessagingContext.mockReturnValue({});
+    await act(async () => {
+      result.rerender(
+        <FormRuntimeProvider initialState={{ formId: defaultProps.formId }}>
+          <SurveyComponent {...defaultProps} isEmbed />
+        </FormRuntimeProvider>,
+      );
+    });
+
+    // Assert: back to whatever was there before fill mode ever ran.
+    expect(document.body.style.backgroundColor).toBe("rgb(10, 20, 30)");
+    expect(document.documentElement.style.backgroundColor).toBe(
+      "rgb(10, 20, 30)",
+    );
+  });
+
   it("falls back to --sjs-general-backcolor when the dim variable is missing", async () => {
     // Arrange
     mockGetEmbedMessagingContext.mockReturnValue({

--- a/features/public-form/ui/__tests__/survey-component.test.tsx
+++ b/features/public-form/ui/__tests__/survey-component.test.tsx
@@ -5,6 +5,13 @@ import SurveyComponent from "../survey-component";
 import { SurveyModel, CompleteEvent } from "survey-core";
 import { ApiResult } from "@/lib/endatix-api";
 import { FormRuntimeProvider } from "@/lib/form-runtime/form-runtime.context";
+import { DEFAULT_FILL_BACKGROUND_COLOR } from "@/features/embed-form/height-mode";
+
+function cssColor(value: string): string {
+  const probe = document.createElement("div");
+  probe.style.backgroundColor = value;
+  return probe.style.backgroundColor;
+}
 
 // --- HOIST MOCK FUNCTIONS ---
 // All mock functions must be hoisted so they're available in vi.mock factories
@@ -16,6 +23,8 @@ const {
   mockUseSurveyModel,
   mockSendEmbedMessage,
   mockEmbedHeightReporting,
+  mockGetEmbedMessagingContext,
+  mockUseSurveyTheme,
 } = vi.hoisted(() => ({
   mockSubmitPublicForm: vi.fn(),
   mockEnqueueSubmission: vi.fn(),
@@ -30,6 +39,13 @@ const {
     resume: vi.fn(),
     isFrozen: vi.fn(() => false),
   },
+  mockGetEmbedMessagingContext: vi.fn(() => ({})),
+  mockUseSurveyTheme: vi.fn(
+    (..._args: unknown[]): { theme: unknown; error: unknown } => ({
+      theme: undefined,
+      error: null,
+    }),
+  ),
 }));
 
 // --- MOCK DEPENDENCIES ---
@@ -60,6 +76,10 @@ vi.mock("@/features/embed-form", () => ({
   })),
 }));
 
+vi.mock("@/features/embed-form/ui/embed-messaging-context", () => ({
+  getEmbedMessagingContext: () => mockGetEmbedMessagingContext(),
+}));
+
 vi.mock("@/features/analytics/posthog/client", () => ({
   useTrackEvent: vi.fn(() => ({ trackException: vi.fn() })),
   captureException: vi.fn(),
@@ -72,11 +92,11 @@ vi.mock("@/features/asset-storage/client", () => ({
   })),
 }));
 
-vi.mock("./use-survey-theme.hook", () => ({
-  useSurveyTheme: vi.fn(),
+vi.mock("../use-survey-theme.hook", () => ({
+  useSurveyTheme: (...args: unknown[]) => mockUseSurveyTheme(...args),
 }));
 
-vi.mock("./language-selector", () => ({
+vi.mock("../language-selector", () => ({
   LanguageSelector: () => <div>Language Selector</div>,
 }));
 
@@ -196,14 +216,16 @@ const defaultProps = {
   isEmbed: false,
 };
 
-function renderSurveyComponent() {
+function renderSurveyComponent(
+  propsOverride: Partial<typeof defaultProps> = {},
+) {
   return render(
     <FormRuntimeProvider
       initialState={{
         formId: defaultProps.formId,
       }}
     >
-      <SurveyComponent {...defaultProps} />
+      <SurveyComponent {...defaultProps} {...propsOverride} />
     </FormRuntimeProvider>,
   );
 }
@@ -450,5 +472,190 @@ describe("SurveyComponent - submissionUpdateGuard Behavior", () => {
       secondCompleteEventMocks.showSaveInProgress,
     ).not.toHaveBeenCalled();
     await expect(mockSubmitPublicForm).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SurveyComponent - Embed Fill Mode", () => {
+  let realSurveyModel: SurveyModel;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetEmbedMessagingContext.mockReturnValue({});
+    mockUseSurveyTheme.mockReturnValue({ theme: undefined, error: null });
+    document.documentElement.style.backgroundColor = "";
+    document.body.style.backgroundColor = "";
+
+    realSurveyModel = new SurveyModel(defaultProps.definition);
+    mockUseSurveyModel.mockImplementation(() => ({
+      surveyModel: realSurveyModel,
+      isLoading: false,
+      error: null,
+    }));
+  });
+
+  it("paints html/body with the survey's theme background when embedded in fill mode", async () => {
+    // Arrange
+    mockGetEmbedMessagingContext.mockReturnValue({
+      heightMode: "fill",
+      embedId: "embed-1",
+    });
+    Object.defineProperty(realSurveyModel, "themeVariables", {
+      configurable: true,
+      value: { "--sjs-general-backcolor-dim": "rgb(9, 8, 7)" },
+    });
+
+    // Act
+    let result!: ReturnType<typeof renderSurveyComponent>;
+    await act(async () => {
+      result = renderSurveyComponent({ isEmbed: true });
+    });
+
+    // Assert
+    expect(document.body.style.backgroundColor).toBe("rgb(9, 8, 7)");
+    expect(document.documentElement.style.backgroundColor).toBe(
+      "rgb(9, 8, 7)",
+    );
+    const shell = result.container.querySelector('[class*="embedShell"]');
+    expect(shell?.className).toEqual(
+      expect.stringContaining("embedShellFill"),
+    );
+  });
+
+  it("falls back to --sjs-general-backcolor when the dim variable is missing", async () => {
+    // Arrange
+    mockGetEmbedMessagingContext.mockReturnValue({
+      heightMode: "fill",
+      embedId: "embed-1",
+    });
+    Object.defineProperty(realSurveyModel, "themeVariables", {
+      configurable: true,
+      value: { "--sjs-general-backcolor": "rgb(4, 5, 6)" },
+    });
+
+    // Act
+    await act(async () => {
+      renderSurveyComponent({ isEmbed: true });
+    });
+
+    // Assert
+    expect(document.body.style.backgroundColor).toBe(cssColor("rgb(4, 5, 6)"));
+  });
+
+  it("falls back to the default fill background when no theme variable is available", async () => {
+    // Arrange
+    mockGetEmbedMessagingContext.mockReturnValue({
+      heightMode: "fill",
+      embedId: "embed-1",
+    });
+    Object.defineProperty(realSurveyModel, "themeVariables", {
+      configurable: true,
+      value: {},
+    });
+
+    // Act
+    await act(async () => {
+      renderSurveyComponent({ isEmbed: true });
+    });
+
+    // Assert
+    expect(document.body.style.backgroundColor).toBe(
+      cssColor(DEFAULT_FILL_BACKGROUND_COLOR),
+    );
+  });
+
+  it("does not paint html/body in the default auto-resize embed mode", async () => {
+    // Arrange
+    mockGetEmbedMessagingContext.mockReturnValue({});
+
+    // Act
+    let result!: ReturnType<typeof renderSurveyComponent>;
+    await act(async () => {
+      result = renderSurveyComponent({ isEmbed: true });
+    });
+
+    // Assert
+    expect(document.body.style.backgroundColor).toBe("");
+    expect(document.documentElement.style.backgroundColor).toBe("");
+    const shell = result.container.querySelector('[class*="embedShell"]');
+    expect(shell?.className).not.toEqual(
+      expect.stringContaining("embedShellFill"),
+    );
+  });
+
+  it("ignores heightMode=fill when not embedded at all", async () => {
+    // Arrange
+    mockGetEmbedMessagingContext.mockReturnValue({ heightMode: "fill" });
+
+    // Act
+    await act(async () => {
+      renderSurveyComponent({ isEmbed: false });
+    });
+
+    // Assert
+    expect(document.body.style.backgroundColor).toBe("");
+    expect(document.documentElement.style.backgroundColor).toBe("");
+  });
+
+  it("ignores heightMode=fill without an embedId (not a genuine SDK load)", async () => {
+    // Arrange: only embed.js ever sets heightMode=fill, and it always sets
+    // embedId alongside it — a bare ?heightMode=fill (e.g. someone opening
+    // the embed URL directly) shouldn't trigger fill styling.
+    mockGetEmbedMessagingContext.mockReturnValue({ heightMode: "fill" });
+
+    // Act
+    let result!: ReturnType<typeof renderSurveyComponent>;
+    await act(async () => {
+      result = renderSurveyComponent({ isEmbed: true });
+    });
+
+    // Assert
+    expect(document.body.style.backgroundColor).toBe("");
+    expect(document.documentElement.style.backgroundColor).toBe("");
+    const shell = result.container.querySelector('[class*="embedShell"]');
+    expect(shell?.className).not.toEqual(
+      expect.stringContaining("embedShellFill"),
+    );
+  });
+
+  it("re-applies the background once the survey's real theme finishes applying", async () => {
+    // Arrange: useSurveyTheme applies DefaultLight first and the real theme
+    // a render later once it's parsed (see use-survey-theme.hook.tsx) — the
+    // effect must re-run on that second pass, not just the first.
+    mockGetEmbedMessagingContext.mockReturnValue({
+      heightMode: "fill",
+      embedId: "embed-1",
+    });
+    mockUseSurveyTheme.mockReturnValue({ theme: undefined, error: null });
+    Object.defineProperty(realSurveyModel, "themeVariables", {
+      configurable: true,
+      value: { "--sjs-general-backcolor-dim": "rgb(1, 1, 1)" },
+    });
+
+    // Act: first pass, as if only DefaultLight has been applied so far.
+    const result = renderSurveyComponent({ isEmbed: true });
+    await act(async () => {});
+
+    // Assert
+    expect(document.body.style.backgroundColor).toBe("rgb(1, 1, 1)");
+
+    // Act: second pass, simulating the real theme finishing application.
+    Object.defineProperty(realSurveyModel, "themeVariables", {
+      configurable: true,
+      value: { "--sjs-general-backcolor-dim": "rgb(2, 2, 2)" },
+    });
+    mockUseSurveyTheme.mockReturnValue({
+      theme: { themeName: "custom" },
+      error: null,
+    });
+    await act(async () => {
+      result.rerender(
+        <FormRuntimeProvider initialState={{ formId: defaultProps.formId }}>
+          <SurveyComponent {...defaultProps} isEmbed />
+        </FormRuntimeProvider>,
+      );
+    });
+
+    // Assert
+    expect(document.body.style.backgroundColor).toBe("rgb(2, 2, 2)");
   });
 });

--- a/features/public-form/ui/survey-component.module.css
+++ b/features/public-form/ui/survey-component.module.css
@@ -11,6 +11,15 @@
   position: relative;
 }
 
+/* Fill mode: the parent script's iframe has already been sized to at least
+   fill its host container (see src/embed/embed.ts). Stretch to match so the
+   survey's own theme background reaches the edges instead of leaving a
+   transparent gap that shows the host page through. */
+.embedShellFill {
+  min-height: 100%;
+  background-color: var(--sjs-general-backcolor-dim, transparent);
+}
+
 .layoutFullHeight :global(.sd-completedpage),
 .embedShell :global(.sd-completedpage) {
   box-sizing: border-box;

--- a/features/public-form/ui/survey-component.module.css
+++ b/features/public-form/ui/survey-component.module.css
@@ -12,11 +12,16 @@
 }
 
 /* Fill mode: the parent script's iframe has already been sized to at least
-   fill its host container (see src/embed/embed.ts). Stretch to match so the
-   survey's own theme background reaches the edges instead of leaving a
-   transparent gap that shows the host page through. */
+   fill its host container (see src/embed/embed.ts). Paint the survey's own
+   theme background so it reaches the edges instead of leaving a transparent
+   gap that shows the host page through — via the canvas background rule
+   (html/body backgrounds fill the full viewport regardless of box height),
+   not by stretching this element's own box. Deliberately no min-height
+   here: EmbedHeightReporter measures document.body.scrollHeight, and any
+   ancestor whose height tracks the iframe's own size (rather than content)
+   floors that measurement at the iframe's current height — once grown, it
+   could never shrink back down. */
 .embedShellFill {
-  min-height: 100%;
   background-color: var(--sjs-general-backcolor-dim, transparent);
 }
 

--- a/features/public-form/ui/survey-component.tsx
+++ b/features/public-form/ui/survey-component.tsx
@@ -128,8 +128,20 @@ export default function SurveyComponent({
       themeVariables["--sjs-general-backcolor-dim"] ||
       themeVariables["--sjs-general-backcolor"] ||
       DEFAULT_FILL_BACKGROUND_COLOR;
+
+    const previousHtmlBackground = document.documentElement.style.backgroundColor;
+    const previousBodyBackground = document.body.style.backgroundColor;
     document.documentElement.style.backgroundColor = backgroundColor;
     document.body.style.backgroundColor = backgroundColor;
+
+    // Restore whatever was there before on unmount, on a fill-to-auto
+    // transition, or before re-applying a changed theme's color — this
+    // mutates document/body, which outlives this component, so it
+    // shouldn't leave a stale override behind for whatever renders next.
+    return () => {
+      document.documentElement.style.backgroundColor = previousHtmlBackground;
+      document.body.style.backgroundColor = previousBodyBackground;
+    };
   }, [isFillMode, surveyModel, appliedTheme]);
 
   const getSubmissionId = useCallback(() => {

--- a/features/public-form/ui/survey-component.tsx
+++ b/features/public-form/ui/survey-component.tsx
@@ -6,6 +6,8 @@ import {
   embedHeightReporting,
   useSurveyEmbedBehavior,
 } from "@/features/embed-form";
+import { DEFAULT_FILL_BACKGROUND_COLOR } from "@/features/embed-form/height-mode";
+import { getEmbedMessagingContext } from "@/features/embed-form/ui/embed-messaging-context";
 import type { EmbedFormInfo } from "@/features/embed-form/types";
 import type { SubmissionOperation } from "@/features/public-form/application/submit-form-operation";
 import { submitPublicForm } from "@/features/public-form/application/submit-public-form";
@@ -84,12 +86,51 @@ export default function SurveyComponent({
   const { enqueueSubmission, clearQueue, waitForInFlightPartial } =
     useSubmissionQueue(formId, runtimeToken);
   const [isSubmitting, startSubmitting] = useTransition();
-  useSurveyTheme(theme, surveyModel);
+  const { theme: appliedTheme } = useSurveyTheme(theme, surveyModel);
   useRichText(surveyModel);
   useLoopAwareSummaryTable(surveyModel);
   const { trackException } = useTrackEvent();
   const submissionUpdateGuard = useRef<boolean>(false);
   const originalCompletedHtmlRef = useRef<string | null>(null);
+
+  // SurveyComponent is only ever loaded client-side (see
+  // dynamic(..., { ssr: false }) in survey-js-wrapper.tsx), so there's no
+  // server-rendered output to mismatch — safe to read synchronously instead
+  // of via useEffect+state. Require embedId too: embed.js always sets it
+  // alongside heightMode=fill, so a bare `?heightMode=fill` visit (not
+  // driven by our own SDK) doesn't trigger fill styling.
+  const embedMessagingContext = isEmbed ? getEmbedMessagingContext() : undefined;
+  const isFillMode = Boolean(
+    embedMessagingContext?.heightMode === "fill" &&
+      embedMessagingContext?.embedId,
+  );
+
+  useEffect(() => {
+    if (!isFillMode || !surveyModel) {
+      return;
+    }
+
+    // The iframe's outer height chain is fully under our control, but the
+    // surrounding host page's own layout wrappers (e.g. AppProvider's
+    // sidebar shell) are shared with non-embed routes and aren't guaranteed
+    // to propagate height down to us. Paint the canvas directly instead of
+    // depending on that chain: html/body backgrounds fill the full iframe
+    // viewport regardless of their own box height (CSS canvas painting),
+    // so this reaches the space beyond the survey's own content even if
+    // some ancestor's box stays content-sized.
+    //
+    // `appliedTheme` (from useSurveyTheme) is in the dependency list even
+    // though it's unused directly: useSurveyTheme applies DefaultLight
+    // first and the survey's real theme a render later once parsed, so
+    // without it this effect would only ever see the DefaultLight colors.
+    const themeVariables = surveyModel.themeVariables ?? {};
+    const backgroundColor =
+      themeVariables["--sjs-general-backcolor-dim"] ||
+      themeVariables["--sjs-general-backcolor"] ||
+      DEFAULT_FILL_BACKGROUND_COLOR;
+    document.documentElement.style.backgroundColor = backgroundColor;
+    document.body.style.backgroundColor = backgroundColor;
+  }, [isFillMode, surveyModel, appliedTheme]);
 
   const getSubmissionId = useCallback(() => {
     return stateRef.current.submissionId;
@@ -281,11 +322,12 @@ export default function SurveyComponent({
     return <div>Loading...</div>;
   }
 
+  const shellClassName = isEmbed
+    ? `${styles.embedShell}${isFillMode ? ` ${styles.embedShellFill}` : ""}`
+    : styles.layoutFullHeight;
+
   return (
-    <div
-      className={isEmbed ? styles.embedShell : styles.layoutFullHeight}
-      style={surveyModel.themeVariables}
-    >
+    <div className={shellClassName} style={surveyModel.themeVariables}>
       {isRespondentTestMode && <TestSubmissionBadge />}
       <LanguageSelector
         availableLocales={surveyLocales}

--- a/src/embed/README.md
+++ b/src/embed/README.md
@@ -85,6 +85,32 @@ The embed SDK is built **before** the Next.js dev server starts via the `predev`
 | `data-base-url` | Override the default base URL (optional) |
 | `data-token` | Access token for private forms (optional) |
 | `data-prefill` | Pre-fill query string (optional) |
+| `data-height-mode` | `auto` (default) or `fill` — see [Height Modes](#height-modes) below (optional) |
+
+### Height Modes
+
+By default (`auto`, or the attribute omitted entirely), the iframe height tracks the form's content only — this is unchanged.
+
+Set `data-height-mode="fill"` to make the iframe fill its parent container's height when the form content is shorter, while still growing beyond the container when content is taller. The iframe never gets internal scrollbars in either mode.
+
+```html
+<div style="height: 800px;">
+  <script
+    src="https://your-endatix-instance.com/embed/v1/embed.js"
+    data-form-id="123456789"
+    data-height-mode="fill">
+  </script>
+</div>
+```
+
+**Requirements and caveats for `fill` mode:**
+
+- The value is case-sensitive — only exactly `auto` or `fill` are recognized; anything else logs a console warning and falls back to `auto`.
+- The wrapping element (or `document.body`, if the script isn't wrapped in anything) needs an **explicit** CSS height, e.g. `height: 800px`. A wrapper sized only with `min-height`, or with no height rule at all, does not give the iframe anything definite to fill against — in that case `fill` silently behaves exactly like `auto`.
+- The script tag (and the container the SDK injects next to it) should be the only in-flow content inside that height-constrained wrapper. The fill calculation uses the wrapper's full height, not "space remaining below other children" — a heading or other sibling in the same wrapper will overflow rather than share the space. Give the embed its own wrapper if it needs to sit alongside other content.
+- If the wrapper itself has `overflow: hidden`, a form that grows taller than the container will be clipped instead of extending the page. Fill mode's "grows when needed, no scrollbars" behavior depends on the wrapper allowing overflow.
+- In a flex layout, a bare explicit height on the wrapper works when the flex item already resolves to a definite size (e.g. a sized flex container with default `align-items: stretch`). A flex parent sized only with `min-height`, or a `flex-direction: column` parent where the item has no `flex: 1`, may not reliably propagate a definite height — treat flex support as narrower than the plain block-level case.
+- On the survey's completion ("thank you") screen specifically, its layout uses `100vh` internally, which resolves against the iframe's own (now filled) viewport — so the completion screen may report a slightly taller height than the in-progress form did in very tall containers. This is cosmetic and self-stabilizing, not a growth loop.
 
 ### Programmatic Usage
 
@@ -92,7 +118,8 @@ The embed SDK is built **before** the Next.js dev server starts via the `predev`
 window.EndatixEmbed.embedFormAt("123456789", {
   baseUrl: "https://your-endatix-instance.com",
   token: "optional-token",
-  prefill: "name=John&email=john@example.com"
+  prefill: "name=John&email=john@example.com",
+  heightMode: "fill" // "auto" (default) or "fill"
 });
 ```
 

--- a/src/embed/__tests__/embed.test.ts
+++ b/src/embed/__tests__/embed.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { parseUrl, parseNumericId } from "../embed";
+import { parseUrl, parseNumericId, parseHeightMode } from "../embed";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("parseUrl", () => {
   it("returns null for empty string", () => {
@@ -109,5 +113,47 @@ describe("parseNumericId", () => {
     const result = parseNumericId("1000000000000000000", "formId");
     expect(result.isValid).toBe(true);
     expect(result.id).toBe(BigInt("1000000000000000000"));
+  });
+});
+
+describe("parseHeightMode", () => {
+  it("returns auto for undefined", () => {
+    expect(parseHeightMode(undefined)).toBe("auto");
+  });
+
+  it("returns auto for an empty string", () => {
+    expect(parseHeightMode("")).toBe("auto");
+  });
+
+  it("returns auto for the literal auto value", () => {
+    expect(parseHeightMode("auto")).toBe("auto");
+  });
+
+  it("returns fill for the literal fill value", () => {
+    expect(parseHeightMode("fill")).toBe("fill");
+  });
+
+  it("trims whitespace around a valid value", () => {
+    expect(parseHeightMode("  fill  ")).toBe("fill");
+  });
+
+  it("returns auto and warns for an invalid value", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = parseHeightMode("bogus");
+
+    expect(result).toBe("auto");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid data-height-mode value "bogus"'),
+    );
+  });
+
+  it("returns auto without warning for an invalid value when warn is false", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = parseHeightMode("bogus", false);
+
+    expect(result).toBe("auto");
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/src/embed/embed.test.ts
+++ b/src/embed/embed.test.ts
@@ -1,17 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HeightMode } from "./embed";
 
 type TestEmbedInstance = {
   iframe: HTMLIFrameElement;
   container: HTMLElement;
   expectedOrigin: string;
   embedId: string;
+  heightMode: HeightMode;
 };
 
 type TestEmbedApi = {
   instances: TestEmbedInstance[];
   embedFormAt(
     formId: string,
-    options: { baseUrl?: string; token?: string; prefill?: string },
+    options: {
+      baseUrl?: string;
+      token?: string;
+      prefill?: string;
+      heightMode?: string;
+    },
     targetScript: HTMLScriptElement | null,
   ): void;
 };
@@ -188,6 +195,128 @@ describe("Endatix embed host script", () => {
 
     // Assert
     expect(instance.iframe.style.height).toBe("10000px");
+  });
+
+  it("does not leave a container in the DOM when no valid base URL can be resolved", async () => {
+    // Arrange
+    const api = await loadEmbedApi();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    // Act: no baseUrl option, and no document.currentScript to fall back
+    // to outside of real <script> execution, so URL resolution fails.
+    api.embedFormAt("123", {}, null);
+
+    // Assert
+    expect(error).toHaveBeenCalledWith(
+      "Cannot auto-resolve valid base URL. Cannot embed form",
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "No valid baseUrl passed. Falling back to default.",
+    );
+    expect(api.instances).toHaveLength(0);
+    expect(document.querySelector("[data-endatix-loaded]")).toBeNull();
+  });
+
+  describe("height mode", () => {
+    it("leaves the wrapper and iframe height styles untouched by default", async () => {
+      // Arrange
+      const api = await loadEmbedApi();
+
+      // Act
+      api.embedFormAt(
+        "123",
+        { baseUrl: "https://hub.example/embed/v1/embed.js" },
+        null,
+      );
+
+      // Assert
+      const instance = api.instances[0];
+      expect(instance.heightMode).toBe("auto");
+      expect(instance.container.style.height).toBe("");
+      expect(instance.iframe.style.minHeight).toBe("");
+      expect(new URL(instance.iframe.src).searchParams.has("heightMode")).toBe(
+        false,
+      );
+    });
+
+    it("fills the wrapper and iframe when heightMode is fill", async () => {
+      // Arrange
+      const api = await loadEmbedApi();
+
+      // Act
+      api.embedFormAt(
+        "123",
+        {
+          baseUrl: "https://hub.example/embed/v1/embed.js",
+          heightMode: "fill",
+        },
+        null,
+      );
+
+      // Assert
+      const instance = api.instances[0];
+      expect(instance.heightMode).toBe("fill");
+      expect(instance.container.style.height).toBe("100%");
+      expect(instance.iframe.style.minHeight).toBe("100%");
+      // The inner document needs to know it's in fill mode too (to stretch
+      // and paint its own html/body) — it can only learn that from the URL.
+      expect(new URL(instance.iframe.src).searchParams.get("heightMode")).toBe(
+        "fill",
+      );
+    });
+
+    it("warns and falls back to auto for an invalid heightMode value", async () => {
+      // Arrange
+      const api = await loadEmbedApi();
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      // Act
+      api.embedFormAt(
+        "123",
+        {
+          baseUrl: "https://hub.example/embed/v1/embed.js",
+          heightMode: "bogus",
+        },
+        null,
+      );
+
+      // Assert
+      const instance = api.instances[0];
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid data-height-mode value "bogus"'),
+      );
+      expect(instance.heightMode).toBe("auto");
+      expect(instance.container.style.height).toBe("");
+      expect(instance.iframe.style.minHeight).toBe("");
+    });
+
+    it("keeps the MAX_IFRAME_HEIGHT clamp independent of the fill-mode minHeight", async () => {
+      // Arrange
+      const api = await loadEmbedApi();
+      api.embedFormAt(
+        "123",
+        {
+          baseUrl: "https://hub.example/embed/v1/embed.js",
+          heightMode: "fill",
+        },
+        null,
+      );
+      const instance = api.instances[0];
+
+      // Act
+      dispatchMessage(instance, {
+        type: "endatix:resize",
+        embedId: instance.embedId,
+        height: 20000,
+      });
+
+      // Assert
+      expect(instance.iframe.style.height).toBe("10000px");
+      expect(instance.iframe.style.minHeight).toBe("100%");
+    });
   });
 
   it("navigates only to safe URLs from trusted iframes", async () => {

--- a/src/embed/embed.ts
+++ b/src/embed/embed.ts
@@ -3,11 +3,15 @@ const MAX_SNOWFLAKE_ID = BigInt("9223372036854775807");
 const MAX_IFRAME_HEIGHT = 10_000;
 const EMBED_ID_QUERY_PARAM = "embedId";
 const PARENT_ORIGIN_QUERY_PARAM = "parentOrigin";
+const HEIGHT_MODE_QUERY_PARAM = "heightMode";
+
+type HeightMode = "auto" | "fill";
 
 interface EmbedOptions {
   baseUrl?: string;
   token?: string;
   prefill?: string;
+  heightMode?: string;
 }
 
 interface EmbedInstance {
@@ -17,6 +21,7 @@ interface EmbedInstance {
   options: EmbedOptions;
   expectedOrigin: string;
   embedId: string;
+  heightMode: HeightMode;
 }
 
 interface ParseResult {
@@ -138,6 +143,29 @@ export const parseNumericId = (
       error: `${paramName} must be a valid numeric value`,
     };
   }
+};
+
+const DEFAULT_HEIGHT_MODE: HeightMode = "auto";
+
+export const parseHeightMode = (
+  value: unknown,
+  warn = true,
+): HeightMode => {
+  const trimmedValue = typeof value === "string" ? value.trim() : value;
+
+  if (trimmedValue === undefined || trimmedValue === "") {
+    return DEFAULT_HEIGHT_MODE;
+  }
+
+  if (trimmedValue === "auto" || trimmedValue === "fill") {
+    return trimmedValue;
+  }
+
+  warnIfEnabled(
+    `Invalid data-height-mode value "${String(value)}". Falling back to "auto".`,
+    warn,
+  );
+  return DEFAULT_HEIGHT_MODE;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -351,15 +379,13 @@ const endatixEmbed: EndatixEmbedApi = {
       return;
     }
     const validatedFormId = parsedFormId.id.toString();
+    const heightMode = parseHeightMode(options.heightMode);
 
     const container = document.createElement("div");
     container.dataset.endatixForm = validatedFormId;
     container.dataset.endatixLoaded = "true";
-
-    if (targetScript?.parentNode) {
-      targetScript.parentNode.insertBefore(container, targetScript.nextSibling);
-    } else {
-      document.body.appendChild(container);
+    if (heightMode === "fill") {
+      container.style.height = "100%";
     }
 
     const embedId = createEmbedId(validatedFormId, this.instances.length);
@@ -411,6 +437,9 @@ const endatixEmbed: EndatixEmbedApi = {
       iframeUrl.searchParams.set(PARENT_ORIGIN_QUERY_PARAM, parentOrigin);
     }
     iframeUrl.searchParams.set(EMBED_ID_QUERY_PARAM, embedId);
+    if (heightMode === "fill") {
+      iframeUrl.searchParams.set(HEIGHT_MODE_QUERY_PARAM, "fill");
+    }
 
     iframe.src = iframeUrl.toString();
     iframe.allow = "clipboard-write";
@@ -422,8 +451,17 @@ const endatixEmbed: EndatixEmbedApi = {
     iframe.style.overflow = "hidden";
     iframe.style.display = "block";
     iframe.style.height = "400px";
+    if (heightMode === "fill") {
+      iframe.style.minHeight = "100%";
+    }
 
     container.appendChild(iframe);
+
+    if (targetScript?.parentNode) {
+      targetScript.parentNode.insertBefore(container, targetScript.nextSibling);
+    } else {
+      document.body.appendChild(container);
+    }
 
     this.instances.push({
       iframe,
@@ -432,6 +470,7 @@ const endatixEmbed: EndatixEmbedApi = {
       options,
       expectedOrigin: resolvedUrl.origin,
       embedId,
+      heightMode,
     });
   },
   findInstanceBySource(source: Window): EmbedInstance | null {
@@ -474,11 +513,12 @@ if (!globalThis.EndatixEmbed && globalThis.window) {
   const currentScript = document.currentScript as HTMLScriptElement | null;
   const formId = currentScript?.dataset.formId;
   if (formId && currentScript) {
-    const { baseUrl, prefill, token } = currentScript.dataset;
+    const { baseUrl, prefill, token, heightMode } = currentScript.dataset;
     const options: EmbedOptions = {
       baseUrl: baseUrl || globalThis.EndatixEmbed.getDefaultBaseUrl() || "",
       prefill: prefill || "",
       token: token || "",
+      heightMode: heightMode || "",
     };
 
     const embed = () => {
@@ -495,4 +535,4 @@ if (!globalThis.EndatixEmbed && globalThis.window) {
   Object.seal(globalThis.EndatixEmbed);
 }
 
-export type { EndatixEmbedApi, EmbedOptions, EmbedInstance };
+export type { EndatixEmbedApi, EmbedOptions, EmbedInstance, HeightMode };


### PR DESCRIPTION
## Description

Implements `data-height-mode="fill"` for the embed SDK. Customers embedding a form inside a fixed-height container (sidebar, modal) previously got a visible gap below the iframe, because the SDK only ever sized the iframe to the form's content height. This adds an opt-in `fill` mode that makes the iframe fill the container when content is shorter, and still grow beyond it when content is taller — with `auto` (unchanged) staying the default.

**Approach:** the issue's own suggested implementation (`ResizeObserver` + `Math.max(contentHeight, measuredContainerHeight)` in JS) has a real bug for its own documented edge case: when the parent container has no explicit height, `clientHeight` just mirrors the iframe's own previous rendered height, so the JS-computed max never lets the iframe shrink back down once it's grown — a permanent ratchet. Instead, this uses pure CSS: the wrapper div gets `height: 100%` and the iframe gets `min-height: 100%`, while the existing content-driven `iframe.style.height` logic is untouched. The browser's native `max(height, min-height)` resolution handles "fill or grow, whichever is bigger" on every layout pass with no JS measurement, and CSS percentage-height only resolves against an ancestor with a *definite* height — so a container with no explicit height (or only `min-height`) falls back to exactly today's `auto` behavior automatically, with zero custom detection code.

**Also fixed:** verifying visually surfaced a second issue beyond the outer iframe box — the survey's own document (`html`/`body` inside the iframe) didn't stretch or paint to match the now-larger iframe, leaving a transparent gap that showed the *host page's* background through it instead of the survey's. Fixed by propagating `heightMode` into the iframe via a query param (gated on `embedId` also being present, so a manually-opened embed URL doesn't trigger it) and, in fill mode, painting `html`/`body` with the survey's own theme background — with a fallback chain for missing theme variables, a default applied immediately server-side to cover the loading window, and a fix for a render race where the effect could get stuck on the pre-theme `DefaultLight` color.

### Changes
- `src/embed/embed.ts` — `data-height-mode` attribute / `heightMode` option, CSS-based fill logic, `parseHeightMode` validator. Also fixes a pre-existing bug (unrelated to height mode, but made more visible by it) where a container could be left orphaned in the DOM if base URL resolution failed.
- `features/embed-form/height-mode.ts` — shared `isFillHeightMode` check + default background color, used by both the server-rendered embed page and the client messaging context so there's one source of truth.
- `features/embed-form/*`, `features/public-form/ui/survey-component.*`, `app/(public)/embed/[formId]/page.tsx` — propagate fill mode into the iframe and paint its background/height to match.
- `features/forms/ui/share-dialog.tsx` — Auto-resize / Fill container picker in the Embed code tab, with live snippet regeneration.
- `src/embed/README.md` — documents the attribute, including caveats (requires an explicit height, not `min-height`; script should be the only content in the height-constrained wrapper; wrapper `overflow: hidden` will clip growth; flex parents need more than a bare height).

### Testing
- Unit: `embed.test.ts` (instance/DOM behavior, including query-param propagation and the orphaned-container fix), `__tests__/embed.test.ts` (`parseHeightMode`), `embed-messaging-context.test.ts` (new — direct coverage of query-param parsing), `survey-component.test.tsx` (fill-mode class/background application, theme-race regression, embedId gating), `share-dialog.test.tsx` — full suite green (3,834 passed).
- E2E: real-browser test asserting the iframe fills a 900px container *and* that the inner document's background isn't transparent. All embed e2e tests pass.
- Manually verified against a live seeded form in a fixed-height container, including the specific regression (transparent gap showing host page background) found during review.

## Related Issues
closes #842 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)



## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots

<img width="700" alt="image" src="https://github.com/user-attachments/assets/d98dc281-41c7-4860-b3e9-a9388f2d64fb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embed height modes: automatic resizing and filling the parent container.
  * Added height mode selection to the share dialog and generated embed code.
  * Fill mode now applies full-height layout and theme-based background styling.
  * Added programmatic `heightMode` configuration and validation with fallback behavior.

* **Documentation**
  * Documented height mode options, setup requirements, and layout considerations.

* **Tests**
  * Added coverage for height parsing, embed rendering, resizing, backgrounds, and share dialog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->