### PR TITLE
chore: tell endatix-infra which version was released

### DIFF
--- a/.github/workflows/notify-infra.yml
+++ b/.github/workflows/notify-infra.yml
@@ -6,10 +6,9 @@
 # environments track this component and commits; ArgoCD deploys from there.
 #
 # It reports a fact and makes no decisions. Whether a given version should reach a given
-# cluster — what counts as newer, whether hotfix-line builds are wanted, which environment
-# tracks which channel — is decided in endatix-infra, the repo that owns the desired
-# state. That is why prereleases are NOT filtered here: canaries are exactly what a CI
-# environment wants, and it is not this repo's business which environments exist.
+# cluster is decided in endatix-infra, the repo that owns the desired state. That is why
+# prereleases are NOT filtered here: canaries are exactly what a CI environment wants, and
+# it is not this repo's business which environments exist.
 #
 # Fires for every published release: canaries from main, hotfix builds, and stable
 # releases at the moment their draft is published.
@@ -48,15 +47,13 @@ jobs:
           recursive: true
 
       # A DIFFERENT scope from the release pipeline's token, which is deliberately limited
-      # to this repository. This one reaches into endatix-infra and nothing else, and asks
-      # for the single permission the call below needs. create-github-app-token can only
-      # narrow what the App was granted, never widen it, so if the App does not hold
-      # Actions write on endatix-infra this step fails loudly here rather than producing a
-      # token that 403s later.
+      # to this repository. This one reaches into endatix-infra and nothing else.
       #
-      # The alternative needs only Contents write: POST /repos/endatix/endatix-infra/
-      # dispatches with event_type=chart-release and the same two values as client_payload
-      # — chart-bump.yml accepts that trigger too.
+      # Contents write is what a repository_dispatch needs, and it is what the App already
+      # holds — so this needs no permission change. A workflow_dispatch would have been
+      # tidier (typed inputs, visible in the Actions UI) but requires Actions write, which
+      # the App does not have; create-github-app-token can only narrow what the App was
+      # granted, never widen it.
       - name: 🔑 Endatix Automations APP token (scoped to endatix-infra)
         id: app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
