### PR TITLE
fix(helm): restore the selectorLabels helper and match the API chart's idioms

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -3,19 +3,16 @@ kind: Deployment
 metadata:
   name: {{ include "endatix-hub.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "endatix-hub.selectorLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Chart.Name }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "endatix-hub.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Chart.Name }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "endatix-hub.selectorLabels" . | nindent 8 }}
     spec:
       # The Hub only talks to the Endatix API over HTTP — it never calls the
       # Kubernetes API, so a mounted service-account token would just park a
@@ -29,8 +26,14 @@ spec:
         fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
-      imagePullSecrets: {{ .Values.imagePullSecrets | toJson }}
-      nodeSelector: {{ .Values.nodeSelector | toJson }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
@@ -83,7 +86,8 @@ spec:
             - name: NEXT_OTEL_VERBOSE
               value: {{ ternary "0" "" .Values.otel.enabled | quote }}
 
-          resources: {{ .Values.resources | toJson }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
# Restore the selectorLabels helper and match the API chart's idioms

## Description

Two chart-consistency regressions from #874. **Neither changes what a stock install deploys** — verified below.

### 1. `selectorLabels` was inlined in `deployment.yaml` but kept everywhere else

#874 replaced `include "endatix-hub.selectorLabels"` with literal labels in three places, but left the helper defined and left `service.yaml` using it twice. The chart ended up with five sites emitting the same two labels — three literal, two via the helper.

The helper's own doc comment, still in the file, says why that matters:

> …the Deployment selector, the pod template, and the Service selector — **a Deployment's selector is immutable, so all three must stay in sync.**

`spec.selector.matchLabels` cannot be changed after creation. Edit the inlined labels and miss `service.yaml`, or the reverse, and you get a Service selecting no pods, or a `helm upgrade` that fails on an immutable field and can only be recovered by deleting the Deployment. The helper made that impossible; splitting it across two files reintroduces it while the helper's continued existence implies a guarantee it no longer provides.

### 2. `toJson` replaced with the idiom the API chart already uses

```diff
-      imagePullSecrets: {{ .Values.imagePullSecrets | toJson }}
-      nodeSelector: {{ .Values.nodeSelector | toJson }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
```

To be clear: **`toJson` was not broken.** YAML is a superset of JSON, the flow mappings parsed correctly, and the values reached Kubernetes intact. I checked before changing anything.

The reasons to change it are consistency and output quality. `endatix/helm` — the API chart these are deployed alongside — already uses `{{- with }}` + `toYaml` for exactly these three fields. And `toJson` emitted `imagePullSecrets: []` and `nodeSelector: {}` on every install even when empty, plus single-line flow mappings that make `helm template` output and GitOps diffs harder to read.

## Verification

Rendered four value combinations before and after, parsed both to structures, and diffed:

| Scenario | Result |
|---|---|
| defaults | only `imagePullSecrets: []` and `nodeSelector: {}` disappear |
| `nodeSelector` + `imagePullSecrets` set | **identical** — values preserved exactly |
| `baseUrl` mode | only the two empty keys disappear |
| custom `resources` | only the two empty keys disappear |

So the entire semantic delta is two empty collections no longer being emitted. Kubernetes treats absent and empty identically for both, and the API chart already omits them.

Also confirmed: `helm lint` passes, all three `api.apiUrl` / `api.baseUrl` branches still render correctly including both guard errors, and the existing `helm/__tests__/api-env-vars.test.ts` suite still passes (5/5).

## Related Issues

Follows #874.

## Type of Change

- [x] Refactoring (non-breaking change which improves code quality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — no documented behaviour changes
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — see the note below
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## A follow-up worth considering

`helm/__tests__/api-env-vars.test.ts` asserts on template **source text** rather than rendered output, so it cannot catch either problem fixed here — and a label drift between `deployment.yaml` and `service.yaml` would sail past it.

CI already has helm available (`build-ci.yml` notes the chart "only needs the runner's preinstalled helm"), so `helm lint` plus a few `helm template --set …` assertions would cover far more for the same effort. That is also what the platform migration plan asks for upstream. Happy to write it as a separate PR.