### PR TITLE
feat(h865): add paged items grid and list filter back navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,26 @@
 - Use `Promise.all` for independent data dependencies. Await sequentially only when a later call depends on an earlier result.
 - For server page calls to the Endatix API, convert `ApiResult<T>` with `toResult(...)` so unexpected operational failures are logged consistently and expected invalid/not-found states can map to page-specific fallback UI.
 
+## Table filter state (client)
+
+- One debounced field (a search box): `useListUrlState()` (`lib/list-page/use-list-url-state.ts`).
+- **Two or more** debounced fields on the same table (search + a free-text filter, etc.): `useTableFiltersUrlState(keys)` (`components/table`), not one `useListUrlState` / `useUrlSearchParamsUpdater` call per field. Independent debounced writers race — each rebuilds the next URL from its own `searchParams` snapshot at the moment its timer fires, so whichever settles second can silently drop the other's just-committed change. `useTableFiltersUrlState` commits every field together in a single `updateUrl` call per settle window, so there is exactly one writer.
+  - `keys` must be a module-level constant array (e.g. `const FILTER_KEYS = ["search", "hasLocale"] as const;`), not an inline literal — it drives the hook's effect dependencies.
+  - Non-debounced filters (`Select`s, checkboxes) still call `updateUrl` directly; they don't need to be listed in `keys`.
+  - Reference: `features/data-lists/view-lists/ui/data-lists-page.tsx` (`DATA_LISTS_FILTER_KEYS` in `utils.ts`).
+
+## Detail → list back navigation
+
+When a detail page has a "Back to `<list>`" control that should restore the list's last paging/filters, use `BackToTableButton` (`components/table/back-to-table-button.tsx`) backed by `lib/list-page/table-return-to`. Do **not** carry list state back via a URL param (e.g. `?from=...`) for this — session-scoped storage keeps detail URLs shareable/bookmarkable without embedding list state, and is naturally scoped per browser tab (a middle-click into a new tab correctly falls back to the bare list path instead of inheriting another tab's filters).
+
+- The list page remembers its own current query in a `useEffect` keyed on `searchParams`: `rememberTableReturnTo(tableKey, searchParams.toString(), parse, scopeId?)`.
+- The detail page's back control is `<BackToTableButton tableKey="..." fallbackHref="..." parse={...} buildHref={...} />` (or call `getTableReturnHref(...)` directly outside a `Link`).
+- `tableKey` scopes the storage key (e.g. `"data-lists"`, `"submissions"`); also pass `scopeId` when the list itself is per-parent-entity (e.g. a formId for `/forms/:formId/submissions`).
+- **`parse` is mandatory and is the whitelist.** It must be the same `parse*ListParams` + `serialize*ListSearchParams` round-trip the list page's own URL parsing already uses (paging clamped to positive ints, enums/culture-codes validated, unknown keys dropped). `table-return-to` re-runs `parse` on read too — defense in depth, since a value written by an older app version (or edited via storage/devtools) must be re-validated before ever being reused for navigation — and falls back to `fallbackHref` if `parse` throws or empties the query. Never pass a function that returns raw/unvalidated input, and `buildHref` must build against a hardcoded list path, never treat the stored value itself as a redirect target.
+- `parse` / `buildHref` should be stable references (module-level functions, not inline closures) — they're effect dependencies on `BackToTableButton`.
+- Reference implementation: `features/data-lists/view-lists/utils.ts` (`parseDataListsReturnQuery`, `dataListsListHrefFromQuery`), wired into `data-lists-page.tsx` (remember) and `data-list-details-page.tsx` (`BackToTableButton`).
+- `features/submissions/list-submission-query/submission-list-return-to.ts` + `back-to-submissions-button.tsx` predate this shared abstraction (bespoke sessionStorage, same shape, not yet migrated). Move it onto `table-return-to` / `BackToTableButton` next time that code is touched rather than adding a third bespoke copy.
+
 ## Error Handling
 
 - Preserve API-provided user-facing messages, validation errors, and error codes through the shared result mappers.

--- a/app/(main)/data-lists/[dataListId]/page.tsx
+++ b/app/(main)/data-lists/[dataListId]/page.tsx
@@ -7,10 +7,7 @@ import {
 } from "@/features/data-lists/view-list-details";
 import { getDataListItemsPage } from "@/features/data-lists/view-list-details/get-data-list-items.server";
 import { parseDataListItemsParams } from "@/features/data-lists/view-list-details/utils";
-import {
-  firstString,
-  parseDataListsReturnHref,
-} from "@/features/data-lists/view-lists/utils";
+import { firstString } from "@/features/data-lists/view-lists/utils";
 import { isNotFoundError } from "@/lib/endatix-api";
 import { hasValue, SearchParam } from "@/lib/utils/next-utils";
 
@@ -21,7 +18,6 @@ interface DataListDetailsRoutePageProps {
     page: SearchParam;
     pageSize: SearchParam;
     search: SearchParam;
-    from: SearchParam;
   }>;
 }
 
@@ -57,14 +53,12 @@ export default async function DataListDetailsRoutePage({
     locale: dataListResult.data.defaultLocale,
   });
   const openReplaceOnLoad = hasValue(raw.action, "replace");
-  const returnHref = parseDataListsReturnHref(firstString(raw.from));
 
   return (
     <DataListDetailsPage
       initialDetails={dataListResult.data}
       itemsPromise={itemsPromise}
       openReplaceOnLoad={openReplaceOnLoad}
-      returnHref={returnHref}
     />
   );
 }

--- a/app/(main)/data-lists/[dataListId]/page.tsx
+++ b/app/(main)/data-lists/[dataListId]/page.tsx
@@ -5,16 +5,24 @@ import {
   getDataListByIdAction,
   DataListDetailsPage,
 } from "@/features/data-lists/view-list-details";
-import { isNotFoundError } from "@/lib/endatix-api";
-import { hasValue, SearchParam } from "@/lib/utils/next-utils";
+import { getDataListItemsPage } from "@/features/data-lists/view-list-details/get-data-list-items.server";
+import { parseDataListItemsParams } from "@/features/data-lists/view-list-details/utils";
 import {
   firstString,
   parseDataListsReturnHref,
 } from "@/features/data-lists/view-lists/utils";
