### PR TITLE
fix(h865): move locale filters to toolbar to stop click loops

### DIFF
--- a/app/(main)/data-lists/page.tsx
+++ b/app/(main)/data-lists/page.tsx
@@ -5,11 +5,9 @@ import {
   DataListsPageHeader,
 } from "@/features/data-lists/view-lists/ui/data-lists-page";
 import { DataListsListToolbar } from "@/features/data-lists/view-lists/ui/data-lists-list-toolbar";
+import { DataListsLocaleFilter } from "@/features/data-lists/view-lists/ui/data-lists-locale-filter";
 import { DataListsTableSkeleton } from "@/features/data-lists/view-lists/ui/data-lists-table-skeleton";
-import {
-  getDataListLocales,
-  getDataListsPage,
-} from "@/features/data-lists/view-lists/get-data-lists.server";
+import { getDataListsPage } from "@/features/data-lists/view-lists/get-data-lists.server";
 import {
   firstString,
   parseDataListsListParams,
@@ -53,16 +51,19 @@ export default async function DataListsRoutePage({
     modifiedFrom: firstString(raw.modifiedFrom),
     modifiedTo: firstString(raw.modifiedTo),
   });
-  // Start list fetch without blocking the toolbar; locales resolve for the
-  // filter so FacetedFilter is not remounted via Suspense on every hasLocale nav.
   const dataListsPromise = getDataListsPage(listRequest);
-  const locales = await getDataListLocales();
   const openCreateOnLoad = hasValue(raw.action, "create");
 
   return (
     <>
       <DataListsPageHeader />
-      <DataListsListToolbar locales={locales} />
+      <DataListsListToolbar
+        localeFilter={
+          <Suspense fallback={null}>
+            <DataListsLocaleFilter />
+          </Suspense>
+        }
+      />
       <Suspense fallback={<DataListsTableSkeleton />}>
         <DataListsPage
           dataListsPromise={dataListsPromise}

--- a/app/(main)/data-lists/page.tsx
+++ b/app/(main)/data-lists/page.tsx
@@ -53,14 +53,16 @@ export default async function DataListsRoutePage({
     modifiedFrom: firstString(raw.modifiedFrom),
     modifiedTo: firstString(raw.modifiedTo),
   });
+  // Start list fetch without blocking the toolbar; locales resolve for the
+  // filter so FacetedFilter is not remounted via Suspense on every hasLocale nav.
   const dataListsPromise = getDataListsPage(listRequest);
-  const localesPromise = getDataListLocales();
+  const locales = await getDataListLocales();
   const openCreateOnLoad = hasValue(raw.action, "create");
 
   return (
     <>
       <DataListsPageHeader />
-      <DataListsListToolbar localesPromise={localesPromise} />
+      <DataListsListToolbar locales={locales} />
       <Suspense fallback={<DataListsTableSkeleton />}>
         <DataListsPage
           dataListsPromise={dataListsPromise}

--- a/app/(main)/data-lists/page.tsx
+++ b/app/(main)/data-lists/page.tsx
@@ -60,9 +60,7 @@ export default async function DataListsRoutePage({
   return (
     <>
       <DataListsPageHeader />
-      <Suspense fallback={<DataListsListToolbar />}>
-        <DataListsToolbar localesPromise={localesPromise} />
-      </Suspense>
+      <DataListsListToolbar localesPromise={localesPromise} />
       <Suspense fallback={<DataListsTableSkeleton />}>
         <DataListsPage
           dataListsPromise={dataListsPromise}
@@ -71,15 +69,4 @@ export default async function DataListsRoutePage({
       </Suspense>
     </>
   );
-}
-
-interface DataListsToolbarProps {
-  localesPromise: Promise<string[]>;
-}
-
-async function DataListsToolbar({
-  localesPromise,
-}: Readonly<DataListsToolbarProps>) {
-  const locales = await localesPromise;
-  return <DataListsListToolbar locales={locales} />;
 }

--- a/components/table/__tests__/data-table-chrome.test.ts
+++ b/components/table/__tests__/data-table-chrome.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DATA_TABLE_COLUMN_LABEL_CLASS_NAME,
   DATA_TABLE_ELEMENT_CLASS_NAME,
+  DATA_TABLE_SHRINK_WRAP_CLASS_NAME,
   dataTableBodyCellClassName,
   dataTableBodyRowClassName,
   dataTableColumnLabelClassName,
@@ -87,5 +88,6 @@ describe("data-table-chrome", () => {
   it("fills the surface width without collapsing compact columns", () => {
     expect(DATA_TABLE_ELEMENT_CLASS_NAME).toContain("min-w-full");
     expect(DATA_TABLE_ELEMENT_CLASS_NAME).not.toContain("table-fixed");
+    expect(DATA_TABLE_SHRINK_WRAP_CLASS_NAME).toBe("w-px");
   });
 });

--- a/components/table/__tests__/reset-filters-button.test.tsx
+++ b/components/table/__tests__/reset-filters-button.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ResetFiltersButton } from "../reset-filters-button";
+
+describe("ResetFiltersButton", () => {
+  it("exposes an accessible name and calls onClick", () => {
+    const onClick = vi.fn();
+    render(<ResetFiltersButton onClick={onClick} />);
+
+    const button = screen.getByRole("button", { name: "Reset Filters" });
+    fireEvent.click(button);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the button and does not fire onClick when disabled", () => {
+    const onClick = vi.fn();
+    render(<ResetFiltersButton onClick={onClick} disabled />);
+
+    const button = screen.getByRole("button", {
+      name: "Reset Filters",
+    }) as HTMLButtonElement;
+
+    expect(button.disabled).toBe(true);
+
+    fireEvent.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/components/table/data-table-chrome.ts
+++ b/components/table/data-table-chrome.ts
@@ -8,6 +8,9 @@ export const DATA_TABLE_COLUMN_LABEL_CLASS_NAME =
 export const DATA_TABLE_ELEMENT_CLASS_NAME =
   "min-w-full border-separate border-spacing-0";
 
+/** Shrink a column to its content (`w-px`); pair with `min-w-*` when a floor is needed. */
+export const DATA_TABLE_SHRINK_WRAP_CLASS_NAME = "w-px";
+
 export function dataTableColumnLabelClassName(className?: string): string {
   return cn(DATA_TABLE_COLUMN_LABEL_CLASS_NAME, className);
 }

--- a/components/table/index.ts
+++ b/components/table/index.ts
@@ -17,6 +17,7 @@ export {
 export {
   DATA_TABLE_COLUMN_LABEL_CLASS_NAME,
   DATA_TABLE_ELEMENT_CLASS_NAME,
+  DATA_TABLE_SHRINK_WRAP_CLASS_NAME,
   dataTableBodyCellClassName,
   dataTableBodyRowClassName,
   dataTableColumnLabelClassName,

--- a/components/table/index.ts
+++ b/components/table/index.ts
@@ -34,6 +34,7 @@ export {
   PagedTableFooter,
   type PagedTableFooterProps,
 } from "./paged-table-footer";
+export { ResetFiltersButton } from "./reset-filters-button";
 export { TableEmptyRow } from "./table-empty-row";
 export { TableSearchInput } from "./table-search-input";
 export {

--- a/components/table/reset-filters-button.tsx
+++ b/components/table/reset-filters-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { X } from "lucide-react";
+
+type ResetFiltersButtonProps = {
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+};
+
+/**
+ * "Reset Filters" action for a `DataTableToolbar`. Pair with the caller's own
+ * active-filters check (e.g. only render when a filter is set) and pass a
+ * handler that clears search/filter URL params and resets `page`. Sized to
+ * match `FacetedFilter`'s trigger (`size="sm"`) and collapses to icon-only
+ * below `sm` to save toolbar space, with the label kept for screen readers.
+ */
+export function ResetFiltersButton({
+  onClick,
+  disabled = false,
+  className,
+}: Readonly<ResetFiltersButtonProps>) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label="Reset Filters"
+      className={cn("shrink-0 px-2 lg:px-3", className)}
+    >
+      <X />
+      <span className="sr-only sm:not-sr-only">Reset Filters</span>
+    </Button>
+  );
+}

--- a/features/data-lists/view-list-details/ui/data-list-details-page.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-details-page.tsx
@@ -8,6 +8,7 @@ import {
   FacetedFilter,
   DataTableToolbar,
   PagedTableFooter,
+  ResetFiltersButton,
   TableSearchInput,
   type FacetedFilterOption,
 } from "@/components/table";
@@ -39,7 +40,7 @@ import {
   parseHasLocaleFilterSet,
   serializeHasLocaleFilter,
 } from "../../view-lists/utils";
-import { ChevronDown, Download, PencilLine, Upload, X } from "lucide-react";
+import { ChevronDown, Download, PencilLine, Upload } from "lucide-react";
 import type { Route } from "next";
 import {
   Suspense,
@@ -419,8 +420,7 @@ function DataListItemsSection({
               />
             ) : null}
             {search.trim() || selectedLocales.size > 0 ? (
-              <Button
-                variant="ghost"
+              <ResetFiltersButton
                 onClick={() => {
                   setSearch("");
                   updateUrl({
@@ -429,11 +429,7 @@ function DataListItemsSection({
                     page: "1",
                   });
                 }}
-                className="shrink-0 px-2 lg:px-3"
-              >
-                Reset Filters
-                <X />
-              </Button>
+              />
             ) : null}
           </>
         }

--- a/features/data-lists/view-list-details/ui/data-list-details-page.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-details-page.tsx
@@ -6,6 +6,7 @@ import {
   CellDate,
   createPagedTableFooterProps,
   FacetedFilter,
+  DataTableToolbar,
   PagedTableFooter,
   TableSearchInput,
   type FacetedFilterOption,
@@ -393,47 +394,50 @@ function DataListItemsSection({
   }, [availableLocales, defaultLocale]);
 
   return (
-    <div className="space-y-3">
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
-        <TableSearchInput
-          value={search}
-          onChange={setSearch}
-          placeholder="Search items by value or label"
-          ariaLabel="Search data list items"
-        />
-        <div className="flex max-w-full min-w-0 items-center gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          {localeOptions.length > 0 ? (
-            <FacetedFilter
-              title="Locale"
-              options={localeOptions}
-              selectedValues={selectedLocales}
-              onValueChange={(values) => {
-                updateUrl({
-                  hasLocale: serializeHasLocaleFilter(values) ?? null,
-                  page: '1',
-                });
-              }}
+    <div className="flex flex-col gap-3">
+      <DataTableToolbar
+        filters={
+          <>
+            <TableSearchInput
+              value={search}
+              onChange={setSearch}
+              placeholder="Search items by value or label"
+              ariaLabel="Search data list items"
+              className="min-w-[12rem] flex-none lg:flex-1"
             />
-          ) : null}
-          {search.trim() || selectedLocales.size > 0 ? (
-            <Button
-              variant="ghost"
-              onClick={() => {
-                setSearch('');
-                updateUrl({
-                  search: null,
-                  hasLocale: null,
-                  page: '1',
-                });
-              }}
-              className="shrink-0 px-2 lg:px-3"
-            >
-              Reset Filters
-              <X className="ml-2 h-4 w-4" />
-            </Button>
-          ) : null}
-        </div>
-      </div>
+            {localeOptions.length > 0 ? (
+              <FacetedFilter
+                title="Locale"
+                options={localeOptions}
+                selectedValues={selectedLocales}
+                onValueChange={(values) => {
+                  updateUrl({
+                    hasLocale: serializeHasLocaleFilter(values) ?? null,
+                    page: '1',
+                  });
+                }}
+              />
+            ) : null}
+            {search.trim() || selectedLocales.size > 0 ? (
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  setSearch('');
+                  updateUrl({
+                    search: null,
+                    hasLocale: null,
+                    page: '1',
+                  });
+                }}
+                className="shrink-0 px-2 lg:px-3"
+              >
+                Reset Filters
+                <X />
+              </Button>
+            ) : null}
+          </>
+        }
+      />
       <Suspense
         fallback={
           <DataListItemsTableSkeleton

--- a/features/data-lists/view-list-details/ui/data-list-details-page.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-details-page.tsx
@@ -413,7 +413,7 @@ function DataListItemsSection({
                 onValueChange={(values) => {
                   updateUrl({
                     hasLocale: serializeHasLocaleFilter(values) ?? null,
-                    page: '1',
+                    page: "1",
                   });
                 }}
               />
@@ -422,11 +422,11 @@ function DataListItemsSection({
               <Button
                 variant="ghost"
                 onClick={() => {
-                  setSearch('');
+                  setSearch("");
                   updateUrl({
                     search: null,
                     hasLocale: null,
-                    page: '1',
+                    page: "1",
                   });
                 }}
                 className="shrink-0 px-2 lg:px-3"
@@ -476,10 +476,14 @@ function DataListItemsPanel({
     defaultLocale,
     availableLocales,
   });
+  // A fresh `[...paged.items]` literal here is a new reference every render,
+  // which defeats internal row-model memoization and can cascade into a
+  // setState loop (see data-lists-page.tsx's tableData for the same fix).
+  const items = useMemo(() => [...paged.items], [paged.items]);
 
   return (
     <DataListItemsTable
-      items={[...paged.items]}
+      items={items}
       labelColumns={labelColumns}
       defaultLocale={defaultLocale}
       emptyMessage={

--- a/features/data-lists/view-list-details/ui/data-list-details-page.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-details-page.tsx
@@ -5,6 +5,7 @@ import {
   BackToTableButton,
   CellDate,
   createPagedTableFooterProps,
+  FacetedFilter,
   PagedTableFooter,
   TableSearchInput,
   type FacetedFilterOption,
@@ -37,7 +38,7 @@ import {
   parseHasLocaleFilterSet,
   serializeHasLocaleFilter,
 } from "../../view-lists/utils";
-import { ChevronDown, Download, PencilLine, Upload } from "lucide-react";
+import { ChevronDown, Download, PencilLine, Upload, X } from "lucide-react";
 import type { Route } from "next";
 import {
   Suspense,
@@ -393,12 +394,46 @@ function DataListItemsSection({
 
   return (
     <div className="space-y-3">
-      <TableSearchInput
-        value={search}
-        onChange={setSearch}
-        placeholder="Search items by value or label"
-        ariaLabel="Search data list items"
-      />
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+        <TableSearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Search items by value or label"
+          ariaLabel="Search data list items"
+        />
+        <div className="flex max-w-full min-w-0 items-center gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {localeOptions.length > 0 ? (
+            <FacetedFilter
+              title="Locale"
+              options={localeOptions}
+              selectedValues={selectedLocales}
+              onValueChange={(values) => {
+                updateUrl({
+                  hasLocale: serializeHasLocaleFilter(values) ?? null,
+                  page: '1',
+                });
+              }}
+            />
+          ) : null}
+          {search.trim() || selectedLocales.size > 0 ? (
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setSearch('');
+                updateUrl({
+                  search: null,
+                  hasLocale: null,
+                  page: '1',
+                });
+              }}
+              className="shrink-0 px-2 lg:px-3"
+            >
+              Reset Filters
+              <X className="ml-2 h-4 w-4" />
+            </Button>
+          ) : null}
+        </div>
+      </div>
       <Suspense
         fallback={
           <DataListItemsTableSkeleton
@@ -410,14 +445,6 @@ function DataListItemsSection({
           itemsPromise={itemsPromise}
           availableLocales={availableLocales}
           defaultLocale={defaultLocale}
-          localeOptions={localeOptions}
-          selectedLocales={selectedLocales}
-          onLocaleFilterChange={(values) => {
-            updateUrl({
-              hasLocale: serializeHasLocaleFilter(values) ?? null,
-              page: "1",
-            });
-          }}
         />
       </Suspense>
     </div>
@@ -428,16 +455,10 @@ function DataListItemsPanel({
   itemsPromise,
   availableLocales,
   defaultLocale,
-  localeOptions,
-  selectedLocales,
-  onLocaleFilterChange,
 }: Readonly<{
   itemsPromise: Promise<DataListItemsPage>;
   availableLocales: string[];
   defaultLocale?: string;
-  localeOptions: FacetedFilterOption[];
-  selectedLocales: Set<string>;
-  onLocaleFilterChange: (values: Set<string>) => void;
 }>) {
   const paged = use(itemsPromise);
   const { updateUrl, searchParams } = useListUrlState();
@@ -457,9 +478,6 @@ function DataListItemsPanel({
       items={[...paged.items]}
       labelColumns={labelColumns}
       defaultLocale={defaultLocale}
-      localeOptions={localeOptions}
-      selectedLocales={selectedLocales}
-      onLocaleFilterChange={onLocaleFilterChange}
       emptyMessage={
         hasFilters
           ? "No items match the current filters."

--- a/features/data-lists/view-list-details/ui/data-list-items-table-skeleton.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-items-table-skeleton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  DATA_TABLE_ELEMENT_CLASS_NAME,
   DataTableSurface,
   dataTableBodyCellClassName,
   dataTableBodyRowClassName,
@@ -35,7 +36,7 @@ export function DataListItemsTableSkeleton({
   return (
     <DataTableSurface data-slot="data-list-items-table-skeleton">
       <div className="w-full overflow-x-auto">
-        <Table className="border-separate border-spacing-0">
+        <Table className={DATA_TABLE_ELEMENT_CLASS_NAME}>
           <TableHeader className="bg-surface-container-low">
             <TableRow className="border-0 hover:bg-transparent">
               {["Value", ...localeHeaders].map((title) => (

--- a/features/data-lists/view-list-details/ui/data-list-items-table.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-items-table.tsx
@@ -2,6 +2,7 @@
 
 import {
   DATA_TABLE_ELEMENT_CLASS_NAME,
+  DATA_TABLE_SHRINK_WRAP_CLASS_NAME,
   dataTableBodyCellClassName,
   dataTableBodyRowClassName,
   dataTableColumnLabelClassName,
@@ -56,8 +57,8 @@ function buildColumns(
         <span className="font-mono text-xs">{row.original.value}</span>
       ),
       meta: {
-        headerClassName: 'min-w-[8rem]',
-        cellClassName: 'min-w-[8rem]',
+        headerClassName: `${DATA_TABLE_SHRINK_WRAP_CLASS_NAME} min-w-[8rem]`,
+        cellClassName: `${DATA_TABLE_SHRINK_WRAP_CLASS_NAME} min-w-[8rem]`,
       },
     },
     ...labelColumns.map(

--- a/features/data-lists/view-list-details/ui/data-list-items-table.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-items-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { TruncatedId } from "@/components/common/truncated-id";
 import {
   DATA_TABLE_ELEMENT_CLASS_NAME,
   DATA_TABLE_SHRINK_WRAP_CLASS_NAME,
@@ -54,7 +55,7 @@ function buildColumns(
         <span className={dataTableColumnLabelClassName()}>Value</span>
       ),
       cell: ({ row }) => (
-        <span className="font-mono text-xs">{row.original.value}</span>
+        <TruncatedId id={row.original.value} copyLabel="Copy value" />
       ),
       meta: {
         headerClassName: `${DATA_TABLE_SHRINK_WRAP_CLASS_NAME} min-w-[8rem]`,

--- a/features/data-lists/view-list-details/ui/data-list-items-table.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-items-table.tsx
@@ -1,16 +1,14 @@
-"use client";
+'use client';
 
 import {
   DATA_TABLE_ELEMENT_CLASS_NAME,
-  DataTableColumnHeader,
   dataTableBodyCellClassName,
   dataTableBodyRowClassName,
+  dataTableColumnLabelClassName,
   dataTableHeaderCellClassName,
   DataTableEmpty,
   DataTableSurface,
-  FacetedFilter,
-  type FacetedFilterOption,
-} from "@/components/table";
+} from '@/components/table';
 import {
   Table,
   TableBody,
@@ -18,18 +16,18 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/ui/table";
-import { formatLocaleLabel } from "@/features/data-lists/translations/locale-discovery";
-import type { DataListItem } from "@/lib/endatix-api/data-lists/types";
-import { resolveCatalogDefaultLabelText } from "@/lib/localization";
+} from '@/components/ui/table';
+import { formatLocaleLabel } from '@/features/data-lists/translations/locale-discovery';
+import type { DataListItem } from '@/lib/endatix-api/data-lists/types';
+import { resolveCatalogDefaultLabelText } from '@/lib/localization';
 import {
   flexRender,
   getCoreRowModel,
   useReactTable,
   type ColumnDef,
-} from "@tanstack/react-table";
-import { type ReactNode, useMemo } from "react";
-import "./table-types";
+} from '@tanstack/react-table';
+import { type ReactNode, useMemo } from 'react';
+import './table-types';
 
 type DataListItemsTableProps = {
   items: DataListItem[];
@@ -38,85 +36,54 @@ type DataListItemsTableProps = {
   defaultLocale?: string;
   emptyMessage?: string;
   footer?: ReactNode;
-  localeOptions?: FacetedFilterOption[];
-  selectedLocales?: Set<string>;
-  onLocaleFilterChange?: (values: Set<string>) => void;
 };
 
 type DataListItemRow = DataListItem & { rowId: string };
 
-function buildColumns(args: {
-  labelColumns: readonly string[];
-  defaultLocale: string | undefined;
-  localeOptions: FacetedFilterOption[];
-  selectedLocales: Set<string>;
-  onLocaleFilterChange: ((values: Set<string>) => void) | undefined;
-}): ColumnDef<DataListItemRow>[] {
-  const {
-    labelColumns,
-    defaultLocale,
-    localeOptions,
-    selectedLocales,
-    onLocaleFilterChange,
-  } = args;
-
+function buildColumns(
+  labelColumns: readonly string[],
+  defaultLocale: string | undefined,
+): ColumnDef<DataListItemRow>[] {
   return [
     {
-      id: "value",
-      accessorKey: "value",
+      id: 'value',
+      accessorKey: 'value',
       enableSorting: false,
-      header: ({ column }) => (
-        <DataTableColumnHeader
-          column={column}
-          title="Value"
-          facetFilterActive={selectedLocales.size > 0}
-          facetFilter={
-            onLocaleFilterChange && localeOptions.length > 0 ? (
-              <FacetedFilter
-                title="Locale"
-                options={localeOptions}
-                selectedValues={selectedLocales}
-                onValueChange={onLocaleFilterChange}
-              />
-            ) : undefined
-          }
-        />
+      header: () => (
+        <span className={dataTableColumnLabelClassName()}>Value</span>
       ),
       cell: ({ row }) => (
         <span className="font-mono text-xs">{row.original.value}</span>
       ),
       meta: {
-        headerClassName: "min-w-[8rem]",
-        cellClassName: "min-w-[8rem]",
+        headerClassName: 'min-w-[8rem]',
+        cellClassName: 'min-w-[8rem]',
       },
     },
     ...labelColumns.map(
       (columnKey): ColumnDef<DataListItemRow> => ({
         id: `label:${columnKey}`,
         enableSorting: false,
-        header: ({ column }) => (
-          <DataTableColumnHeader
-            column={column}
-            title={
-              columnKey === "default"
-                ? `Default (${defaultLocale ?? "—"})`
-                : formatLocaleLabel(columnKey)
-            }
-          />
+        header: () => (
+          <span className={dataTableColumnLabelClassName()}>
+            {columnKey === 'default'
+              ? `Default (${defaultLocale ?? '—'})`
+              : formatLocaleLabel(columnKey)}
+          </span>
         ),
         cell: ({ row }) => {
           const text =
-            columnKey === "default"
+            columnKey === 'default'
               ? resolveCatalogDefaultLabelText(
                   row.original.labels,
                   defaultLocale,
                 )
               : row.original.labels[columnKey];
-          return text?.trim() ? text : "—";
+          return text?.trim() ? text : '—';
         },
         meta: {
-          headerClassName: "min-w-[10rem]",
-          cellClassName: "min-w-[10rem]",
+          headerClassName: 'min-w-[10rem]',
+          cellClassName: 'min-w-[10rem]',
         },
       }),
     ),
@@ -127,11 +94,8 @@ export function DataListItemsTable({
   items,
   labelColumns,
   defaultLocale,
-  emptyMessage = "No items in this list.",
+  emptyMessage = 'No items in this list.',
   footer,
-  localeOptions = [],
-  selectedLocales = new Set(),
-  onLocaleFilterChange,
 }: Readonly<DataListItemsTableProps>) {
   const data = useMemo<DataListItemRow[]>(
     () =>
@@ -143,21 +107,8 @@ export function DataListItemsTable({
   );
 
   const columns = useMemo(
-    () =>
-      buildColumns({
-        labelColumns,
-        defaultLocale,
-        localeOptions,
-        selectedLocales,
-        onLocaleFilterChange,
-      }),
-    [
-      labelColumns,
-      defaultLocale,
-      localeOptions,
-      selectedLocales,
-      onLocaleFilterChange,
-    ],
+    () => buildColumns(labelColumns, defaultLocale),
+    [labelColumns, defaultLocale],
   );
 
   const table = useReactTable({
@@ -168,7 +119,7 @@ export function DataListItemsTable({
     enableColumnPinning: true,
     initialState: {
       columnPinning: {
-        left: ["value"],
+        left: ['value'],
       },
     },
   });
@@ -195,15 +146,14 @@ export function DataListItemsTable({
                 className="border-0 hover:bg-transparent"
               >
                 {headerGroup.headers.map((header) => {
-                  const isPinnedLeft = header.column.getIsPinned() === "left";
+                  const isPinnedLeft = header.column.getIsPinned() === 'left';
                   return (
                     <TableHead
                       key={header.id}
                       colSpan={header.colSpan}
                       className={dataTableHeaderCellClassName({
                         isPinnedLeft,
-                        className:
-                          header.column.columnDef.meta?.headerClassName,
+                        className: header.column.columnDef.meta?.headerClassName,
                       })}
                     >
                       {header.isPlaceholder
@@ -227,7 +177,7 @@ export function DataListItemsTable({
                   className={dataTableBodyRowClassName({ isEvenRow })}
                 >
                   {row.getVisibleCells().map((cell) => {
-                    const isPinnedLeft = cell.column.getIsPinned() === "left";
+                    const isPinnedLeft = cell.column.getIsPinned() === 'left';
                     return (
                       <TableCell
                         key={cell.id}

--- a/features/data-lists/view-list-details/ui/data-list-items-table.tsx
+++ b/features/data-lists/view-list-details/ui/data-list-items-table.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import {
   DATA_TABLE_ELEMENT_CLASS_NAME,
@@ -9,7 +9,7 @@ import {
   dataTableHeaderCellClassName,
   DataTableEmpty,
   DataTableSurface,
-} from '@/components/table';
+} from "@/components/table";
 import {
   Table,
   TableBody,
@@ -17,18 +17,18 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table';
-import { formatLocaleLabel } from '@/features/data-lists/translations/locale-discovery';
-import type { DataListItem } from '@/lib/endatix-api/data-lists/types';
-import { resolveCatalogDefaultLabelText } from '@/lib/localization';
+} from "@/components/ui/table";
+import { formatLocaleLabel } from "@/features/data-lists/translations/locale-discovery";
+import type { DataListItem } from "@/lib/endatix-api/data-lists/types";
+import { resolveCatalogDefaultLabelText } from "@/lib/localization";
 import {
   flexRender,
   getCoreRowModel,
   useReactTable,
   type ColumnDef,
-} from '@tanstack/react-table';
-import { type ReactNode, useMemo } from 'react';
-import './table-types';
+} from "@tanstack/react-table";
+import { type ReactNode, useMemo } from "react";
+import "./table-types";
 
 type DataListItemsTableProps = {
   items: DataListItem[];
@@ -47,8 +47,8 @@ function buildColumns(
 ): ColumnDef<DataListItemRow>[] {
   return [
     {
-      id: 'value',
-      accessorKey: 'value',
+      id: "value",
+      accessorKey: "value",
       enableSorting: false,
       header: () => (
         <span className={dataTableColumnLabelClassName()}>Value</span>
@@ -67,24 +67,24 @@ function buildColumns(
         enableSorting: false,
         header: () => (
           <span className={dataTableColumnLabelClassName()}>
-            {columnKey === 'default'
-              ? `Default (${defaultLocale ?? '—'})`
+            {columnKey === "default"
+              ? `Default (${defaultLocale ?? "—"})`
               : formatLocaleLabel(columnKey)}
           </span>
         ),
         cell: ({ row }) => {
           const text =
-            columnKey === 'default'
+            columnKey === "default"
               ? resolveCatalogDefaultLabelText(
                   row.original.labels,
                   defaultLocale,
                 )
               : row.original.labels[columnKey];
-          return text?.trim() ? text : '—';
+          return text?.trim() ? text : "—";
         },
         meta: {
-          headerClassName: 'min-w-[10rem]',
-          cellClassName: 'min-w-[10rem]',
+          headerClassName: "min-w-[10rem]",
+          cellClassName: "min-w-[10rem]",
         },
       }),
     ),
@@ -95,7 +95,7 @@ export function DataListItemsTable({
   items,
   labelColumns,
   defaultLocale,
-  emptyMessage = 'No items in this list.',
+  emptyMessage = "No items in this list.",
   footer,
 }: Readonly<DataListItemsTableProps>) {
   const data = useMemo<DataListItemRow[]>(
@@ -120,7 +120,7 @@ export function DataListItemsTable({
     enableColumnPinning: true,
     initialState: {
       columnPinning: {
-        left: ['value'],
+        left: ["value"],
       },
     },
   });
@@ -147,14 +147,15 @@ export function DataListItemsTable({
                 className="border-0 hover:bg-transparent"
               >
                 {headerGroup.headers.map((header) => {
-                  const isPinnedLeft = header.column.getIsPinned() === 'left';
+                  const isPinnedLeft = header.column.getIsPinned() === "left";
                   return (
                     <TableHead
                       key={header.id}
                       colSpan={header.colSpan}
                       className={dataTableHeaderCellClassName({
                         isPinnedLeft,
-                        className: header.column.columnDef.meta?.headerClassName,
+                        className:
+                          header.column.columnDef.meta?.headerClassName,
                       })}
                     >
                       {header.isPlaceholder
@@ -178,7 +179,7 @@ export function DataListItemsTable({
                   className={dataTableBodyRowClassName({ isEvenRow })}
                 >
                   {row.getVisibleCells().map((cell) => {
-                    const isPinnedLeft = cell.column.getIsPinned() === 'left';
+                    const isPinnedLeft = cell.column.getIsPinned() === "left";
                     return (
                       <TableCell
                         key={cell.id}

--- a/features/data-lists/view-lists/__tests__/catalog-locales.test.ts
+++ b/features/data-lists/view-lists/__tests__/catalog-locales.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { collectCatalogLocales } from "../catalog-locales";
+import type { DataList } from "@/lib/endatix-api/data-lists/types";
+
+function list(partial: Partial<DataList>): DataList {
+  return {
+    id: "1",
+    name: "List",
+    isActive: true,
+    createdAt: new Date("2024-01-01"),
+    itemsCount: 0,
+    ...partial,
+  };
+}
+
+describe("collectCatalogLocales", () => {
+  it("unions default and available locales, sorted, unique", () => {
+    const locales = collectCatalogLocales([
+      list({ defaultLocale: "es", availableLocales: ["en", "es"] }),
+      list({ defaultLocale: "de", availableLocales: ["en"] }),
+    ]);
+
+    expect(locales).toEqual(["de", "en", "es"]);
+  });
+
+  it("skips missing default and empty availableLocales", () => {
+    expect(
+      collectCatalogLocales([
+        list({ availableLocales: undefined }),
+        list({ defaultLocale: "", availableLocales: [] }),
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/features/data-lists/view-lists/__tests__/data-lists-list-toolbar.test.tsx
+++ b/features/data-lists/view-lists/__tests__/data-lists-list-toolbar.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DataListsListToolbar } from "../ui/data-lists-list-toolbar";
+
+const updateUrl = vi.fn();
+const setSearch = vi.fn();
+let mockSearchParams = new URLSearchParams();
+let mockSearch = "";
+
+vi.mock("@/lib/list-page/use-list-url-state", () => ({
+  useListUrlState: () => ({
+    search: mockSearch,
+    setSearch,
+    urlSearch: mockSearch,
+    updateUrl,
+    searchParams: mockSearchParams,
+  }),
+}));
+
+describe("DataListsListToolbar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    mockSearch = "";
+  });
+
+  it("shows Reset Filters when a filter is active and clears search, locale, and date bounds on click", () => {
+    mockSearchParams = new URLSearchParams(
+      "search=widgets&hasLocale=en&createdFrom=2024-01-01&page=2",
+    );
+    mockSearch = "widgets";
+
+    render(<DataListsListToolbar locales={["en", "es"]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /reset filters/i }));
+
+    expect(setSearch).toHaveBeenCalledWith("");
+    expect(updateUrl).toHaveBeenCalledWith({
+      search: null,
+      hasLocale: null,
+      createdFrom: null,
+      createdTo: null,
+      modifiedFrom: null,
+      modifiedTo: null,
+      page: "1",
+    });
+  });
+
+  it("hides Reset Filters when no filters are active", () => {
+    render(<DataListsListToolbar locales={["en", "es"]} />);
+
+    expect(screen.queryByRole("button", { name: /reset filters/i })).toBeNull();
+  });
+});

--- a/features/data-lists/view-lists/__tests__/data-lists-list-toolbar.test.tsx
+++ b/features/data-lists/view-lists/__tests__/data-lists-list-toolbar.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DataListsListToolbar } from "../ui/data-lists-list-toolbar";
+import {
+  DataListsListToolbar,
+  DataListsLocaleFacet,
+} from "../ui/data-lists-list-toolbar";
 
 const updateUrl = vi.fn();
 const setSearch = vi.fn();
@@ -30,7 +33,7 @@ describe("DataListsListToolbar", () => {
     );
     mockSearch = "widgets";
 
-    render(<DataListsListToolbar locales={["en", "es"]} />);
+    render(<DataListsListToolbar />);
 
     fireEvent.click(screen.getByRole("button", { name: /reset filters/i }));
 
@@ -47,8 +50,27 @@ describe("DataListsListToolbar", () => {
   });
 
   it("hides Reset Filters when no filters are active", () => {
-    render(<DataListsListToolbar locales={["en", "es"]} />);
+    render(<DataListsListToolbar />);
 
     expect(screen.queryByRole("button", { name: /reset filters/i })).toBeNull();
+  });
+});
+
+describe("DataListsLocaleFacet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("renders a Locale filter when locales are present", () => {
+    render(<DataListsLocaleFacet locales={["en", "es"]} />);
+
+    expect(screen.getByRole("button", { name: /locale/i })).toBeTruthy();
+  });
+
+  it("renders nothing when the catalog is empty", () => {
+    const { container } = render(<DataListsLocaleFacet locales={[]} />);
+
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/features/data-lists/view-lists/catalog-locales.ts
+++ b/features/data-lists/view-lists/catalog-locales.ts
@@ -1,0 +1,19 @@
+import type { DataList } from "@/lib/endatix-api/data-lists/types";
+
+/**
+ * Tenant cultures from list aggregates: DefaultLocale ∪ AvailableLocales.
+ * Same source as OSS `DataList` / `ListDistinctLocalesAsync` — not item `labels` keys.
+ */
+export function collectCatalogLocales(lists: readonly DataList[]): string[] {
+  const seen = new Set<string>();
+  for (const list of lists) {
+    if (list.defaultLocale) {
+      seen.add(list.defaultLocale);
+    }
+    for (const locale of list.availableLocales ?? []) {
+      seen.add(locale);
+    }
+  }
+
+  return [...seen].sort((left, right) => left.localeCompare(right));
+}

--- a/features/data-lists/view-lists/get-data-lists-for-creator.action.ts
+++ b/features/data-lists/view-lists/get-data-lists-for-creator.action.ts
@@ -2,36 +2,14 @@
 
 import type { DataList } from "@/lib/endatix-api/data-lists/types";
 import { Result } from "@/lib/result";
-import { getDataListsPage } from "./get-data-lists.server";
-
-const CREATOR_PAGE_SIZE = 100;
-const CREATOR_MAX_PAGES = 200;
+import { listAllDataLists } from "./get-data-lists.server";
 
 export type GetDataListsForCreatorResult = Result<DataList[]>;
 
-/**
- * Loads every data list for Creator dropdowns (paginates until exhausted).
- */
+/** Loads every data list for Creator dropdowns. */
 export async function getDataListsForCreatorAction(): Promise<GetDataListsForCreatorResult> {
   try {
-    const allLists: DataList[] = [];
-    let page = 1;
-    let hasNextPage = true;
-
-    while (hasNextPage && page <= CREATOR_MAX_PAGES) {
-      const pageResult = await getDataListsPage({
-        page,
-        pageSize: CREATOR_PAGE_SIZE,
-      });
-      allLists.push(...pageResult.items);
-      if (pageResult.items.length === 0) {
-        break;
-      }
-      hasNextPage = pageResult.hasNextPage;
-      page += 1;
-    }
-
-    return Result.success(allLists);
+    return Result.success(await listAllDataLists());
   } catch (error) {
     const message =
       error instanceof Error

--- a/features/data-lists/view-lists/get-data-lists.server.ts
+++ b/features/data-lists/view-lists/get-data-lists.server.ts
@@ -41,9 +41,24 @@ export async function getDataListLocales(): Promise<string[]> {
     loggerName: "data-lists.locales",
   });
 
-  if (Result.isError(result)) {
-    throw new DataLoadError(result.message);
+  if (Result.isSuccess(result)) {
+    return result.value;
   }
 
-  return result.value;
+  // GET /data-lists/locales is OSS e966+. Older APIs bind "locales" as GetById (Int64).
+  return collectCatalogLocales(await getAllDataLists());
+}
+
+function collectCatalogLocales(lists: readonly DataList[]): string[] {
+  const seen = new Set<string>();
+  for (const list of lists) {
+    if (list.defaultLocale) {
+      seen.add(list.defaultLocale);
+    }
+    for (const locale of list.availableLocales ?? []) {
+      seen.add(locale);
+    }
+  }
+
+  return [...seen].sort((left, right) => left.localeCompare(right));
 }

--- a/features/data-lists/view-lists/get-data-lists.server.ts
+++ b/features/data-lists/view-lists/get-data-lists.server.ts
@@ -6,6 +6,7 @@ import type {
   ListDataListsRequest,
 } from "@/lib/endatix-api/data-lists/types";
 import type { DataListsPage } from "@/lib/endatix-api/data-lists/data-lists";
+import { ApiErrorType } from "@/lib/endatix-api/shared/api-result";
 import { DataLoadError } from "@/lib/errors/data-load-error";
 import { Result } from "@/lib/result";
 import { toResult } from "@/lib/result/map-api-result-to-result";
@@ -33,6 +34,12 @@ export async function getDataListsPage(
   return result.value;
 }
 
+/** Response shapes an older (pre-e966) API returns when it binds "locales" as GetById(Int64) instead of the dedicated locales route. */
+const LEGACY_API_FALLBACK_ERROR_TYPES: ReadonlySet<ApiErrorType> = new Set([
+  ApiErrorType.NotFoundError,
+  ApiErrorType.ValidationError,
+]);
+
 /** Distinct culture codes from tenant data-list catalogs (unfiltered by list query). */
 export async function getDataListLocales(): Promise<string[]> {
   const session = await auth();
@@ -40,17 +47,31 @@ export async function getDataListLocales(): Promise<string[]> {
   await requireHubAccess();
 
   const api = new EndatixApi(session?.accessToken);
-  const result = toResult(await api.dataLists.listLocales(), {
-    fallbackMessage: "Failed to load data list locales.",
-    logMessage: "Failed to load data list locales.",
-    loggerName: "data-lists.locales",
-  });
+  const response = await api.dataLists.listLocales();
 
-  if (Result.isSuccess(result)) {
-    return result.value;
+  if (response.success) {
+    return response.data;
   }
 
-  // GET /data-lists/locales is OSS e966+. Older APIs bind "locales" as GetById (Int64).
+  // GET /data-lists/locales is OSS e966+. Older APIs bind "locales" as GetById
+  // (Int64), which fails route/model binding as 404/400 -- fall back to
+  // aggregating every list only for that specific, expected failure shape.
+  // Any other failure (auth, server error, network) should surface as a real
+  // error instead of silently degrading into an expensive full-tenant scan.
+  if (!LEGACY_API_FALLBACK_ERROR_TYPES.has(response.error.type)) {
+    const result = toResult(response, {
+      fallbackMessage: "Failed to load data list locales.",
+      logMessage: "Failed to load data list locales.",
+      loggerName: "data-lists.locales",
+    });
+    // `response` is a failure, so `result` is always Result.error here.
+    throw new DataLoadError(
+      Result.isError(result)
+        ? result.message
+        : "Failed to load data list locales.",
+    );
+  }
+
   return collectCatalogLocales(await getAllDataLists());
 }
 

--- a/features/data-lists/view-lists/get-data-lists.server.ts
+++ b/features/data-lists/view-lists/get-data-lists.server.ts
@@ -98,9 +98,11 @@ async function fetchAllDataListPages(api: EndatixApi): Promise<DataList[]> {
     });
     allItems.push(...paged.items);
     if (paged.items.length === 0 || !paged.hasNextPage) {
-      break;
+      return allItems;
     }
   }
 
-  return allItems;
+  throw new DataLoadError(
+    `Failed to load all data lists: exceeded ${MAX_LIST_PAGES} pages.`,
+  );
 }

--- a/features/data-lists/view-lists/get-data-lists.server.ts
+++ b/features/data-lists/view-lists/get-data-lists.server.ts
@@ -10,23 +10,72 @@ import { ApiErrorType } from "@/lib/endatix-api/shared/api-result";
 import { DataLoadError } from "@/lib/errors/data-load-error";
 import { Result } from "@/lib/result";
 import { toResult } from "@/lib/result/map-api-result-to-result";
+import { collectCatalogLocales } from "./catalog-locales";
 
 const AGGREGATE_PAGE_SIZE = 100;
+const MAX_LIST_PAGES = 200;
+
+const LIST_PAGE_MAP_OPTIONS = {
+  fallbackMessage: "Failed to load data lists.",
+  logMessage: "Failed to load data lists.",
+  loggerName: "data-lists.list",
+} as const;
+
+const LOCALES_MAP_OPTIONS = {
+  fallbackMessage: "Failed to load data list locales.",
+  logMessage: "Failed to load data list locales.",
+  loggerName: "data-lists.locales",
+} as const;
+
+/** 404/400 from pre-e966 APIs that bind GET /data-lists/locales as GetById(Int64). */
+const LEGACY_LOCALES_ROUTE_ERROR_TYPES: ReadonlySet<ApiErrorType> = new Set([
+  ApiErrorType.NotFoundError,
+  ApiErrorType.ValidationError,
+]);
 
 export async function getDataListsPage(
   request: ListDataListsRequest,
 ): Promise<DataListsPage> {
+  const api = await requireDataListsApi();
+  return fetchDataListsPage(api, request);
+}
+
+/** Distinct cultures from list aggregates. Prefers GET /data-lists/locales. */
+export async function getDataListLocales(): Promise<string[]> {
+  const api = await requireDataListsApi();
+  const response = await api.dataLists.listLocales();
+
+  if (response.success) {
+    return response.data;
+  }
+
+  if (LEGACY_LOCALES_ROUTE_ERROR_TYPES.has(response.error.type)) {
+    return collectCatalogLocales(await fetchAllDataListPages(api));
+  }
+
+  const result = toResult(response, LOCALES_MAP_OPTIONS);
+  if (Result.isError(result)) {
+    throw new DataLoadError(result.message);
+  }
+
+  throw new DataLoadError(LOCALES_MAP_OPTIONS.fallbackMessage);
+}
+
+async function requireDataListsApi(): Promise<EndatixApi> {
   const session = await auth();
   const { requireHubAccess } = await authorization(session);
   await requireHubAccess();
+  return new EndatixApi(session?.accessToken);
+}
 
-  const api = new EndatixApi(session?.accessToken);
-  const result = toResult(await api.dataLists.list(request), {
-    fallbackMessage: "Failed to load data lists.",
-    logMessage: "Failed to load data lists.",
-    loggerName: "data-lists.list",
-  });
-
+async function fetchDataListsPage(
+  api: EndatixApi,
+  request: ListDataListsRequest,
+): Promise<DataListsPage> {
+  const result = toResult(
+    await api.dataLists.list(request),
+    LIST_PAGE_MAP_OPTIONS,
+  );
   if (Result.isError(result)) {
     throw new DataLoadError(result.message);
   }
@@ -34,80 +83,24 @@ export async function getDataListsPage(
   return result.value;
 }
 
-/** Response shapes an older (pre-e966) API returns when it binds "locales" as GetById(Int64) instead of the dedicated locales route. */
-const LEGACY_API_FALLBACK_ERROR_TYPES: ReadonlySet<ApiErrorType> = new Set([
-  ApiErrorType.NotFoundError,
-  ApiErrorType.ValidationError,
-]);
-
-/** Distinct culture codes from tenant data-list catalogs (unfiltered by list query). */
-export async function getDataListLocales(): Promise<string[]> {
-  const session = await auth();
-  const { requireHubAccess } = await authorization(session);
-  await requireHubAccess();
-
-  const api = new EndatixApi(session?.accessToken);
-  const response = await api.dataLists.listLocales();
-
-  if (response.success) {
-    return response.data;
-  }
-
-  // GET /data-lists/locales is OSS e966+. Older APIs bind "locales" as GetById
-  // (Int64), which fails route/model binding as 404/400 -- fall back to
-  // aggregating every list only for that specific, expected failure shape.
-  // Any other failure (auth, server error, network) should surface as a real
-  // error instead of silently degrading into an expensive full-tenant scan.
-  if (!LEGACY_API_FALLBACK_ERROR_TYPES.has(response.error.type)) {
-    const result = toResult(response, {
-      fallbackMessage: "Failed to load data list locales.",
-      logMessage: "Failed to load data list locales.",
-      loggerName: "data-lists.locales",
-    });
-    // `response` is a failure, so `result` is always Result.error here.
-    throw new DataLoadError(
-      Result.isError(result)
-        ? result.message
-        : "Failed to load data list locales.",
-    );
-  }
-
-  return collectCatalogLocales(await getAllDataLists());
+/** Every tenant data list (Creator dropdowns, locales fallback). Caps pages. */
+export async function listAllDataLists(): Promise<DataList[]> {
+  return fetchAllDataListPages(await requireDataListsApi());
 }
 
-/** Aggregates every data list across all pages (fallback for pre-e966 APIs without GET /data-lists/locales). */
-async function getAllDataLists(
-  request: Omit<ListDataListsRequest, "page" | "pageSize"> = {},
-): Promise<DataList[]> {
+async function fetchAllDataListPages(api: EndatixApi): Promise<DataList[]> {
   const allItems: DataList[] = [];
-  let currentPage = 1;
-  let totalPages = 1;
 
-  while (currentPage <= totalPages) {
-    const page = await getDataListsPage({
-      ...request,
-      page: currentPage,
+  for (let page = 1; page <= MAX_LIST_PAGES; page += 1) {
+    const paged = await fetchDataListsPage(api, {
+      page,
       pageSize: AGGREGATE_PAGE_SIZE,
     });
-
-    allItems.push(...page.items);
-    totalPages = Math.max(page.totalPages, 1);
-    currentPage += 1;
+    allItems.push(...paged.items);
+    if (paged.items.length === 0 || !paged.hasNextPage) {
+      break;
+    }
   }
 
   return allItems;
-}
-
-function collectCatalogLocales(lists: readonly DataList[]): string[] {
-  const seen = new Set<string>();
-  for (const list of lists) {
-    if (list.defaultLocale) {
-      seen.add(list.defaultLocale);
-    }
-    for (const locale of list.availableLocales ?? []) {
-      seen.add(locale);
-    }
-  }
-
-  return [...seen].sort((left, right) => left.localeCompare(right));
 }

--- a/features/data-lists/view-lists/get-data-lists.server.ts
+++ b/features/data-lists/view-lists/get-data-lists.server.ts
@@ -1,11 +1,16 @@
 import { auth } from "@/auth";
 import { authorization } from "@/features/auth/authorization";
 import { EndatixApi } from "@/lib/endatix-api";
-import type { ListDataListsRequest } from "@/lib/endatix-api/data-lists/types";
+import type {
+  DataList,
+  ListDataListsRequest,
+} from "@/lib/endatix-api/data-lists/types";
 import type { DataListsPage } from "@/lib/endatix-api/data-lists/data-lists";
 import { DataLoadError } from "@/lib/errors/data-load-error";
 import { Result } from "@/lib/result";
 import { toResult } from "@/lib/result/map-api-result-to-result";
+
+const AGGREGATE_PAGE_SIZE = 100;
 
 export async function getDataListsPage(
   request: ListDataListsRequest,
@@ -47,6 +52,29 @@ export async function getDataListLocales(): Promise<string[]> {
 
   // GET /data-lists/locales is OSS e966+. Older APIs bind "locales" as GetById (Int64).
   return collectCatalogLocales(await getAllDataLists());
+}
+
+/** Aggregates every data list across all pages (fallback for pre-e966 APIs without GET /data-lists/locales). */
+async function getAllDataLists(
+  request: Omit<ListDataListsRequest, "page" | "pageSize"> = {},
+): Promise<DataList[]> {
+  const allItems: DataList[] = [];
+  let currentPage = 1;
+  let totalPages = 1;
+
+  while (currentPage <= totalPages) {
+    const page = await getDataListsPage({
+      ...request,
+      page: currentPage,
+      pageSize: AGGREGATE_PAGE_SIZE,
+    });
+
+    allItems.push(...page.items);
+    totalPages = Math.max(page.totalPages, 1);
+    currentPage += 1;
+  }
+
+  return allItems;
 }
 
 function collectCatalogLocales(lists: readonly DataList[]): string[] {

--- a/features/data-lists/view-lists/ui/data-lists-list-toolbar.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-list-toolbar.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { FacetedFilter, TableSearchInput } from "@/components/table";
+import {
+  DataTableToolbar,
+  FacetedFilter,
+  TableSearchInput,
+} from "@/components/table";
 import { Button } from "@/components/ui/button";
 import { formatLocaleLabel } from "@/features/data-lists/translations/locale-discovery";
 import { useListUrlState } from "@/lib/list-page/use-list-url-state";
@@ -57,38 +61,42 @@ export function DataListsListToolbar({
   };
 
   return (
-    <div className="mt-6 flex flex-col gap-3 lg:flex-row lg:items-center">
-      <TableSearchInput
-        value={search}
-        onChange={setSearch}
-        placeholder="Search by name or description"
-        ariaLabel="Search data lists"
-      />
-      <div className="flex max-w-full min-w-0 items-center gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        {localeOptions.length > 0 ? (
-          <FacetedFilter
-            title="Locale"
-            options={localeOptions}
-            selectedValues={selectedLocales}
-            onValueChange={(values) => {
-              updateUrl({
-                hasLocale: serializeHasLocaleFilter(values) ?? null,
-                page: "1",
-              });
-            }}
+    <DataTableToolbar
+      className="mt-6"
+      filters={
+        <>
+          <TableSearchInput
+            value={search}
+            onChange={setSearch}
+            placeholder="Search by name or description"
+            ariaLabel="Search data lists"
+            className="min-w-[12rem] flex-none lg:flex-1"
           />
-        ) : null}
-        {hasActiveFilters ? (
-          <Button
-            variant="ghost"
-            onClick={resetFilters}
-            className="shrink-0 px-2 lg:px-3"
-          >
-            Reset Filters
-            <X className="ml-2 h-4 w-4" />
-          </Button>
-        ) : null}
-      </div>
-    </div>
+          {localeOptions.length > 0 ? (
+            <FacetedFilter
+              title="Locale"
+              options={localeOptions}
+              selectedValues={selectedLocales}
+              onValueChange={(values) => {
+                updateUrl({
+                  hasLocale: serializeHasLocaleFilter(values) ?? null,
+                  page: "1",
+                });
+              }}
+            />
+          ) : null}
+          {hasActiveFilters ? (
+            <Button
+              variant="ghost"
+              onClick={resetFilters}
+              className="shrink-0 px-2 lg:px-3"
+            >
+              Reset Filters
+              <X />
+            </Button>
+          ) : null}
+        </>
+      }
+    />
   );
 }

--- a/features/data-lists/view-lists/ui/data-lists-list-toolbar.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-list-toolbar.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/table";
 import { formatLocaleLabel } from "@/features/data-lists/translations/locale-discovery";
 import { useListUrlState } from "@/lib/list-page/use-list-url-state";
-import { useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 import {
   listUrlStateFromSearchParams,
   parseHasLocaleFilterSet,
@@ -16,27 +16,15 @@ import {
 } from "../utils";
 
 type DataListsListToolbarProps = {
-  /** Tenant catalog locales (resolved on the server — avoid Suspense remounts). */
-  locales: readonly string[];
+  /** Streamed locale facet (Suspense). Keeps search/reset outside that boundary. */
+  localeFilter?: ReactNode;
 };
 
 export function DataListsListToolbar({
-  locales,
+  localeFilter,
 }: Readonly<DataListsListToolbarProps>) {
   const { search, setSearch, updateUrl, searchParams } = useListUrlState();
   const urlState = listUrlStateFromSearchParams(searchParams);
-  const selectedLocales = useMemo(
-    () => parseHasLocaleFilterSet(searchParams.get("hasLocale")),
-    [searchParams],
-  );
-  const localeOptions = useMemo(
-    () =>
-      locales.map((value) => ({
-        value,
-        label: formatLocaleLabel(value),
-      })),
-    [locales],
-  );
   const hasActiveFilters = Boolean(
     search.trim() ||
     urlState.hasLocale ||
@@ -71,24 +59,53 @@ export function DataListsListToolbar({
             ariaLabel="Search data lists"
             className="min-w-[12rem] flex-none lg:flex-1"
           />
-          {localeOptions.length > 0 ? (
-            <FacetedFilter
-              title="Locale"
-              options={localeOptions}
-              selectedValues={selectedLocales}
-              onValueChange={(values) => {
-                updateUrl({
-                  hasLocale: serializeHasLocaleFilter(values) ?? null,
-                  page: "1",
-                });
-              }}
-            />
-          ) : null}
+          {localeFilter}
           {hasActiveFilters ? (
             <ResetFiltersButton onClick={resetFilters} />
           ) : null}
         </>
       }
+    />
+  );
+}
+
+type DataListsLocaleFacetProps = {
+  locales: readonly string[];
+};
+
+/** Locale FacetedFilter only — mounted after catalog resolves so toolbar shell stays stable. */
+export function DataListsLocaleFacet({
+  locales,
+}: Readonly<DataListsLocaleFacetProps>) {
+  const { updateUrl, searchParams } = useListUrlState();
+  const selectedLocales = useMemo(
+    () => parseHasLocaleFilterSet(searchParams.get("hasLocale")),
+    [searchParams],
+  );
+  const localeOptions = useMemo(
+    () =>
+      locales.map((value) => ({
+        value,
+        label: formatLocaleLabel(value),
+      })),
+    [locales],
+  );
+
+  if (localeOptions.length === 0) {
+    return null;
+  }
+
+  return (
+    <FacetedFilter
+      title="Locale"
+      options={localeOptions}
+      selectedValues={selectedLocales}
+      onValueChange={(values) => {
+        updateUrl({
+          hasLocale: serializeHasLocaleFilter(values) ?? null,
+          page: "1",
+        });
+      }}
     />
   );
 }

--- a/features/data-lists/view-lists/ui/data-lists-list-toolbar.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-list-toolbar.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { formatLocaleLabel } from "@/features/data-lists/translations/locale-discovery";
 import { useListUrlState } from "@/lib/list-page/use-list-url-state";
 import { X } from "lucide-react";
-import { Suspense, use, useMemo } from "react";
+import { useMemo } from "react";
 import {
   listUrlStateFromSearchParams,
   parseHasLocaleFilterSet,
@@ -13,17 +13,26 @@ import {
 } from "../utils";
 
 type DataListsListToolbarProps = {
-  localesPromise: Promise<string[]>;
+  /** Tenant catalog locales (resolved on the server — avoid Suspense remounts). */
+  locales: readonly string[];
 };
 
 export function DataListsListToolbar({
-  localesPromise,
+  locales,
 }: Readonly<DataListsListToolbarProps>) {
   const { search, setSearch, updateUrl, searchParams } = useListUrlState();
   const urlState = listUrlStateFromSearchParams(searchParams);
   const selectedLocales = useMemo(
     () => parseHasLocaleFilterSet(searchParams.get("hasLocale")),
     [searchParams],
+  );
+  const localeOptions = useMemo(
+    () =>
+      locales.map((value) => ({
+        value,
+        label: formatLocaleLabel(value),
+      })),
+    [locales],
   );
   const hasActiveFilters = Boolean(
     search.trim() ||
@@ -56,10 +65,11 @@ export function DataListsListToolbar({
         ariaLabel="Search data lists"
       />
       <div className="flex max-w-full min-w-0 items-center gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        <Suspense fallback={<LocaleFilterFallback />}>
-          <DataListsLocaleFilter
-            localesPromise={localesPromise}
-            selectedLocales={selectedLocales}
+        {localeOptions.length > 0 ? (
+          <FacetedFilter
+            title="Locale"
+            options={localeOptions}
+            selectedValues={selectedLocales}
             onValueChange={(values) => {
               updateUrl({
                 hasLocale: serializeHasLocaleFilter(values) ?? null,
@@ -67,7 +77,7 @@ export function DataListsListToolbar({
               });
             }}
           />
-        </Suspense>
+        ) : null}
         {hasActiveFilters ? (
           <Button
             variant="ghost"
@@ -80,51 +90,5 @@ export function DataListsListToolbar({
         ) : null}
       </div>
     </div>
-  );
-}
-
-function LocaleFilterFallback() {
-  return (
-    <Button
-      type="button"
-      variant="outline"
-      disabled
-      className="rounded-full border-dashed"
-    >
-      Locale
-    </Button>
-  );
-}
-
-function DataListsLocaleFilter({
-  localesPromise,
-  selectedLocales,
-  onValueChange,
-}: Readonly<{
-  localesPromise: Promise<string[]>;
-  selectedLocales: Set<string>;
-  onValueChange: (values: Set<string>) => void;
-}>) {
-  const tenantLocales = use(localesPromise);
-  const options = useMemo(
-    () =>
-      tenantLocales.map((value) => ({
-        value,
-        label: formatLocaleLabel(value),
-      })),
-    [tenantLocales],
-  );
-
-  if (options.length === 0) {
-    return null;
-  }
-
-  return (
-    <FacetedFilter
-      title="Locale"
-      options={options}
-      selectedValues={selectedLocales}
-      onValueChange={onValueChange}
-    />
   );
 }

--- a/features/data-lists/view-lists/ui/data-lists-list-toolbar.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-list-toolbar.tsx
@@ -1,58 +1,130 @@
 "use client";
 
-import {
-  DataTableToolbar,
-  FacetedFilter,
-  TableSearchInput,
-} from "@/components/table";
+import { FacetedFilter, TableSearchInput } from "@/components/table";
+import { Button } from "@/components/ui/button";
 import { formatLocaleLabel } from "@/features/data-lists/translations/locale-discovery";
 import { useListUrlState } from "@/lib/list-page/use-list-url-state";
-import { useMemo } from "react";
-import { parseHasLocaleFilterSet, serializeHasLocaleFilter } from "../utils";
+import { X } from "lucide-react";
+import { Suspense, use, useMemo } from "react";
+import {
+  listUrlStateFromSearchParams,
+  parseHasLocaleFilterSet,
+  serializeHasLocaleFilter,
+} from "../utils";
+
+type DataListsListToolbarProps = {
+  localesPromise: Promise<string[]>;
+};
 
 export function DataListsListToolbar({
-  locales = [],
-}: Readonly<{ locales?: string[] }>) {
+  localesPromise,
+}: Readonly<DataListsListToolbarProps>) {
   const { search, setSearch, updateUrl, searchParams } = useListUrlState();
+  const urlState = listUrlStateFromSearchParams(searchParams);
   const selectedLocales = useMemo(
     () => parseHasLocaleFilterSet(searchParams.get("hasLocale")),
     [searchParams],
   );
-  const localeOptions = useMemo(
+  const hasActiveFilters = Boolean(
+    search.trim() ||
+      urlState.hasLocale ||
+      urlState.createdFrom ||
+      urlState.createdTo ||
+      urlState.modifiedFrom ||
+      urlState.modifiedTo,
+  );
+
+  const resetFilters = (): void => {
+    setSearch("");
+    updateUrl({
+      search: null,
+      hasLocale: null,
+      createdFrom: null,
+      createdTo: null,
+      modifiedFrom: null,
+      modifiedTo: null,
+      page: "1",
+    });
+  };
+
+  return (
+    <div className="mt-6 flex flex-col gap-3 lg:flex-row lg:items-center">
+      <TableSearchInput
+        value={search}
+        onChange={setSearch}
+        placeholder="Search by name or description"
+        ariaLabel="Search data lists"
+      />
+      <div className="flex max-w-full min-w-0 items-center gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <Suspense fallback={<LocaleFilterFallback />}>
+          <DataListsLocaleFilter
+            localesPromise={localesPromise}
+            selectedLocales={selectedLocales}
+            onValueChange={(values) => {
+              updateUrl({
+                hasLocale: serializeHasLocaleFilter(values) ?? null,
+                page: "1",
+              });
+            }}
+          />
+        </Suspense>
+        {hasActiveFilters ? (
+          <Button
+            variant="ghost"
+            onClick={resetFilters}
+            className="shrink-0 px-2 lg:px-3"
+          >
+            Reset Filters
+            <X className="ml-2 h-4 w-4" />
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function LocaleFilterFallback() {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      disabled
+      className="rounded-full border-dashed"
+    >
+      Locale
+    </Button>
+  );
+}
+
+function DataListsLocaleFilter({
+  localesPromise,
+  selectedLocales,
+  onValueChange,
+}: Readonly<{
+  localesPromise: Promise<string[]>;
+  selectedLocales: Set<string>;
+  onValueChange: (values: Set<string>) => void;
+}>) {
+  const tenantLocales = use(localesPromise);
+  const options = useMemo(
     () =>
-      locales.map((value) => ({
+      tenantLocales.map((value) => ({
         value,
         label: formatLocaleLabel(value),
       })),
-    [locales],
+    [tenantLocales],
   );
 
+  if (options.length === 0) {
+    return null;
+  }
+
   return (
-    <DataTableToolbar
-      className="mt-6"
-      filters={
-        <>
-          <TableSearchInput
-            value={search}
-            onChange={setSearch}
-            placeholder="Search by name or description"
-            ariaLabel="Search data lists"
-          />
-          {localeOptions.length > 0 ? (
-            <FacetedFilter
-              title="Locale"
-              options={localeOptions}
-              selectedValues={selectedLocales}
-              onValueChange={(values) => {
-                updateUrl({
-                  hasLocale: serializeHasLocaleFilter(values) ?? null,
-                  page: "1",
-                });
-              }}
-            />
-          ) : null}
-        </>
-      }
+    <FacetedFilter
+      title="Locale"
+      options={options}
+      selectedValues={selectedLocales}
+      onValueChange={onValueChange}
     />
   );
 }

--- a/features/data-lists/view-lists/ui/data-lists-list-toolbar.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-list-toolbar.tsx
@@ -3,12 +3,11 @@
 import {
   DataTableToolbar,
   FacetedFilter,
+  ResetFiltersButton,
   TableSearchInput,
 } from "@/components/table";
-import { Button } from "@/components/ui/button";
 import { formatLocaleLabel } from "@/features/data-lists/translations/locale-discovery";
 import { useListUrlState } from "@/lib/list-page/use-list-url-state";
-import { X } from "lucide-react";
 import { useMemo } from "react";
 import {
   listUrlStateFromSearchParams,
@@ -40,11 +39,11 @@ export function DataListsListToolbar({
   );
   const hasActiveFilters = Boolean(
     search.trim() ||
-      urlState.hasLocale ||
-      urlState.createdFrom ||
-      urlState.createdTo ||
-      urlState.modifiedFrom ||
-      urlState.modifiedTo,
+    urlState.hasLocale ||
+    urlState.createdFrom ||
+    urlState.createdTo ||
+    urlState.modifiedFrom ||
+    urlState.modifiedTo,
   );
 
   const resetFilters = (): void => {
@@ -86,14 +85,7 @@ export function DataListsListToolbar({
             />
           ) : null}
           {hasActiveFilters ? (
-            <Button
-              variant="ghost"
-              onClick={resetFilters}
-              className="shrink-0 px-2 lg:px-3"
-            >
-              Reset Filters
-              <X />
-            </Button>
+            <ResetFiltersButton onClick={resetFilters} />
           ) : null}
         </>
       }

--- a/features/data-lists/view-lists/ui/data-lists-locale-filter.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-locale-filter.tsx
@@ -1,0 +1,8 @@
+import { getDataListLocales } from "../get-data-lists.server";
+import { DataListsLocaleFacet } from "./data-lists-list-toolbar";
+
+/** Await locales and render the facet; intended for a Suspense boundary. */
+export async function DataListsLocaleFilter() {
+  const locales = await getDataListLocales();
+  return <DataListsLocaleFacet locales={locales} />;
+}

--- a/features/data-lists/view-lists/ui/data-lists-page.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-page.tsx
@@ -184,7 +184,7 @@ export function DataListsPage({
         setIsDeleteBlocked(dependenciesResult.value.length > 0);
       });
     },
-    [replaceListHref],
+    [replaceListHref, startDependenciesTransition],
   );
 
   const handleDelete = () => {
@@ -240,6 +240,10 @@ export function DataListsPage({
     [updateUrl, createdDateFilter, modifiedDateFilter, handleOpenDelete],
   );
 
+  // TanStack Table requires a referentially-stable `data` array — an inline
+  // `[...paged.items]` literal here is a new reference every render, which
+  // defeats its internal row-model memoization and cascades into a setState
+  // loop from inside its row-pagination/row-model machinery.
   const tableData = useMemo(() => [...paged.items], [paged.items]);
   const table = useReactTable({
     data: tableData,

--- a/features/data-lists/view-lists/ui/data-lists-page.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-page.tsx
@@ -14,6 +14,8 @@ import {
   CellDate,
   createPagedTableFooterProps,
   DataTableColumnHeader,
+  DATA_TABLE_ELEMENT_CLASS_NAME,
+  DATA_TABLE_SHRINK_WRAP_CLASS_NAME,
   dataTableBodyCellClassName,
   dataTableBodyRowClassName,
   dataTableColumnLabelClassName,
@@ -274,7 +276,7 @@ export function DataListsPage({
           </DataTableEmpty>
         ) : (
           <div className="w-full overflow-x-auto">
-            <Table className="border-separate border-spacing-0">
+            <Table className={DATA_TABLE_ELEMENT_CLASS_NAME}>
               <TableHeader className="bg-surface-container-low">
                 {table.getHeaderGroups().map((headerGroup) => (
                   <TableRow
@@ -459,6 +461,10 @@ function buildDataListColumns({
       id: sortableId("isActive"),
       accessorKey: "isActive",
       enableSorting: true,
+      meta: {
+        headerClassName: DATA_TABLE_SHRINK_WRAP_CLASS_NAME,
+        cellClassName: DATA_TABLE_SHRINK_WRAP_CLASS_NAME,
+      },
       header: ({ column }) => (
         <DataTableColumnHeader
           column={column}
@@ -472,8 +478,8 @@ function buildDataListColumns({
       id: "locales",
       enableSorting: false,
       meta: {
-        headerClassName: "min-w-[10rem]",
-        cellClassName: "min-w-[10rem]",
+        headerClassName: `${DATA_TABLE_SHRINK_WRAP_CLASS_NAME} min-w-[10rem]`,
+        cellClassName: `${DATA_TABLE_SHRINK_WRAP_CLASS_NAME} min-w-[10rem]`,
       },
       header: () => (
         <span className={dataTableColumnLabelClassName()}>Locales</span>
@@ -490,8 +496,8 @@ function buildDataListColumns({
       accessorKey: "createdAt",
       enableSorting: true,
       meta: {
-        headerClassName: "hidden md:table-cell",
-        cellClassName: "hidden md:table-cell",
+        headerClassName: `hidden md:table-cell ${DATA_TABLE_SHRINK_WRAP_CLASS_NAME}`,
+        cellClassName: `hidden md:table-cell ${DATA_TABLE_SHRINK_WRAP_CLASS_NAME}`,
       },
       header: ({ column }) => (
         <DataTableColumnHeader
@@ -517,8 +523,8 @@ function buildDataListColumns({
       accessorKey: "modifiedAt",
       enableSorting: true,
       meta: {
-        headerClassName: "hidden md:table-cell",
-        cellClassName: "hidden md:table-cell",
+        headerClassName: `hidden md:table-cell ${DATA_TABLE_SHRINK_WRAP_CLASS_NAME}`,
+        cellClassName: `hidden md:table-cell ${DATA_TABLE_SHRINK_WRAP_CLASS_NAME}`,
       },
       header: ({ column }) => (
         <DataTableColumnHeader
@@ -544,8 +550,8 @@ function buildDataListColumns({
       accessorKey: "itemsCount",
       enableSorting: true,
       meta: {
-        headerClassName: "hidden text-right md:table-cell",
-        cellClassName: "hidden text-right md:table-cell",
+        headerClassName: `hidden text-right md:table-cell ${DATA_TABLE_SHRINK_WRAP_CLASS_NAME}`,
+        cellClassName: `hidden text-right md:table-cell ${DATA_TABLE_SHRINK_WRAP_CLASS_NAME}`,
       },
       header: ({ column }) => (
         <DataTableColumnHeader
@@ -567,8 +573,8 @@ function buildDataListColumns({
       id: "actions",
       enableSorting: false,
       meta: {
-        headerClassName: "text-right",
-        cellClassName: "text-right",
+        headerClassName: `text-right ${DATA_TABLE_SHRINK_WRAP_CLASS_NAME}`,
+        cellClassName: `text-right ${DATA_TABLE_SHRINK_WRAP_CLASS_NAME}`,
       },
       header: () => (
         <span className={dataTableColumnLabelClassName()}>Actions</span>

--- a/features/data-lists/view-lists/ui/data-lists-page.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-page.tsx
@@ -475,8 +475,8 @@ function buildDataListColumns({
         headerClassName: "min-w-[10rem]",
         cellClassName: "min-w-[10rem]",
       },
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Locales" />
+      header: () => (
+        <span className={dataTableColumnLabelClassName()}>Locales</span>
       ),
       cell: ({ row }) => (
         <DataListLocalesCell

--- a/features/data-lists/view-lists/ui/data-lists-table-skeleton.tsx
+++ b/features/data-lists/view-lists/ui/data-lists-table-skeleton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  DATA_TABLE_ELEMENT_CLASS_NAME,
   DataTableSurface,
   dataTableBodyCellClassName,
   dataTableBodyRowClassName,
@@ -23,7 +24,7 @@ export function DataListsTableSkeleton() {
   return (
     <DataTableSurface data-slot="data-lists-table-skeleton" className="mt-4">
       <div className="w-full overflow-x-auto">
-        <Table className="border-separate border-spacing-0">
+        <Table className={DATA_TABLE_ELEMENT_CLASS_NAME}>
           <TableHeader className="bg-surface-container-low">
             <TableRow className="border-0 hover:bg-transparent">
               {[

--- a/features/submissions/ui/filters/submissions-filter-toolbar.tsx
+++ b/features/submissions/ui/filters/submissions-filter-toolbar.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { CheckSquare, Eye, Sparkles, X } from "lucide-react";
-import { FacetedFilter } from "@/components/table";
+import { CheckSquare, Eye, Sparkles } from "lucide-react";
+import { FacetedFilter, ResetFiltersButton } from "@/components/table";
 
 interface SubmissionsFilterToolbarProps {
   isCompleteFilter: Set<string>;
@@ -73,17 +72,7 @@ export function SubmissionsFilterToolbar({
         disabled={disabled}
       />
       {hasActiveFilters && (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onResetFilters}
-          disabled={disabled}
-          className="shrink-0 px-2 lg:px-3"
-          aria-label="Reset Filters"
-        >
-          <X />
-          <span className="sr-only sm:not-sr-only">Reset Filters</span>
-        </Button>
+        <ResetFiltersButton onClick={onResetFilters} disabled={disabled} />
       )}
     </>
   );

--- a/lib/utils/__tests__/hooks/use-url-search-params-updater.hook.test.ts
+++ b/lib/utils/__tests__/hooks/use-url-search-params-updater.hook.test.ts
@@ -48,4 +48,18 @@ describe("useUrlSearchParamsUpdater", () => {
       scroll: false,
     });
   });
+
+  it("skips replace when the query string is unchanged", () => {
+    replace.mockClear();
+    const { result } = renderHook(() => useUrlSearchParamsUpdater());
+
+    act(() => {
+      result.current.updateUrl({
+        page: "2",
+        search: "alpha",
+      });
+    });
+
+    expect(replace).not.toHaveBeenCalled();
+  });
 });

--- a/lib/utils/hooks/use-url-search-params-updater.hook.ts
+++ b/lib/utils/hooks/use-url-search-params-updater.hook.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { Route } from "next";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
@@ -23,7 +23,10 @@ export function useUrlSearchParamsUpdater() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const searchParamsRef = useRef(searchParams);
-  searchParamsRef.current = searchParams;
+
+  useEffect(() => {
+    searchParamsRef.current = searchParams;
+  }, [searchParams]);
 
   const updateUrl = useCallback<UrlSearchParamsUpdater>(
     (updates) => {

--- a/lib/utils/hooks/use-url-search-params-updater.hook.ts
+++ b/lib/utils/hooks/use-url-search-params-updater.hook.ts
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { useCallback } from "react";
-import type { Route } from "next";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useRef } from 'react';
+import type { Route } from 'next';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 /**
  * The type of a function that updates the URL search params.
@@ -15,16 +15,20 @@ export type UrlSearchParamsUpdater = (
 
 /**
  * A hook that provides a function to update the URL search params.
- * @returns An object with the current URL search params and the function to update the URL search params.
+ * `updateUrl` is identity-stable across searchParams changes (reads via ref)
+ * so debounced search effects do not re-arm on every filter navigation.
  */
 export function useUrlSearchParamsUpdater() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
 
   const updateUrl = useCallback<UrlSearchParamsUpdater>(
     (updates) => {
-      const nextSearchParams = new URLSearchParams(searchParams.toString());
+      const current = searchParamsRef.current;
+      const nextSearchParams = new URLSearchParams(current.toString());
 
       Object.entries(updates).forEach(([key, value]) => {
         if (!value) {
@@ -36,12 +40,16 @@ export function useUrlSearchParamsUpdater() {
       });
 
       const queryString = nextSearchParams.toString();
+      if (queryString === current.toString()) {
+        return;
+      }
+
       const href = (
         queryString ? `${pathname}?${queryString}` : pathname
       ) as Route;
       router.replace(href, { scroll: false });
     },
-    [pathname, router, searchParams],
+    [pathname, router],
   );
 
   return { searchParams, updateUrl };

--- a/lib/utils/hooks/use-url-search-params-updater.hook.ts
+++ b/lib/utils/hooks/use-url-search-params-updater.hook.ts
@@ -1,8 +1,8 @@
-'use client';
+"use client";
 
-import { useCallback, useRef } from 'react';
-import type { Route } from 'next';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useRef } from "react";
+import type { Route } from "next";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 /**
  * The type of a function that updates the URL search params.


### PR DESCRIPTION
## Summary
- Move Locale `FacetedFilter` out of column headers onto the toolbar (index + items), matching Submissions one-click pills
- Add **Reset Filters** (clears search, locale, and index date bounds; keeps sort)
- Fixes the nested popover/dropdown click-handler loop that froze the page after applying locale filters
- Added copy value icon to the data list items value for ease of UX

### Related Tasks
- closes https://github.com/endatix/endatix-hub/issues/865

## Test plan
- [x] Index: Locale pill above the table; selecting a locale does not freeze the page
- [x] Index: Reset Filters clears search, locale, and date filters
- [x] Items: Locale pill + Reset; filtered columns still hide unselected locales
- [x] Column headers still sort (index) and date-filter Created/Modified
- [x] Edit Data List functions
- [x] Submissions Grid functions after refactoring with common components

### Screenshots
<img width="599" height="857" alt="image" src="https://github.com/user-attachments/assets/f0f7eb04-3584-4cb3-a74e-5595d71d6142" />
<img width="692" height="731" alt="image" src="https://github.com/user-attachments/assets/728d8d9c-fa20-4bcf-aec7-9a419d4662dd" />
<img width="1127" height="484" alt="image" src="https://github.com/user-attachments/assets/51e12cf7-221f-45ea-89a8-f7ce3999dba8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added locale filtering and item search to data-list details.
  - Added a reset-filters button that clears active searches and filters.
  - Data-list pages now support consolidated locale options, including legacy data.

- **Bug Fixes**
  - Prevented unnecessary page updates when URL filters remain unchanged.
  - Improved data-list loading and table responsiveness.

- **UI Improvements**
  - Optimized table column sizing for clearer, more compact layouts.
  - Standardized filter reset controls across data-list and submission views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->