@@ -65,17 +62,17 @@ jobs:
           private-key: ${{ env.ENDATIX_PROJECT_AUTOMATIONS_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: endatix-infra
-          permission-actions: write
+          permission-contents: write
 
       - name: 🚀 Trigger chart-bump
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          # The chart-bump script strips a leading v and rejects anything that is not
-          # plain semver, so the tag is passed through as-is.
+          # chart-bump strips a leading v, so the tag goes through as-is. Built with jq
+          # rather than string-interpolated so the tag cannot break out of the JSON body.
           VERSION: ${{ github.event.release.tag_name }}
+          OWNER: ${{ github.repository_owner }}
         run: |
-          gh workflow run chart-bump.yml \
-            --repo ${{ github.repository_owner }}/endatix-infra \
-            --field service=endatix-hub \
-            --field version="$VERSION"
+          jq -nc --arg v "$VERSION" \
+            '{event_type: "chart-release", client_payload: {service: "endatix-hub", version: $v}}' \
+            | gh api --method POST "/repos/${OWNER}/endatix-infra/dispatches" --input -
           echo "Asked endatix-infra to pin endatix-hub $VERSION" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/notify-infra.yml
+++ b/.github/workflows/notify-infra.yml
@@ -1,0 +1,81 @@
+# Tell endatix-infra which version was just released.
+#
+# scripts/release-publish.sh pushes the Helm chart at the release version, so by the time
+# a release is published, ghcr.io/endatix/charts/endatix-hub:<version> exists. This workflow
+# hands that version to endatix-infra, which pins it into the umbrella chart of whichever
+# environments track this component and commits; ArgoCD deploys from there.
+#
+# It reports a fact and makes no decisions. Whether a given version should reach a given
+# cluster — what counts as newer, whether hotfix-line builds are wanted, which environment
+# tracks which channel — is decided in endatix-infra, the repo that owns the desired
+# state. That is why prereleases are NOT filtered here: canaries are exactly what a CI
+# environment wants, and it is not this repo's business which environments exist.
+#
+# Fires for every published release: canaries from main, hotfix builds, and stable
+# releases at the moment their draft is published.
+name: Notify infra of release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # OIDC for Infisical
+
+# One notification per tag, and never cancel: a dropped notification leaves the
+# environment silently a version behind until the next release happens to fix it.
+concurrency:
+  group: notify-infra-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    name: Pin hub ${{ github.event.release.tag_name }} in infra
+    runs-on: ubuntu-latest
+    # Matches the release pipeline's environment so the Infisical machine identity
+    # authenticates on the same OIDC subject.
+    environment:
+      name: Production
+    steps:
+      - name: 🔐 Fetch secrets (Infisical, OIDC)
+        uses: Infisical/secrets-action@03d3fa38607956c493f53c6633f94006a13c47ae # v1.0.7
+        with:
+          method: "oidc"
+          env-slug: "prod"
+          project-slug: "github-actions-for-endatix"
+          identity-id: "403af1ed-7046-480f-a100-c4482b8a89ac"
+          recursive: true
+
+      # A DIFFERENT scope from the release pipeline's token, which is deliberately limited
+      # to this repository. This one reaches into endatix-infra and nothing else, and asks
+      # for the single permission the call below needs. create-github-app-token can only
+      # narrow what the App was granted, never widen it, so if the App does not hold
+      # Actions write on endatix-infra this step fails loudly here rather than producing a
+      # token that 403s later.
+      #
+      # The alternative needs only Contents write: POST /repos/endatix/endatix-infra/
+      # dispatches with event_type=chart-release and the same two values as client_payload
+      # — chart-bump.yml accepts that trigger too.
+      - name: 🔑 Endatix Automations APP token (scoped to endatix-infra)
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ env.ENDATIX_PROJECT_AUTOMATIONS_APP_ID }}
+          private-key: ${{ env.ENDATIX_PROJECT_AUTOMATIONS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: endatix-infra
+          permission-actions: write
+
+      - name: 🚀 Trigger chart-bump
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The chart-bump script strips a leading v and rejects anything that is not
+          # plain semver, so the tag is passed through as-is.
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          gh workflow run chart-bump.yml \
+            --repo ${{ github.repository_owner }}/endatix-infra \
+            --field service=hub \
+            --field version="$VERSION"
+          echo "Asked endatix-infra to pin hub $VERSION" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/notify-infra.yml
+++ b/.github/workflows/notify-infra.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   notify:
-    name: Pin hub ${{ github.event.release.tag_name }} in infra
+    name: Pin endatix-hub ${{ github.event.release.tag_name }} in infra
     runs-on: ubuntu-latest
     # Matches the release pipeline's environment so the Infisical machine identity
     # authenticates on the same OIDC subject.
@@ -76,6 +76,6 @@ jobs:
         run: |
           gh workflow run chart-bump.yml \
             --repo ${{ github.repository_owner }}/endatix-infra \
-            --field service=hub \
+            --field service=endatix-hub \
             --field version="$VERSION"
-          echo "Asked endatix-infra to pin hub $VERSION" >> "$GITHUB_STEP_SUMMARY"
+          echo "Asked endatix-infra to pin endatix-hub $VERSION" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds one workflow so the Kubernetes environments stop being pinned by hand.

## Shape

On `release: [published]`, it sends a `chart-release` repository dispatch to `endatix-infra` carrying the chart name and `github.event.release.tag_name`. Infra's `chart-bump` pins that version into the environment's umbrella `Chart.yaml` and commits; ArgoCD deploys it.

`scripts/release-publish.sh` already pushes the Helm chart at the release version, so the matching chart exists by the time a release is published. Nothing else in this repo changes.

Fires for canaries from `main`, hotfix builds, and stable releases when their draft is published. No filtering here — which environments exist and what each tracks is decided in `endatix-infra`.

Pairs with endatix/endatix-infra#17, merged.

## Why `repository_dispatch` and not `workflow_dispatch`

`workflow_dispatch` would be tidier — typed inputs, visible in the Actions UI. It needs `actions: write`, and the Endatix Automations App holds `contents`, `issues`, `metadata`, `organization_projects` and `packages` — no `actions` permission at all, so it would 403. `create-github-app-token` can only narrow what the App was granted, never widen it.

`repository_dispatch` needs only `contents: write`, which the App already has, so this works with no permission change. Both triggers are accepted on the infra side; the receiving path has been exercised through this one.

The token here is scoped to `endatix-infra` alone, separate from the release pipeline's token which is scoped to this repository.