+import { isNotFoundError } from "@/lib/endatix-api";
+import { hasValue, SearchParam } from "@/lib/utils/next-utils";
 
 interface DataListDetailsRoutePageProps {
   params: Promise<{ dataListId: string }>;
-  searchParams: Promise<{ action: SearchParam; from: SearchParam }>;
+  searchParams: Promise<{
+    action: SearchParam;
+    page: SearchParam;
+    pageSize: SearchParam;
+    search: SearchParam;
+    from: SearchParam;
+  }>;
 }
 
 export default async function DataListDetailsRoutePage({
@@ -26,6 +34,7 @@ export default async function DataListDetailsRoutePage({
   await requireHubAccess();
 
   const { dataListId } = await params;
+  const raw = await searchParams;
   const dataListResult = await getDataListByIdAction(dataListId);
 
   if (!dataListResult.success) {
@@ -36,13 +45,24 @@ export default async function DataListDetailsRoutePage({
     throw new Error(dataListResult.error.message);
   }
 
-  const { action, from } = await searchParams;
-  const openReplaceOnLoad = hasValue(action, "replace");
-  const returnHref = parseDataListsReturnHref(firstString(from));
+  const itemsRequest = parseDataListItemsParams({
+    page: firstString(raw.page),
+    pageSize: firstString(raw.pageSize),
+    search: firstString(raw.search),
+  });
+  const includeLocales = dataListResult.data.availableLocales ?? [];
+  const itemsPromise = getDataListItemsPage(dataListId, {
+    ...itemsRequest,
+    includeLocales,
+    locale: dataListResult.data.defaultLocale,
+  });
+  const openReplaceOnLoad = hasValue(raw.action, "replace");
+  const returnHref = parseDataListsReturnHref(firstString(raw.from));
 
   return (
     <DataListDetailsPage
       initialDetails={dataListResult.data}
+      itemsPromise={itemsPromise}
       openReplaceOnLoad={openReplaceOnLoad}
       returnHref={returnHref}
     />

--- a/components/table/__tests__/back-to-table-button.test.tsx
+++ b/components/table/__tests__/back-to-table-button.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { BackToTableButton } from "../back-to-table-button";
+import { rememberTableReturnTo } from "@/lib/list-page/table-return-to";
+
+const identityParse = (query: string) => query;
+const buildHref = (query: string) => `/things?${query}`;
+
+describe("BackToTableButton", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("uses the fallback href when nothing is remembered", async () => {
+    // Arrange & Act
+    render(
+      <BackToTableButton
+        tableKey="things"
+        fallbackHref="/things"
+        parse={identityParse}
+        buildHref={buildHref}
+        text="Back to Things"
+      />,
+    );
+
+    // Assert
+    const link = await screen.findByRole("link", { name: /back to things/i });
+    await waitFor(() => {
+      expect(link.getAttribute("href")).toBe("/things");
+    });
+  });
+
+  it("restores the remembered query, scoped by tableKey", async () => {
+    // Arrange
+    rememberTableReturnTo("things", "page=2&search=abc", identityParse);
+
+    // Act
+    render(
+      <BackToTableButton
+        tableKey="things"
+        fallbackHref="/things"
+        parse={identityParse}
+        buildHref={buildHref}
+      />,
+    );
+
+    // Assert
+    const link = await screen.findByRole("link", { name: /back/i });
+    await waitFor(() => {
+      expect(link.getAttribute("href")).toBe("/things?page=2&search=abc");
+    });
+  });
+
+  it("scopes remembered queries by scopeId", async () => {
+    // Arrange
+    rememberTableReturnTo("things", "page=9", identityParse, "parent-a");
+    rememberTableReturnTo("things", "page=1", identityParse, "parent-b");
+
+    // Act
+    render(
+      <BackToTableButton
+        tableKey="things"
+        scopeId="parent-a"
+        fallbackHref="/things"
+        parse={identityParse}
+        buildHref={buildHref}
+      />,
+    );
+
+    // Assert
+    const link = await screen.findByRole("link", { name: /back/i });
+    await waitFor(() => {
+      expect(link.getAttribute("href")).toBe("/things?page=9");
+    });
+  });
+});

--- a/components/table/__tests__/use-table-filters-url-state.test.ts
+++ b/components/table/__tests__/use-table-filters-url-state.test.ts
@@ -1,0 +1,119 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTableFiltersUrlState } from "../use-table-filters-url-state";
+
+const replace = vi.fn();
+let searchParams = new URLSearchParams("page=2&search=alpha");
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  usePathname: () => "/data-lists",
+  useSearchParams: () => searchParams,
+}));
+
+const FILTER_KEYS = ["search", "hasLocale"] as const;
+
+describe("useTableFiltersUrlState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    replace.mockClear();
+    searchParams = new URLSearchParams("page=2&search=alpha");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("initializes values from the URL for every key", () => {
+    // Arrange & Act
+    const { result } = renderHook(() => useTableFiltersUrlState(FILTER_KEYS));
+
+    // Assert
+    expect(result.current.values).toEqual({ search: "alpha", hasLocale: "" });
+  });
+
+  it("coalesces edits to two fields into a single updateUrl call", () => {
+    // Arrange
+    const { result } = renderHook(() => useTableFiltersUrlState(FILTER_KEYS));
+
+    // Act — edit both fields within the debounce window
+    act(() => {
+      result.current.setValue("search", "cities");
+    });
+    act(() => {
+      result.current.setValue("hasLocale", "es");
+    });
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+
+    // Assert — one navigation, both values present (neither dropped)
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(replace).toHaveBeenCalledWith(
+      "/data-lists?page=1&search=cities&hasLocale=es",
+      { scroll: false },
+    );
+  });
+
+  it("resets page to 1 when a filter commits", () => {
+    // Arrange
+    const { result } = renderHook(() => useTableFiltersUrlState(FILTER_KEYS));
+
+    // Act
+    act(() => {
+      result.current.setValue("search", "cities");
+    });
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+
+    // Assert
+    const [href] = replace.mock.calls[0];
+    expect(href).toContain("page=1");
+  });
+
+  it("clears a filter when the committed value is empty", () => {
+    // Arrange
+    const { result } = renderHook(() => useTableFiltersUrlState(FILTER_KEYS));
+
+    // Act
+    act(() => {
+      result.current.setValue("search", "   ");
+    });
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+
+    // Assert
+    expect(replace).toHaveBeenCalledWith("/data-lists?page=1", {
+      scroll: false,
+    });
+  });
+
+  it("does not navigate when nothing changed", () => {
+    // Arrange
+    renderHook(() => useTableFiltersUrlState(FILTER_KEYS));
+
+    // Act
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // Assert
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("resyncs local values when the URL changes from outside", () => {
+    // Arrange
+    const { result, rerender } = renderHook(() =>
+      useTableFiltersUrlState(FILTER_KEYS),
+    );
+
+    // Act
+    searchParams = new URLSearchParams("search=beta&hasLocale=fr");
+    rerender();
+
+    // Assert
+    expect(result.current.values).toEqual({ search: "beta", hasLocale: "fr" });
+  });
+});

--- a/components/table/back-to-table-button.tsx
+++ b/components/table/back-to-table-button.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { useEffect, useState } from "react";
+import type { Route } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { getTableReturnHref } from "@/lib/list-page/table-return-to";
+
+interface BackToTableButtonProps extends Omit<
+  ComponentProps<typeof Button>,
+  "asChild" | "children"
+> {
+  /** Identifies the list this button returns to, e.g. `"data-lists"`, `"submissions"`. */
+  tableKey: string;
+  /** Scopes the remembered query when the list is per-parent-entity (e.g. a formId). */
+  scopeId?: string;
+  /** Bare list path used when nothing is remembered (or storage is unavailable). */
+  fallbackHref: string;
+  /**
+   * Re-parses a query string through the list's own whitelist (same
+   * `parse*ListParams` + `serialize*ListSearchParams` round-trip the list
+   * page uses). Must be a stable reference (module-level function or
+   * `useCallback`) — it re-runs on every render this button's inputs change.
+   */
+  parse: (query: string) => string;
+  /** Builds the full href from an already-validated query string. */
+  buildHref: (query: string) => string;
+  text?: string;
+}
+
+/**
+ * "Back to list" control that restores the list's last remembered
+ * paging/filters via session-scoped storage (see `lib/list-page/table-return-to`),
+ * falling back to `fallbackHref` on first visit, private browsing, or a new tab.
+ */
+export function BackToTableButton({
+  tableKey,
+  scopeId,
+  fallbackHref,
+  parse,
+  buildHref,
+  text = "Back",
+  variant = "outline",
+  ...props
+}: Readonly<BackToTableButtonProps>) {
+  const [href, setHref] = useState(fallbackHref);
+
+  useEffect(() => {
+    setHref(
+      getTableReturnHref(tableKey, fallbackHref, parse, buildHref, scopeId),
+    );
+  }, [tableKey, scopeId, fallbackHref, parse, buildHref]);
+
+  return (
+    <Button variant={variant} asChild {...props}>
+      <Link href={href as Route} className="flex items-center gap-2">
+        <ArrowLeft className="h-4 w-4" />
+        {text}
+      </Link>
+    </Button>
+  );
+}

--- a/components/table/index.ts
+++ b/components/table/index.ts
@@ -1,3 +1,4 @@
+export { BackToTableButton } from "./back-to-table-button";
 export {
   DATA_TABLE_COLUMN_LABEL_CLASS_NAME,
   DATA_TABLE_ELEMENT_CLASS_NAME,
@@ -19,3 +20,7 @@ export {
 } from "./paged-table-footer";
 export { TableEmptyRow } from "./table-empty-row";
 export { TableSearchInput } from "./table-search-input";
+export {
+  useTableFiltersUrlState,
+  type UseTableFiltersUrlStateResult,
+} from "./use-table-filters-url-state";

--- a/components/table/use-table-filters-url-state.ts
+++ b/components/table/use-table-filters-url-state.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  useUrlSearchParamsUpdater,
+  type UrlSearchParamsUpdater,
+} from "@/lib/utils/hooks/use-url-search-params-updater.hook";
+
+const DEFAULT_DEBOUNCE_MS = 350;
+
+export interface UseTableFiltersUrlStateResult {
+  /** Current (possibly not-yet-committed) value for each key. */
+  values: Record<string, string>;
+  /** Updates one field's local value; the whole set commits together after `debounceMs`. */
+  setValue: (key: string, value: string) => void;
+  searchParams: URLSearchParams;
+  updateUrl: UrlSearchParamsUpdater;
+}
+
+function readUrlValues(
+  keys: readonly string[],
+  searchParams: URLSearchParams,
+): Record<string, string> {
+  return Object.fromEntries(
+    keys.map((key) => [key, searchParams.get(key) ?? ""]),
+  );
+}
+
+/**
+ * Debounced, URL-backed state for N table filter fields (a search box plus
+ * one or more free-text filters), committed to the URL in a single
+ * coalesced `updateUrl` call per settle window.
+ *
+ * `keys` must be a stable reference — a module-level constant array (e.g.
+ * `const FILTER_KEYS = ["search", "hasLocale"] as const;`), not an inline
+ * array literal — since it drives this hook's effect dependencies.
+ *
+ * Do not also call `useListUrlState` / `useUrlSearchParamsUpdater` for
+ * another debounced filter on the same table: two independent debounced
+ * writers race — each rebuilds the URL from its own `searchParams`
+ * snapshot at the moment its timer fires, so whichever settles second can
+ * silently drop the other's just-committed change. List every debounced
+ * filter key here instead so there is exactly one writer per settle
+ * window.
+ *
+ * Always resets `page` to `"1"` when any field's committed value changes.
+ * Non-debounced filters (`Select`s, checkboxes, etc.) should call
+ * `updateUrl` directly instead of going through this hook.
+ */
+export function useTableFiltersUrlState(
+  keys: readonly string[],
+  debounceMs: number = DEFAULT_DEBOUNCE_MS,
+): UseTableFiltersUrlStateResult {
+  const { searchParams, updateUrl } = useUrlSearchParamsUpdater();
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    readUrlValues(keys, searchParams),
+  );
+
+  // URL changed from outside this hook (back/forward, footer paging,
+  // another control) — resync local state.
+  useEffect(() => {
+    setValues(readUrlValues(keys, searchParams));
+  }, [keys, searchParams]);
+
+  useEffect(() => {
+    const urlValues = readUrlValues(keys, searchParams);
+    const trimmed = Object.fromEntries(
+      keys.map((key) => [key, (values[key] ?? "").trim()]),
+    );
+    const changed = keys.some((key) => trimmed[key] !== urlValues[key]);
+    if (!changed) {
+      return;
+    }
+
+    const timeout = globalThis.window.setTimeout(() => {
+      updateUrl({
+        ...Object.fromEntries(keys.map((key) => [key, trimmed[key] || null])),
+        page: "1",
+      });
+    }, debounceMs);
+
+    return () => globalThis.window.clearTimeout(timeout);
+  }, [keys, values, searchParams, updateUrl, debounceMs]);
+
+  const setValue = (key: string, value: string): void => {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return { values, setValue, searchParams, updateUrl };
+}

--- a/features/data-lists/view-list-details/__tests__/list-data-list-items-query.test.ts
+++ b/features/data-lists/view-list-details/__tests__/list-data-list-items-query.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { parseDataListItemsParams } from "../utils";
+
+describe("parseDataListItemsParams", () => {
+  it("maps Hub search to API query with default page size 25", () => {
+    // Arrange & Act
+    const parsed = parseDataListItemsParams({
+      search: "  york ",
+      page: "2",
+    });
+
+    // Assert
+    expect(parsed).toEqual({
+      page: 2,
+      pageSize: 25,
+      query: "york",
+    });
+  });
+});

--- a/features/data-lists/view-list-details/get-data-list-by-id.action.ts
+++ b/features/data-lists/view-list-details/get-data-list-by-id.action.ts
@@ -15,7 +15,9 @@ export async function getDataListByIdAction(
   await requireHubAccess();
 
   const api = new EndatixApi(session?.accessToken);
-  const result = await api.dataLists.getById(dataListId);
+  const result = await api.dataLists.getById(dataListId, {
+    includeItems: false,
+  });
 
   if (ApiResult.isError(result)) {
     return result;

--- a/features/data-lists/view-list-details/get-data-list-items.server.ts
+++ b/features/data-lists/view-list-details/get-data-list-items.server.ts
@@ -1,0 +1,30 @@
+import { auth } from "@/auth";
+import { authorization } from "@/features/auth/authorization";
+import { EndatixApi } from "@/lib/endatix-api";
+import type { DataListItemsPage } from "@/lib/endatix-api/data-lists/data-lists";
+import type { ListDataListItemsRequest } from "@/lib/endatix-api/data-lists/types";
+import { DataLoadError } from "@/lib/errors/data-load-error";
+import { Result } from "@/lib/result";
+import { toResult } from "@/lib/result/map-api-result-to-result";
+
+export async function getDataListItemsPage(
+  dataListId: string,
+  request: ListDataListItemsRequest,
+): Promise<DataListItemsPage> {
+  const session = await auth();
+  const { requireHubAccess } = await authorization(session);
+  await requireHubAccess();
+
+  const api = new EndatixApi(session?.accessToken);
+  const result = toResult(await api.dataLists.listItems(dataListId, request), {
+    fallbackMessage: "Failed to load data list items.",
+    logMessage: "Failed to load data list items.",
+    loggerName: "data-lists.items",
+  });
+
+  if (Result.isError(result)) {
+    throw new DataLoadError(result.message);
+  }
+
+  return result.value;
+}

--- a/features/data-lists/view-list-details/ui/data-list-details-page.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-details-page.tsx
@@ -2,6 +2,11 @@
 
 import { Button } from "@/components/ui/button";
 import {
+  createPagedTableFooterProps,
+  PagedTableFooter,
+  TableSearchInput,
+} from "@/components/table";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -9,6 +14,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { toast } from "@/components/ui/toast";
 import type { DataListDetails } from "@/lib/endatix-api/data-lists/types";
+import type { DataListItemsPage } from "@/lib/endatix-api/data-lists/data-lists";
+import { useListUrlState } from "@/lib/list-page/use-list-url-state";
 import { TelemetryLogger } from "@/features/telemetry";
 import { withBasePath } from "@/lib/hosting";
 import { getFormattedDate } from "@/lib/utils";
@@ -19,13 +26,13 @@ import {
 import { ArrowLeft, ChevronDown, Download, Upload } from "lucide-react";
 import Link from "next/link";
 import type { Route } from "next";
-import { useEffect, useState, useTransition } from "react";
+import { Suspense, use, useEffect, useState, useTransition } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
 import { ReplaceItemsDialog } from "../../replace-items/ui/replace-items-dialog";
 import { useRouter } from "next/navigation";
 import { validateEndatixId } from "@/lib/utils/type-validators";
 import { Result } from "@/lib/result";
 import type { DataListSourceFormat } from "../../add-items/data-list-items-input";
-import { serializeDataListItemsJson } from "../../utils";
 import { DataListItemsTable } from "./data-list-items-table";
 import { LocaleCatalogPanel } from "./locale-catalog-panel";
 
@@ -33,12 +40,14 @@ const CSV_EXPORT_LOGGER = "data-lists.exportCsv";
 
 interface DataListDetailsPageProps {
   initialDetails: DataListDetails;
+  itemsPromise: Promise<DataListItemsPage>;
   openReplaceOnLoad?: boolean;
   returnHref?: string;
 }
 
 export function DataListDetailsPage({
   initialDetails,
+  itemsPromise,
   openReplaceOnLoad = false,
   returnHref = "/data-lists",
 }: Readonly<DataListDetailsPageProps>) {
@@ -90,22 +99,35 @@ export function DataListDetailsPage({
     setIsReplaceDialogOpen(true);
   };
 
-  const handleDownloadCsv = (): void => {
+  const handleDownloadJson = (): void => {
+    void downloadExport("json");
+  };
+
+  const downloadExport = (format: "csv" | "json"): void => {
     if (Result.isError(dataListIdResult)) {
       toast.error(dataListIdResult.message);
       return;
     }
 
     const dataListId = dataListIdResult.value;
+    const fallbackName =
+      format === "json"
+        ? `data-list-${dataListId}.json`
+        : `data-list-${dataListId}-translations.csv`;
+    const successMessage = format === "json" ? "JSON downloaded" : "CSV downloaded";
+    const errorMessage =
+      format === "json"
+        ? "Failed to download JSON"
+        : "Failed to download translations CSV";
 
     startDownloadTransition(async () => {
       try {
         const response = await fetch(
-          withBasePath(`/api/data-lists/${dataListId}/export?format=csv`),
+          withBasePath(`/api/data-lists/${dataListId}/export?format=${format}`),
         );
 
         if (!response.ok) {
-          let message = "Failed to download translations CSV";
+          let message = errorMessage;
           try {
             const payload = (await response.json()) as { error?: string };
             if (payload.error) {
@@ -113,7 +135,7 @@ export function DataListDetailsPage({
             }
           } catch (error) {
             TelemetryLogger.error(
-              "Failed to parse data list CSV export error response",
+              "Failed to parse data list export error response",
               error,
               {
                 "http.status_code": response.status,
@@ -130,26 +152,18 @@ export function DataListDetailsPage({
         const blob = await response.blob();
         const fileName = getFilenameFromContentDisposition(
           response.headers,
-          `data-list-${dataListId}-translations.csv`,
+          fallbackName,
         );
         initiateFileDownload(blob, fileName);
-        toast.success("CSV downloaded");
+        toast.success(successMessage);
       } catch {
-        toast.error("Failed to download translations CSV");
+        toast.error(errorMessage);
       }
     });
   };
 
-  const handleDownloadJson = (): void => {
-    const json = serializeDataListItemsJson(details.items);
-    const blob = new Blob([json], { type: "application/json;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = `data-list-${details.id}.json`;
-    anchor.click();
-    URL.revokeObjectURL(url);
-    toast.success("JSON downloaded");
+  const handleDownloadCsv = (): void => {
+    void downloadExport("csv");
   };
 
   const availableLocales = details.availableLocales ?? [];
@@ -183,8 +197,8 @@ export function DataListDetailsPage({
                 Modified: {getFormattedDate(details.modifiedAt as Date | null)}
               </span>
               <span>
-                {details.items.length} item
-                {details.items.length === 1 ? "" : "s"}
+                {details.itemsCount} item
+                {details.itemsCount === 1 ? "" : "s"}
               </span>
             </div>
           </div>
@@ -228,13 +242,28 @@ export function DataListDetailsPage({
           </div>
         </div>
 
-        <LocaleCatalogPanel details={details} onUpdated={setDetails} />
-
-        <DataListItemsTable
-          items={details.items}
-          availableLocales={availableLocales}
-          defaultLocale={details.defaultLocale}
+        <LocaleCatalogPanel
+          details={details}
+          onUpdated={(updated) => {
+            setDetails(updated);
+            router.refresh();
+          }}
         />
+
+        <Suspense
+          fallback={
+            <div className="space-y-3">
+              <Skeleton className="h-10 w-full max-w-sm" />
+              <Skeleton className="h-64 w-full" />
+            </div>
+          }
+        >
+          <DataListItemsPanel
+            itemsPromise={itemsPromise}
+            availableLocales={availableLocales}
+            defaultLocale={details.defaultLocale}
+          />
+        </Suspense>
       </div>
 
       <ReplaceItemsDialog
@@ -250,9 +279,47 @@ export function DataListDetailsPage({
         initialFormat={replaceInitialFormat}
         onReplaced={(updated) => {
           setDetails(updated);
+          router.refresh();
           toast.success("Data list details updated");
         }}
       />
     </>
+  );
+}
+
+function DataListItemsPanel({
+  itemsPromise,
+  availableLocales,
+  defaultLocale,
+}: Readonly<{
+  itemsPromise: Promise<DataListItemsPage>;
+  availableLocales: string[];
+  defaultLocale?: string;
+}>) {
+  const paged = use(itemsPromise);
+  const { search, setSearch, updateUrl, searchParams } = useListUrlState();
+  const footerProps = createPagedTableFooterProps(paged, "items", updateUrl);
+  const hasSearch = Boolean(searchParams.get("search")?.trim());
+
+  return (
+    <div className="space-y-3">
+      <TableSearchInput
+        value={search}
+        onChange={setSearch}
+        placeholder="Search items by value or label"
+        ariaLabel="Search data list items"
+      />
+      <DataListItemsTable
+        items={[...paged.items]}
+        availableLocales={availableLocales}
+        defaultLocale={defaultLocale}
+        emptyMessage={
+          hasSearch
+            ? "No items match the current search."
+            : "No items in this list."
+        }
+        footer={<PagedTableFooter {...footerProps} />}
+      />
+    </div>
   );
 }

--- a/features/data-lists/view-list-details/ui/data-list-details-page.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-details-page.tsx
@@ -121,7 +121,7 @@ export function DataListDetailsPage({
   };
 
   const handleDownloadJson = (): void => {
-    void downloadExport("json");
+    downloadExport("json");
   };
 
   const downloadExport = (format: "csv" | "json"): void => {
@@ -185,7 +185,7 @@ export function DataListDetailsPage({
   };
 
   const handleDownloadCsv = (): void => {
-    void downloadExport("csv");
+    downloadExport("csv");
   };
 
   const availableLocales = details.availableLocales ?? [];

--- a/features/data-lists/view-list-details/ui/data-list-details-page.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-details-page.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import {
+  BackToTableButton,
   createPagedTableFooterProps,
   PagedTableFooter,
   TableSearchInput,
@@ -23,18 +24,23 @@ import {
   getFilenameFromContentDisposition,
   initiateFileDownload,
 } from "@/lib/utils/files-download";
-import { ArrowLeft, ChevronDown, Download, Upload } from "lucide-react";
-import Link from "next/link";
+import { ChevronDown, Download, Upload } from "lucide-react";
 import type { Route } from "next";
 import { Suspense, use, useEffect, useState, useTransition } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ReplaceItemsDialog } from "../../replace-items/ui/replace-items-dialog";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { validateEndatixId } from "@/lib/utils/type-validators";
 import { Result } from "@/lib/result";
 import type { DataListSourceFormat } from "../../add-items/data-list-items-input";
 import { DataListItemsTable } from "./data-list-items-table";
 import { LocaleCatalogPanel } from "./locale-catalog-panel";
+import {
+  DATA_LISTS_LIST_PATH,
+  DATA_LISTS_TABLE_KEY,
+  dataListsListHrefFromQuery,
+  parseDataListsReturnQuery,
+} from "../../view-lists/utils";
 
 const CSV_EXPORT_LOGGER = "data-lists.exportCsv";
 
@@ -42,14 +48,12 @@ interface DataListDetailsPageProps {
   initialDetails: DataListDetails;
   itemsPromise: Promise<DataListItemsPage>;
   openReplaceOnLoad?: boolean;
-  returnHref?: string;
 }
 
 export function DataListDetailsPage({
   initialDetails,
   itemsPromise,
   openReplaceOnLoad = false,
-  returnHref = "/data-lists",
 }: Readonly<DataListDetailsPageProps>) {
   const [details, setDetails] = useState(initialDetails);
   const [isReplaceDialogOpen, setIsReplaceDialogOpen] =
@@ -60,7 +64,24 @@ export function DataListDetailsPage({
     useState<DataListSourceFormat>("json");
   const [isDownloadPending, startDownloadTransition] = useTransition();
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const dataListIdResult = validateEndatixId(String(details.id), "dataListId");
+
+  // Items pagination/search is keyed off the URL, but the item set just
+  // changed size (or content) — an out-of-range `page` or stale `search`
+  // would otherwise render a false "no items" empty state after replace.
+  const resetItemsListState = (): void => {
+    const nextParams = new URLSearchParams(searchParams.toString());
+    if (!nextParams.has("page") && !nextParams.has("search")) {
+      return;
+    }
+
+    nextParams.delete("page");
+    nextParams.delete("search");
+    const query = nextParams.toString();
+    router.replace((query ? `${pathname}?${query}` : pathname) as Route);
+  };
 
   useEffect(() => {
     if (!openReplaceOnLoad) {
@@ -114,7 +135,8 @@ export function DataListDetailsPage({
       format === "json"
         ? `data-list-${dataListId}.json`
         : `data-list-${dataListId}-translations.csv`;
-    const successMessage = format === "json" ? "JSON downloaded" : "CSV downloaded";
+    const successMessage =
+      format === "json" ? "JSON downloaded" : "CSV downloaded";
     const errorMessage =
       format === "json"
         ? "Failed to download JSON"
@@ -171,12 +193,13 @@ export function DataListDetailsPage({
   return (
     <>
       <div className="mb-4">
-        <Button variant="outline" asChild>
-          <Link href={returnHref as Route}>
-            <ArrowLeft className="h-4 w-4" />
-            Back to Data Lists
-          </Link>
-        </Button>
+        <BackToTableButton
+          tableKey={DATA_LISTS_TABLE_KEY}
+          fallbackHref={DATA_LISTS_LIST_PATH}
+          parse={parseDataListsReturnQuery}
+          buildHref={dataListsListHrefFromQuery}
+          text="Back to Data Lists"
+        />
       </div>
 
       <div className="space-y-4">
@@ -279,6 +302,7 @@ export function DataListDetailsPage({
         initialFormat={replaceInitialFormat}
         onReplaced={(updated) => {
           setDetails(updated);
+          resetItemsListState();
           router.refresh();
           toast.success("Data list details updated");
         }}

--- a/features/data-lists/view-list-details/ui/data-list-items-table.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-items-table.tsx
@@ -25,13 +25,15 @@ import {
   useReactTable,
   type ColumnDef,
 } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 import "./table-types";
 
 type DataListItemsTableProps = {
   items: DataListItem[];
   availableLocales: string[];
   defaultLocale?: string;
+  emptyMessage?: string;
+  footer?: ReactNode;
 };
 
 type DataListItemRow = DataListItem & { rowId: string };
@@ -92,6 +94,8 @@ export function DataListItemsTable({
   items,
   availableLocales,
   defaultLocale,
+  emptyMessage = "No items in this list.",
+  footer,
 }: Readonly<DataListItemsTableProps>) {
   const labelColumns = useMemo(
     () => ["default", ...availableLocales],
@@ -130,7 +134,8 @@ export function DataListItemsTable({
   if (rows.length === 0) {
     return (
       <DataTableSurface data-slot="data-list-items-table">
-        <DataTableEmpty>No items in this list.</DataTableEmpty>
+        <DataTableEmpty>{emptyMessage}</DataTableEmpty>
+        {footer}
       </DataTableSurface>
     );
   }
@@ -201,6 +206,7 @@ export function DataListItemsTable({
           </TableBody>
         </Table>
       </div>
+      {footer}
     </DataTableSurface>
   );
 }

--- a/features/data-lists/view-list-details/utils.ts
+++ b/features/data-lists/view-list-details/utils.ts
@@ -1,0 +1,25 @@
+import { parsePagedSearchParams } from "@/lib/list-page/parse-paged-search-params";
+import type { ListDataListItemsRequest } from "@/lib/endatix-api/data-lists/types";
+
+export const DEFAULT_DATA_LIST_ITEMS_PAGE_SIZE = 25;
+
+export interface DataListItemsSearchParams {
+  page?: string;
+  pageSize?: string;
+  search?: string;
+}
+
+export function parseDataListItemsParams(
+  searchParams?: DataListItemsSearchParams,
+): ListDataListItemsRequest {
+  const paging = parsePagedSearchParams(
+    searchParams,
+    DEFAULT_DATA_LIST_ITEMS_PAGE_SIZE,
+  );
+  const search = searchParams?.search?.trim() || undefined;
+
+  return {
+    ...paging,
+    query: search,
+  };
+}

--- a/features/data-lists/view-lists/__tests__/list-data-lists-query.test.ts
+++ b/features/data-lists/view-lists/__tests__/list-data-lists-query.test.ts
@@ -96,5 +96,7 @@ describe("parseDataListsReturnQuery + dataListsListHrefFromQuery", () => {
     // Assert
     expect(parsed).not.toContain("evil");
     expect(parsed).toContain("search=cities");
+    expect(parsed).not.toContain("page=");
+    expect(parsed).toContain("pageSize=1000");
   });
 });

--- a/features/data-lists/view-lists/__tests__/list-data-lists-query.test.ts
+++ b/features/data-lists/view-lists/__tests__/list-data-lists-query.test.ts
@@ -3,8 +3,9 @@ import {
   ALL_LOCALES_FILTER_VALUE,
   buildDataListDetailHref,
   buildDataListsListHref,
+  dataListsListHrefFromQuery,
   parseDataListsListParams,
-  parseDataListsReturnHref,
+  parseDataListsReturnQuery,
   serializeDataListsListSearchParams,
 } from "../utils";
 
@@ -52,8 +53,24 @@ describe("serializeDataListsListSearchParams", () => {
       "/data-lists",
     );
   });
+});
 
-  it("round-trips list filters through the detail from param", () => {
+describe("buildDataListDetailHref", () => {
+  it("builds a bare detail href with no query", () => {
+    // Arrange & Act & Assert
+    expect(buildDataListDetailHref("42")).toBe("/data-lists/42");
+  });
+
+  it("appends action when given", () => {
+    // Arrange & Act & Assert
+    expect(buildDataListDetailHref("42", { action: "replace" })).toBe(
+      "/data-lists/42?action=replace",
+    );
+  });
+});
+
+describe("parseDataListsReturnQuery + dataListsListHrefFromQuery", () => {
+  it("round-trips a remembered list query into a full href (BackToTableButton contract)", () => {
     // Arrange
     const listQuery = serializeDataListsListSearchParams({
       page: 3,
@@ -63,17 +80,21 @@ describe("serializeDataListsListSearchParams", () => {
     });
 
     // Act
-    const detailHref = buildDataListDetailHref("42", listQuery, {
-      action: "replace",
-    });
-    const from = new URLSearchParams(detailHref.split("?")[1] ?? "").get(
-      "from",
+    const parsed = parseDataListsReturnQuery(listQuery);
+    const href = dataListsListHrefFromQuery(parsed);
+
+    // Assert
+    expect(href).toBe(`/data-lists?${listQuery}`);
+  });
+
+  it("drops unknown keys and re-clamps paging when re-parsing", () => {
+    // Arrange & Act
+    const parsed = parseDataListsReturnQuery(
+      "page=-5&pageSize=1000&evil=<script>&search=cities",
     );
 
     // Assert
-    expect(detailHref).toContain("action=replace");
-    expect(parseDataListsReturnHref(from ?? undefined)).toBe(
-      `/data-lists?${listQuery}`,
-    );
+    expect(parsed).not.toContain("evil");
+    expect(parsed).toContain("search=cities");
   });
 });

--- a/features/data-lists/view-lists/ui/data-list-row-actions.tsx
+++ b/features/data-lists/view-lists/ui/data-list-row-actions.tsx
@@ -15,17 +15,15 @@ import Link from "next/link";
 
 interface DataListRowActionsProps {
   dataList: DataList;
-  listQuery: string;
   onDelete: (dataList: DataList) => void;
 }
 
 export function DataListRowActions({
   dataList,
-  listQuery,
   onDelete,
 }: Readonly<DataListRowActionsProps>) {
-  const detailHref = buildDataListDetailHref(String(dataList.id), listQuery);
-  const replaceHref = buildDataListDetailHref(String(dataList.id), listQuery, {
+  const detailHref = buildDataListDetailHref(String(dataList.id));
+  const replaceHref = buildDataListDetailHref(String(dataList.id), {
     action: "replace",
   });
   return (

--- a/features/data-lists/view-lists/ui/data-lists-page.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-page.tsx
@@ -13,6 +13,7 @@ import {
   DataTableSurface,
   PagedTableFooter,
   TableSearchInput,
+  useTableFiltersUrlState,
 } from "@/components/table";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -42,7 +43,7 @@ import type {
   FormDependencySummary,
 } from "@/lib/endatix-api/data-lists/types";
 import type { DataListsPage } from "@/lib/endatix-api/data-lists/data-lists";
-import { useUrlSearchParamsUpdater } from "@/lib/utils/hooks/use-url-search-params-updater.hook";
+import { rememberTableReturnTo } from "@/lib/list-page/table-return-to";
 import { Result } from "@/lib/result";
 import { getFormattedDate } from "@/lib/utils";
 import { CreateDataListDialog } from "../../create-list/ui/create-data-list-dialog";
@@ -52,7 +53,9 @@ import { deleteDataListAction } from "../../delete-list/delete-data-list.action"
 import {
   buildDataListDetailHref,
   currentDataListsListHref,
-  currentDataListsListQuery,
+  DATA_LISTS_FILTER_KEYS,
+  DATA_LISTS_TABLE_KEY,
+  parseDataListsReturnQuery,
 } from "../utils";
 
 interface DataListsPageProps {
@@ -60,49 +63,29 @@ interface DataListsPageProps {
   openCreateOnLoad?: boolean;
 }
 
-const FILTERS_DEBOUNCE_MS = 350;
-
 export function DataListsPage({
   dataListsPromise,
   openCreateOnLoad = false,
 }: Readonly<DataListsPageProps>) {
   const paged = use(dataListsPromise);
   const router = useRouter();
-  const { searchParams, updateUrl } = useUrlSearchParamsUpdater();
-  const listQuery = currentDataListsListQuery(searchParams);
-  const urlSearch = searchParams.get("search") ?? "";
-  const urlHasLocale = searchParams.get("hasLocale") ?? "";
-  const [search, setSearch] = useState(urlSearch);
-  const [hasLocale, setHasLocale] = useState(urlHasLocale);
+  const { values, setValue, searchParams, updateUrl } = useTableFiltersUrlState(
+    DATA_LISTS_FILTER_KEYS,
+  );
+  const search = values.search;
+  const hasLocale = values.hasLocale;
+  const hasLocaleInput = searchParams.get("hasLocale") ?? "";
 
+  // Lets "Back to Data Lists" on the detail page restore paging/filters —
+  // see lib/list-page/table-return-to and AGENTS.md "Detail → list back
+  // navigation".
   useEffect(() => {
-    setSearch(urlSearch);
-  }, [urlSearch]);
-
-  useEffect(() => {
-    setHasLocale(urlHasLocale);
-  }, [urlHasLocale]);
-
-  // Coalesced into a single debounce + updateUrl call
-  useEffect(() => {
-    const trimmedSearch = search.trim();
-    const trimmedHasLocale = hasLocale.trim();
-    if (trimmedSearch === urlSearch && trimmedHasLocale === urlHasLocale) {
-      return;
-    }
-
-    const timeout = globalThis.window.setTimeout(() => {
-      updateUrl({
-        search: trimmedSearch || null,
-        hasLocale: trimmedHasLocale || null,
-        page: "1",
-      });
-    }, FILTERS_DEBOUNCE_MS);
-
-    return () => globalThis.window.clearTimeout(timeout);
-  }, [search, hasLocale, urlSearch, urlHasLocale, updateUrl]);
-
-  const hasLocaleInput = urlHasLocale;
+    rememberTableReturnTo(
+      DATA_LISTS_TABLE_KEY,
+      searchParams.toString(),
+      parseDataListsReturnQuery,
+    );
+  }, [searchParams]);
 
   const [isCreateDialogOpen, setIsCreateDialogOpen] =
     useState(openCreateOnLoad);
@@ -192,13 +175,13 @@ export function DataListsPage({
       <div className="mt-6 flex flex-col gap-3 lg:flex-row lg:items-center">
         <TableSearchInput
           value={search}
-          onChange={setSearch}
+          onChange={(value) => setValue("search", value)}
           placeholder="Search by name or description"
           ariaLabel="Search data lists"
         />
         <Input
           value={hasLocale}
-          onChange={(event) => setHasLocale(event.target.value)}
+          onChange={(event) => setValue("hasLocale", event.target.value)}
           placeholder="Filter by locale (e.g. es)"
           aria-label="Filter data lists by locale"
           className="lg:max-w-xs"
@@ -269,7 +252,6 @@ export function DataListsPage({
                   const isEvenRow = rowIndex % 2 === 1;
                   const detailHref = buildDataListDetailHref(
                     String(dataList.id),
-                    listQuery,
                   );
                   return (
                     <TableRow
@@ -338,7 +320,6 @@ export function DataListsPage({
                       >
                         <DataListRowActions
                           dataList={dataList}
-                          listQuery={listQuery}
                           onDelete={handleOpenDelete}
                         />
                       </TableCell>

--- a/features/data-lists/view-lists/utils.ts
+++ b/features/data-lists/view-lists/utils.ts
@@ -5,6 +5,10 @@ import { tryNormalizeCultureCode } from "@/lib/localization";
 export const DEFAULT_DATA_LISTS_PAGE_SIZE = 10;
 export const DATA_LISTS_LIST_PATH = "/data-lists";
 export const ALL_LOCALES_FILTER_VALUE = "__all_locales__";
+/** `tableKey` for `BackToTableButton` / `rememberTableReturnTo` (see `lib/list-page/table-return-to`). */
+export const DATA_LISTS_TABLE_KEY = "data-lists";
+/** Debounced filter keys for `useTableFiltersUrlState` (see `components/table`). Module-level: must stay a stable reference. */
+export const DATA_LISTS_FILTER_KEYS = ["search", "hasLocale"] as const;
 
 export interface DataListsListSearchParams {
   page?: string;
@@ -12,7 +16,6 @@ export interface DataListsListSearchParams {
   search?: string;
   hasLocale?: string;
   action?: string;
-  from?: string;
 }
 
 export interface DataListsListUrlState {
@@ -90,29 +93,25 @@ export function buildDataListsListHref(state: DataListsListUrlState): string {
 
 export function buildDataListDetailHref(
   dataListId: string,
-  listQuery: string,
   extra?: { action?: string },
 ): string {
-  const params = new URLSearchParams();
-  if (listQuery) {
-    params.set("from", listQuery);
-  }
-  if (extra?.action) {
-    params.set("action", extra.action);
-  }
-
-  const query = params.toString();
   const path = `${DATA_LISTS_LIST_PATH}/${dataListId}`;
-  return query ? `${path}?${query}` : path;
+  return extra?.action ? `${path}?action=${extra.action}` : path;
 }
 
-export function parseDataListsReturnHref(from: string | undefined): string {
-  if (!from) {
-    return DATA_LISTS_LIST_PATH;
-  }
+/**
+ * Re-parses a raw list query string through the list's own whitelist
+ * (paging clamped, `hasLocale` culture-code validated, unknown keys
+ * dropped). Pass to `BackToTableButton`'s `parse` prop — see
+ * `lib/list-page/table-return-to`.
+ */
+export function parseDataListsReturnQuery(query: string): string {
+  return currentDataListsListQuery(new URLSearchParams(query));
+}
 
-  const query = currentDataListsListQuery(new URLSearchParams(from));
-  return query ? `${DATA_LISTS_LIST_PATH}?${query}` : DATA_LISTS_LIST_PATH;
+/** Builds `/data-lists?<query>` from an already-validated query string. */
+export function dataListsListHrefFromQuery(query: string): string {
+  return `${DATA_LISTS_LIST_PATH}?${query}`;
 }
 
 export function currentDataListsListQuery(

--- a/lib/list-page/__tests__/table-return-to.test.ts
+++ b/lib/list-page/__tests__/table-return-to.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearTableReturnTo,
+  getTableReturnHref,
+  rememberTableReturnTo,
+} from "../table-return-to";
+
+const identityParse = (query: string) => query;
+const buildHref = (query: string) => `/things?${query}`;
+
+describe("table return-to", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("returns the fallback when nothing is remembered", () => {
+    // Arrange & Act & Assert
+    expect(
+      getTableReturnHref("things", "/things", identityParse, buildHref),
+    ).toBe("/things");
+  });
+
+  it("remembers and restores a query, scoped by table key", () => {
+    // Arrange
+    rememberTableReturnTo("things", "page=2&search=abc", identityParse);
+
+    // Act
+    const href = getTableReturnHref(
+      "things",
+      "/things",
+      identityParse,
+      buildHref,
+    );
+
+    // Assert
+    expect(href).toBe("/things?page=2&search=abc");
+  });
+
+  it("scopes remembered queries by scopeId independently", () => {
+    // Arrange
+    rememberTableReturnTo("things", "page=3", identityParse, "parent-a");
+    rememberTableReturnTo("things", "page=5", identityParse, "parent-b");
+
+    // Act & Assert
+    expect(
+      getTableReturnHref(
+        "things",
+        "/things",
+        identityParse,
+        buildHref,
+        "parent-a",
+      ),
+    ).toBe("/things?page=3");
+    expect(
+      getTableReturnHref(
+        "things",
+        "/things",
+        identityParse,
+        buildHref,
+        "parent-b",
+      ),
+    ).toBe("/things?page=5");
+  });
+
+  it("re-validates the stored value through parse on read (defense in depth)", () => {
+    // Arrange — value was stored under an old/looser rule (or tampered).
+    sessionStorage.setItem("ehx_table_return_things", "page=2&evil=<script>");
+    const whitelistParse = (query: string) => {
+      const params = new URLSearchParams(query);
+      const page = params.get("page");
+      return page ? `page=${page}` : "";
+    };
+
+    // Act
+    const href = getTableReturnHref(
+      "things",
+      "/things",
+      whitelistParse,
+      buildHref,
+    );
+
+    // Assert
+    expect(href).toBe("/things?page=2");
+    expect(href).not.toContain("evil");
+  });
+
+  it("falls back when parse empties the stored query", () => {
+    // Arrange
+    rememberTableReturnTo("things", "junk=1", () => "");
+
+    // Act & Assert
+    expect(getTableReturnHref("things", "/things", () => "", buildHref)).toBe(
+      "/things",
+    );
+  });
+
+  it("falls back when parse throws", () => {
+    // Arrange
+    sessionStorage.setItem("ehx_table_return_things", "page=2");
+    const throwingParse = () => {
+      throw new Error("boom");
+    };
+
+    // Act & Assert
+    expect(
+      getTableReturnHref("things", "/things", throwingParse, buildHref),
+    ).toBe("/things");
+  });
+
+  it("clears a remembered return-to", () => {
+    // Arrange
+    rememberTableReturnTo("things", "page=2", identityParse);
+
+    // Act
+    clearTableReturnTo("things");
+
+    // Assert
+    expect(
+      getTableReturnHref("things", "/things", identityParse, buildHref),
+    ).toBe("/things");
+  });
+
+  it("does not throw when sessionStorage is unavailable", () => {
+    // Arrange
+    const original = globalThis.sessionStorage;
+    vi.stubGlobal("sessionStorage", {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    });
+
+    // Act & Assert
+    expect(() =>
+      rememberTableReturnTo("things", "page=2", identityParse),
+    ).not.toThrow();
+    expect(
+      getTableReturnHref("things", "/things", identityParse, buildHref),
+    ).toBe("/things");
+    expect(() => clearTableReturnTo("things")).not.toThrow();
+
+    vi.stubGlobal("sessionStorage", original);
+  });
+});

--- a/lib/list-page/table-return-to.ts
+++ b/lib/list-page/table-return-to.ts
@@ -1,0 +1,97 @@
+"use client";
+
+function storageKey(tableKey: string, scopeId?: string): string {
+  return scopeId
+    ? `ehx_table_return_${tableKey}_${scopeId}`
+    : `ehx_table_return_${tableKey}`;
+}
+
+/**
+ * Session-scoped "detail → list" back navigation, keyed by `tableKey` (e.g.
+ * `"data-lists"`, `"submissions"`) and an optional `scopeId` for tables that
+ * are per-parent-entity (e.g. a formId).
+ *
+ * This module only stores/retrieves strings — it does not know a table's
+ * filter shape. Callers MUST supply a `parse` function (the same
+ * `parse*ListParams` + `serialize*ListSearchParams` round-trip the list
+ * page itself uses) on both `rememberTableReturnTo` and
+ * `getTableReturnHref`. That round-trip is what makes this safe to reuse as
+ * navigation state: only known keys survive, each is normalized/typed
+ * (paging clamped to positive ints, enums/culture-codes validated, free
+ * text left as inert filter state — never a path or origin). Never pass a
+ * function that returns raw/unvalidated input, and never use a stored value
+ * as a redirect target directly.
+ */
+
+/**
+ * Remembers a list page's current query string for `tableKey` (+
+ * `scopeId`). `search` is typically `useSearchParams().toString()`.
+ */
+export function rememberTableReturnTo(
+  tableKey: string,
+  search: string,
+  parse: (query: string) => string,
+  scopeId?: string,
+): void {
+  if (globalThis.window === undefined) {
+    return;
+  }
+
+  const query = search.startsWith("?") ? search.slice(1) : search;
+
+  try {
+    globalThis.sessionStorage.setItem(
+      storageKey(tableKey, scopeId),
+      parse(query),
+    );
+  } catch {
+    // Quota / private mode / parse threw — ignore; Back falls back to the
+    // caller's bare list path.
+  }
+}
+
+/**
+ * Builds the return href for `tableKey` (+ `scopeId`). Re-runs the
+ * remembered query through `parse` again — defense in depth, since a value
+ * written by an older app version (or edited via devtools/extensions)
+ * should never be trusted without re-validation — then hands the result to
+ * `buildHref`. Falls back to `fallbackHref` when nothing is remembered,
+ * storage is unavailable, or parsing throws/empties.
+ */
+export function getTableReturnHref(
+  tableKey: string,
+  fallbackHref: string,
+  parse: (query: string) => string,
+  buildHref: (query: string) => string,
+  scopeId?: string,
+): string {
+  if (globalThis.window === undefined) {
+    return fallbackHref;
+  }
+
+  try {
+    const stored = globalThis.sessionStorage.getItem(
+      storageKey(tableKey, scopeId),
+    );
+    if (stored == null || stored.trim() === "") {
+      return fallbackHref;
+    }
+
+    const query = parse(stored);
+    return query ? buildHref(query) : fallbackHref;
+  } catch {
+    return fallbackHref;
+  }
+}
+
+export function clearTableReturnTo(tableKey: string, scopeId?: string): void {
+  if (globalThis.window === undefined) {
+    return;
+  }
+
+  try {
+    globalThis.sessionStorage.removeItem(storageKey(tableKey, scopeId));
+  } catch {
+    // ignore
+  }
+}

--- a/project-structure.md
+++ b/project-structure.md
@@ -168,9 +168,11 @@ Action rules:
 
 - Drive search, filters, and pagination from URL `searchParams` (parse in a server page or shared util, e.g. `parsePlatformAdminListParams`, `parseFormsListParams`).
 - Use one paged API endpoint with scope/tenant filters rather than two parallel lists sharing the same `page` param.
-- Client tables update the URL via `useListUrlState` (debounced search, `Select` filters, `PagedTableFooter` / `PagedListFooter`) and receive unresolved promises from the server page wrapped in `Suspense`.
-- Shared helpers live in `lib/list-page/` (`parse-paged-search-params`, `use-list-url-state`).
-- List-table **chrome** (surface, empty state, header/row/cell class helpers, search input, **toolbar**, paged footer) lives in `components/table/`. `DataTableToolbar` is one row: filters scroll, actions stay pinned. Keep the ShadCN primitive (`Table`, `TableRow`, …) in `components/ui/table.tsx`.
+- Client tables update the URL via `useListUrlState` (single debounced field) or `useTableFiltersUrlState` (2+ debounced fields, one coalesced commit — see below), plus `Select` filters calling `updateUrl` directly, `PagedTableFooter` / `PagedListFooter`, and receive unresolved promises from the server page wrapped in `Suspense`.
+- Shared helpers live in `lib/list-page/` (`parse-paged-search-params`, `use-list-url-state`, `table-return-to`).
+- List-table **chrome** (surface, empty state, header/row/cell class helpers, search input, **toolbar**, paged footer, **`BackToTableButton`**, **`useTableFiltersUrlState`**) lives in `components/table/`. `DataTableToolbar` is one row: filters scroll, actions stay pinned. Keep the ShadCN primitive (`Table`, `TableRow`, …) in `components/ui/table.tsx`.
+- **Two or more debounced filter fields on the same table** must share one `useTableFiltersUrlState(keys)` call (`components/table`), not one `useListUrlState`/`useUrlSearchParamsUpdater` per field — independent debounced writers race (each rebuilds the URL from its own stale `searchParams` snapshot) and can silently drop each other's change. `keys` must be a module-level constant array.
+- **Detail → list back navigation** restores the list's paging/filters via session-scoped storage, not a URL param — see AGENTS.md "Detail → list back navigation" and `lib/list-page/table-return-to`.
 - Hub list URL key is **`search`**; map it to the API query field (`query`, `filter`, etc.) inside the slice parser. Do not introduce a parallel `q` param.
 - Reference: `settings/organization/users/page.tsx`, `admin/platform-admins/page.tsx`, `forms/page.tsx`, `features/forms/list-forms/`, and `features/data-lists/view-lists/`.
 
@@ -201,9 +203,10 @@ Hub management grids follow the same URL + chrome pattern as forms/users. Parsin
 | Surface | Slice | Hub URL | API |
 | --- | --- | --- | --- |
 | List | `features/data-lists/view-lists/` | `search`, `hasLocale` (single BCP-47 code), `page`, `pageSize`, `action=create` | `GET /data-lists` (`search`, `hasLocale`) |
-| Detail items | `features/data-lists/view-list-details/` | `search`, `page`, `pageSize`, `from`, `action=replace` | `GET /data-lists/{id}/items` (`query`) + `GET /data-lists/{id}?includeItems=false` |
+| Detail items | `features/data-lists/view-list-details/` | `search`, `page`, `pageSize`, `action=replace` | `GET /data-lists/{id}/items` (`query`) + `GET /data-lists/{id}?includeItems=false` |
 
-- List → detail preserves filters with `from` (serialized list query). Back uses `parseDataListsReturnHref` and ignores unknown keys.
+- List → detail "Back to Data Lists" restores filters/paging via `BackToTableButton` (`tableKey: "data-lists"`), not a URL param — see AGENTS.md "Detail → list back navigation".
+- Replacing items resets the items grid's `page`/`search` (stale values from before the replace would otherwise point past the new item set).
 - Items are **GET-only** in Hub. Authors edit via file replace (`replace-items`), not per-item CRUD.
 - Stream the paged promise from the App Router page into the client table (`use()` + `Suspense`). Footer lives **inside** `DataTableSurface`.
 - Creator Translations CSV wrap lives in `lib/survey-features/data-lists/` (compound keys + SurveyJS CSV merge). Hub actions stay in `features/data-lists/translations/` (`uploadTranslationsCsvAction`, `getDataListTranslationCatalogAction`).

--- a/scripts/upgrade-surveyjs.mjs
+++ b/scripts/upgrade-surveyjs.mjs
@@ -6,16 +6,9 @@
  *   - With version (e.g. 2.5.9): pnpm add survey-*@2.5.9
  *   - Without: pnpm add survey-*@latest
  *
- * Security (for static analysis / learning):
- * - spawnSync(..., { shell: false }) avoids command injection: args are passed
- *   as an array, so the shell never interprets user input. See CWE-78, OWASP
- *   "Command Injection".
- * - Version spec is validated (semver or "latest") so we never pass
- *   shell metacharacters into the child process.
- * - Version parsing/validation uses the semver package (no custom regexes),
- *   avoiding ReDoS (S5852) and matching npm semver behavior.
- * - Executable is resolved to a fixed path (hub node_modules/.bin/pnpm) so
- *   we do not rely on PATH, which may contain user-writable directories.
+ * CLI version is untrusted. It is allowlisted (`latest` or semver.valid)
+ * before any child-process argv is built. spawnSync uses an args array
+ * and shell: false (CWE-78).
  */
 
 import { spawnSync } from "node:child_process";
@@ -27,29 +20,70 @@ import semver from "semver";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Survey packages to upgrade
-const SURVEY_PACKAGES = [
+const SURVEY_PACKAGES = Object.freeze([
   "survey-core",
   "survey-creator-core",
   "survey-creator-react",
   "survey-react-ui",
   "survey-analytics",
-];
+]);
 
-// Extract a valid semver string from a range or tag (e.g. "^2.5.9" or "v2.5.9" -> "2.5.9"). Uses semver package to avoid ReDoS.
+const PACKAGE_NAME_PATTERN = /^survey-[a-z0-9-]+$/;
+const PNPM_BIN_NAMES = new Set(["pnpm", "pnpm.cmd"]);
+
 function parseVersion(versionStr) {
   if (!versionStr || typeof versionStr !== "string") return null;
   const coerced = semver.coerce(versionStr);
   return coerced ? semver.valid(coerced) : null;
 }
 
-// Allow only "latest" or a valid semver string; otherwise default to "latest".
+/** Only `latest` or a canonical semver string. Rejects everything else. */
 function toValidSpec(versionArg) {
-  const raw = versionArg ? parseVersion(versionArg) || versionArg : "latest";
-  if (raw === "latest") {
-    return raw;
+  if (versionArg == null || versionArg === "") {
+    return "latest";
   }
-  return semver.valid(raw) ? raw : "latest";
+  if (typeof versionArg !== "string") {
+    throw new Error("Version must be a string.");
+  }
+  if (versionArg === "latest") {
+    return "latest";
+  }
+  // Do not coerce: "2.5.9; rm" would become "2.5.9". Exact semver only.
+  const parsed = semver.valid(versionArg);
+  if (!parsed) {
+    throw new Error(
+      `Invalid version '${versionArg}'. Use a semver version (e.g. 2.5.9) or omit for latest.`,
+    );
+  }
+  return parsed;
+}
+
+function assertSafePackageNames(packages) {
+  for (const pkg of packages) {
+    if (!PACKAGE_NAME_PATTERN.test(pkg) || !SURVEY_PACKAGES.includes(pkg)) {
+      throw new Error(`Refusing to install unexpected package '${pkg}'.`);
+    }
+  }
+}
+
+function buildPnpmAddArgs(spec) {
+  assertSafePackageNames(SURVEY_PACKAGES);
+  if (spec !== "latest" && !semver.valid(spec)) {
+    throw new Error(`Refusing to pass unvalidated specifier '${spec}'.`);
+  }
+  return ["add", ...SURVEY_PACKAGES.map((pkg) => `${pkg}@${spec}`)];
+}
+
+function assertSafePnpmPath(pnpmPath) {
+  const resolved = path.resolve(pnpmPath);
+  const base = path.basename(resolved);
+  if (!PNPM_BIN_NAMES.has(base)) {
+    throw new Error(`Refusing to execute unexpected binary '${base}'.`);
+  }
+  if (!existsSync(resolved)) {
+    throw new Error(`pnpm not found at ${resolved}.`);
+  }
+  return resolved;
 }
 
 function getInstalledVersion(hubDir) {
@@ -63,17 +97,14 @@ function getInstalledVersion(hubDir) {
   }
 }
 
-// Fixed path to pnpm so we do not rely on PATH (may contain user-writable dirs).
-// Try: hub node_modules, parent node_modules, then same directory as Node (corepack/global).
 function getPnpmPath(hubDir) {
   const name = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-  const inHub = path.join(hubDir, "node_modules", ".bin", name);
-  if (existsSync(inHub)) return inHub;
-  const inParent = path.join(hubDir, "..", "node_modules", ".bin", name);
-  if (existsSync(inParent)) return inParent;
-  const nextToNode = path.join(path.dirname(process.execPath), name);
-  if (existsSync(nextToNode)) return nextToNode;
-  return nextToNode;
+  const candidates = [
+    path.join(hubDir, "node_modules", ".bin", name),
+    path.join(hubDir, "..", "node_modules", ".bin", name),
+    path.join(path.dirname(process.execPath), name),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[2];
 }
 
 console.log("🚀 Upgrading Survey.js packages...\n");
@@ -84,23 +115,11 @@ const hubDir = existsSync(path.join(PROJECT_ROOT, "package.json"))
   : path.resolve(__dirname, "..");
 process.chdir(hubDir);
 
-const versionArg = process.argv[2]?.trim();
-const spec = toValidSpec(versionArg);
-// Build args as array (no shell) so static tools don't flag command injection
-const args = ["add", ...SURVEY_PACKAGES.map((p) => `${p}@${spec}`)];
-
-const pnpmPath = getPnpmPath(hubDir);
-if (!existsSync(pnpmPath)) {
-  console.error(
-    `\n❌ pnpm not found. Tried: hub/node_modules/.bin, parent node_modules/.bin, and Node bin dir (${path.dirname(
-      process.execPath,
-    )}).\n` +
-      `  Run "pnpm install" from the hub directory, or enable corepack: corepack enable\n`,
-  );
-  process.exit(1);
-}
-
 try {
+  const spec = toValidSpec(process.argv[2]?.trim());
+  const args = buildPnpmAddArgs(spec);
+  const pnpmPath = assertSafePnpmPath(getPnpmPath(hubDir));
+
   console.log(`📦 Packages: ${SURVEY_PACKAGES.join(", ")}`);
   console.log(`📌 Specifier: ${spec}\n`);
   console.log(`⚡ Running: pnpm ${args.join(" ")}\n`);
@@ -109,9 +128,9 @@ try {
     stdio: "inherit",
     cwd: hubDir,
     shell: false,
+    windowsHide: true,
   });
 
-  // status is null when the process was killed by a signal (e.g. SIGINT)
   if (result.status !== 0 || result.signal) {
     let msg;
     if (result.error) {


### PR DESCRIPTION
## Summary
- Items grid on detail page: paged/searchable via  `GET /data-lists/{id}/items`. Metadata fetched  with `includeItems=false`. Downloads go through   the export API.
  - Fix: replacing items while paged/searched no  longer shows a false empty state — page/search  reset on replace.
  - "Back to Data Lists" now uses session storage, not a URL `from` param. Cleaner URLs, correctly scoped per tab.
  - Extracted generic, reusable primitives:
    - `lib/list-page/table-return-to.ts` +  `components/table/back-to-table-button.tsx` - keyed back-navigation, always re-validated  through the list's own parser.
    - `components/table/use-table-filters-url-state.ts` - debounced multi-filter URL state, one  coalesced commit (fixes a real race: independent debounced filters can drop each other's change).
  - `AGENTS.md` / `project-structure.md` updated with both patterns for future list/detail  features.

  ## Test plan

  - [x] Replace items while on page 2+ / with  active search — lands on page 1, items show
  - [x] Back to Data Lists restores filters/paging
  - [ ] New tab to a detail link — Back falls back  to bare list, no cross-tab state
  - [ ] Type search + locale filter quickly - both land in URL
  - [ ] Download CSV/JSON from detail page
  - [x] New + existing unit tests, full suite green (592/592)
  
<img width="1160" height="677" alt="image" src="https://github.com/user-attachments/assets/6324fb7c-1935-4d0a-8064-810b66b73682" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated data-list item loading with URL-backed search and pagination.
  * Added coordinated filtering for multiple table fields.
  * Added reliable detail-to-list navigation that restores filters and paging.
  * Added CSV and JSON export options for data-list items.
  * Added clearer empty-state and table footer support.

* **Bug Fixes**
  * Improved validation of restored list state and safely handled invalid or unavailable saved navigation data.
  * Replacing data-list items now resets stale search and pagination settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->