### PR TITLE
feat(e168): drop legacy FluentValidation error body from Hub API client.

### DIFF
--- a/lib/endatix-api/__tests__/auth.test.ts
+++ b/lib/endatix-api/__tests__/auth.test.ts
@@ -31,11 +31,15 @@ describe("Auth", () => {
 
     describe("validation error responses", () => {
       it("should handle FluentValidation error response", async () => {
-        // Arrange
+        // Arrange — Endatix API 0.7.5+ uses the same RFC7807 body as handler ToProblem
         const serverErrorResponse = {
-          statusCode: 400,
-          message: "One or more errors occurred!",
-          errors: {
+          type: "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+          title: "There was a problem with your request",
+          status: 400,
+          detail: "password is too short!",
+          instance: "/api/auth/login",
+          traceId: "0HMPNHL0JHL76:00000001",
+          fields: {
             password: ["password is too short!"],
           },
         };
@@ -43,7 +47,7 @@ describe("Auth", () => {
         const mockResponse = new Response(JSON.stringify(serverErrorResponse), {
           status: 400,
           statusText: "Bad Request",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/problem+json" },
         });
 
         mockFetch.mockResolvedValueOnce(mockResponse);
@@ -67,7 +71,7 @@ describe("Auth", () => {
         expect(ApiResult.isError(result)).toBe(true);
         if (ApiResult.isError(result)) {
           expect(result.error.type).toBe(ApiErrorType.ValidationError);
-          expect(result.error.message).toBe("One or more errors occurred!");
+          expect(result.error.message).toBe("password is too short!");
           expect(result.error.details?.statusCode).toBe(400);
           expect(result.error.fields).toEqual({
             password: ["password is too short!"],

--- a/lib/endatix-api/__tests__/http-error-mapper.test.ts
+++ b/lib/endatix-api/__tests__/http-error-mapper.test.ts
@@ -1,62 +1,63 @@
 import { describe, expect, it } from "vitest";
-import { ApiErrorType, ERROR_CODE } from "../shared/api-result";
+import { ApiErrorType, ApiResult } from "../shared/api-result";
 import { mapResponseToApiError } from "../shared/http-error-mapper";
 
 describe("mapResponseToApiError", () => {
-  it("maps 409 conflict problem details to ConflictError with readable message", async () => {
-    const response = new Response(
-      JSON.stringify({
-        title: "There was a conflict.",
-        status: 409,
-        detail:
-          "Next error(s) occurred:* A submission already exists for this user and form.\n",
-      }),
-      { status: 409, headers: { "Content-Type": "application/problem+json" } },
-    );
+  it("maps 400 problem+json with fields and traceId to ValidationError", async () => {
+    const body = {
+      type: "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+      title: "There was a problem with your request",
+      status: 400,
+      detail: "Name is required.",
+      instance: "/api/forms",
+      traceId: "0HMPNHL0JHL76:00000001",
+      fields: { name: ["Name is required."] },
+    };
 
-    const result = await mapResponseToApiError(response, {
-      endpoint: "/api/forms/1/submissions",
-      method: "POST",
-      statusCode: 409,
+    const response = new Response(JSON.stringify(body), {
+      status: 400,
+      statusText: "Bad Request",
+      headers: { "Content-Type": "application/problem+json" },
     });
 
-    expect(result.success).toBe(false);
-    if (result.success) {
-      throw new Error("Expected error result");
-    }
+    const result = await mapResponseToApiError(response, {
+      endpoint: "/api/forms",
+      method: "POST",
+    });
 
-    expect(result.error.type).toBe(ApiErrorType.ConflictError);
-    expect(result.error.errorCode).toBe(ERROR_CODE.CONFLICT);
-    expect(result.error.message).toBe(
-      "A submission already exists for this user and form.",
-    );
-    expect(result.error.details?.statusCode).toBe(409);
+    expect(ApiResult.isError(result)).toBe(true);
+    if (ApiResult.isError(result)) {
+      expect(result.error.type).toBe(ApiErrorType.ValidationError);
+      expect(result.error.message).toBe("Name is required.");
+      expect(result.error.fields).toEqual({ name: ["Name is required."] });
+      expect(result.error.details?.statusCode).toBe(400);
+      expect(result.error.details?.details).toBe("Name is required.");
+    }
   });
 
-  it("uses CONFLICT fallback for 409 problem body with no detail message or errorCode", async () => {
+  it("falls back to status semantics when body is legacy FE ErrorResponse", async () => {
     const response = new Response(
       JSON.stringify({
-        status: 409,
-        detail: "",
+        statusCode: 400,
+        message: "One or more errors occurred!",
+        errors: { name: ["Name is required."] },
       }),
-      { status: 409, headers: { "Content-Type": "application/problem+json" } },
+      {
+        status: 400,
+        statusText: "Bad Request",
+        headers: { "Content-Type": "application/json" },
+      },
     );
 
     const result = await mapResponseToApiError(response, {
-      endpoint: "/api/forms/1/submissions",
+      endpoint: "/api/forms",
       method: "POST",
-      statusCode: 409,
     });
 
-    expect(result.success).toBe(false);
-    if (result.success) {
-      throw new Error("Expected error result");
+    expect(ApiResult.isError(result)).toBe(true);
+    if (ApiResult.isError(result)) {
+      expect(result.error.type).toBe(ApiErrorType.ValidationError);
+      expect(result.error.fields).toBeUndefined();
     }
-
-    expect(result.error.type).toBe(ApiErrorType.ConflictError);
-    expect(result.error.errorCode).toBe(ERROR_CODE.CONFLICT);
-    expect(result.error.message).toBe(
-      "This action conflicts with the current state. Please try again.",
-    );
   });
 });

--- a/lib/endatix-api/__tests__/problem-details.test.ts
+++ b/lib/endatix-api/__tests__/problem-details.test.ts
@@ -49,3 +49,39 @@ describe("parseProblemDetails", () => {
     expect(parsed?.traceId).toBe("trace-404");
   });
 });
+
+describe("parseProblemDetails - RFC7807 tolerance", () => {
+  it("accepts a body without detail and falls back to title", () => {
+    const parsed = parseProblemDetails({
+      type: "https://www.rfc-editor.org/rfc/rfc9110#name-401-unauthorized",
+      title: "Unauthorized",
+      status: 401,
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.detail).toBe("Unauthorized");
+    expect(parsed?.status).toBe(401);
+  });
+
+  it("keeps instance from the canonical Endatix body", () => {
+    const parsed = parseProblemDetails({
+      type: "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+      title: "There was a problem with your request",
+      status: 400,
+      detail: "Name is required.",
+      instance: "/api/forms",
+      traceId: "00-abc-def-01",
+      fields: { Name: ["Name is required."] },
+    });
+
+    expect(parsed?.instance).toBe("/api/forms");
+    expect(parsed?.traceId).toBe("00-abc-def-01");
+    expect(parsed?.fields).toEqual({ Name: ["Name is required."] });
+  });
+
+  it("still rejects a body with no status", () => {
+    expect(
+      parseProblemDetails({ title: "Nope", detail: "no status" }),
+    ).toBeNull();
+  });
+});

--- a/lib/endatix-api/__tests__/problem-details.test.ts
+++ b/lib/endatix-api/__tests__/problem-details.test.ts
@@ -2,44 +2,50 @@ import { describe, expect, it } from "vitest";
 import { parseProblemDetails } from "../shared/problem-details";
 
 describe("parseProblemDetails", () => {
-  it("parses RFC7807 camelCase problem details", () => {
-    const problem = parseProblemDetails({
-      type: "https://tools.ietf.org/html/rfc7231#section-6.6.1",
-      title: "Export failed",
-      status: 500,
-      detail:
-        "Form schema has not been compiled for this form. Save or publish the form definition to trigger compilation.",
-    });
-
-    expect(problem?.detail).toContain("Form schema has not been compiled");
-    expect(problem?.status).toBe(500);
-  });
-
-  it("parses PascalCase problem details from default .NET serialization", () => {
-    const problem = parseProblemDetails({
-      Title: "Export failed",
-      Status: 409,
-      Detail:
-        "Form schema has not been compiled for this form. Save or publish the form definition to trigger compilation.",
-    });
-
-    expect(problem?.detail).toContain("Form schema has not been compiled");
-    expect(problem?.status).toBe(409);
-    expect(problem?.title).toBe("Export failed");
-  });
-
-  it("accepts partial payloads with only detail and status", () => {
-    const problem = parseProblemDetails({
-      detail: "Export format is not supported.",
+  it("parses the canonical Endatix RFC7807 body with fields and traceId", () => {
+    const parsed = parseProblemDetails({
+      type: "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+      title: "There was a problem with your request",
       status: 400,
+      detail: "Name is required.",
+      instance: "/api/forms",
+      traceId: "0HMPNHL0JHL76:00000001",
+      errorCode: "NotEmptyValidator",
+      fields: { name: ["Name is required."] },
     });
 
-    expect(problem?.detail).toBe("Export format is not supported.");
-    expect(problem?.status).toBe(400);
-    expect(problem?.title).toBe("Error");
+    expect(parsed).not.toBeNull();
+    expect(parsed?.status).toBe(400);
+    expect(parsed?.detail).toBe("Name is required.");
+    expect(parsed?.traceId).toBe("0HMPNHL0JHL76:00000001");
+    expect(parsed?.errorCode).toBe("NotEmptyValidator");
+    expect(parsed?.fields).toEqual({ name: ["Name is required."] });
   });
 
-  it("returns null for unrecognized payloads", () => {
-    expect(parseProblemDetails({ message: "oops" })).toBeNull();
+  it("returns null for the legacy FastEndpoints ErrorResponse shape", () => {
+    const parsed = parseProblemDetails({
+      statusCode: 400,
+      message: "One or more errors occurred!",
+      errors: {
+        password: ["password is too short!"],
+      },
+    });
+
+    expect(parsed).toBeNull();
+  });
+
+  it("accepts PascalCase .NET ProblemDetails members", () => {
+    const parsed = parseProblemDetails({
+      Type: "about:blank",
+      Title: "Resource not found",
+      Status: 404,
+      Detail: "Form not found",
+      TraceId: "trace-404",
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.status).toBe(404);
+    expect(parsed?.detail).toBe("Form not found");
+    expect(parsed?.traceId).toBe("trace-404");
   });
 });

--- a/lib/endatix-api/shared/http-error-mapper.ts
+++ b/lib/endatix-api/shared/http-error-mapper.ts
@@ -15,10 +15,8 @@ export async function mapResponseToApiError<T>(
 
   const serverErrorCode = problemDetails?.errorCode;
 
-  const problemMessage = preferReadableProblemDetail(
-    response.status,
-    problemDetails?.detail ?? problemDetails?.title,
-  );
+  const problemMessage =
+    (problemDetails?.detail ?? problemDetails?.title)?.trim() || undefined;
   // Prefer the server's problem detail over a canned error-code message.
   // When the body has no readable detail/title and no errorCode, leave message
   // undefined so status-specific factories (e.g. conflictError) apply their own fallback.
@@ -53,53 +51,6 @@ export async function mapResponseToApiError<T>(
     detailsWithRetryAfter,
     problemDetails?.fields,
   );
-}
-
-/**
- * Ardalis/Endatix Conflict results often format detail as:
- * "Next error(s) occurred:* A submission already exists..."
- * Prefer the concrete message after `*` for respondent-facing UI.
- */
-function preferReadableProblemDetail(
-  status: number,
-  detail?: string,
-): string | undefined {
-  if (!detail) {
-    return undefined;
-  }
-
-  if (status === 409) {
-    const detailMessage = extractConflictDetailMessage(detail);
-    if (detailMessage) {
-      return detailMessage;
-    }
-  }
-
-  return detail.trim();
-}
-
-/**
- * Extract the message after the first `*` up to the next `*` or line break.
- * Uses a linear string scan (no regex) to avoid ReDoS and Sonar String.match.
- */
-function extractConflictDetailMessage(detail: string): string | undefined {
-  const starIndex = detail.indexOf("*");
-  if (starIndex < 0) {
-    return undefined;
-  }
-
-  const afterStar = detail.slice(starIndex + 1);
-  let end = afterStar.length;
-  for (let i = 0; i < afterStar.length; i += 1) {
-    const ch = afterStar[i];
-    if (ch === "*" || ch === "\r" || ch === "\n") {
-      end = i;
-      break;
-    }
-  }
-
-  const message = afterStar.slice(0, end).trim();
-  return message.length > 0 ? message : undefined;
 }
 
 function parseRetryAfter(retryAfter: string | null): number | undefined {

--- a/lib/endatix-api/shared/problem-details.ts
+++ b/lib/endatix-api/shared/problem-details.ts
@@ -5,6 +5,9 @@ import { z } from "zod";
  *
  * `type` and `title` are optional so partial payloads (e.g. streaming endpoints that only set
  * `detail` + `status`) still surface a useful message instead of falling back to a generic one.
+ *
+ * Endatix API (0.7.5+) emits one RFC7807 shape for handler errors, FluentValidation, and
+ * unhandled exceptions — `fields` is a property→messages dictionary (not FE `{statusCode, message, errors}`).
  */
 export const ProblemDetailsSchema = z.object({
   type: z.string().optional(),
@@ -14,16 +17,6 @@ export const ProblemDetailsSchema = z.object({
   errorCode: z.string().optional(),
   traceId: z.string().optional(),
   fields: z.record(z.string(), z.array(z.string())).optional(),
-});
-
-/**
- * The schema for a ValidationProblemDetails object returned from the API.
- * TODO: Merge this with ProblemDetailsSchema once Endatix API fully moves to problem details
- */
-export const ValidationProblemDetailsSchema = z.object({
-  statusCode: z.number().int().min(400).max(499),
-  message: z.string(),
-  errors: z.record(z.string(), z.array(z.string())),
 });
 
 export type ProblemDetails = z.infer<typeof ProblemDetailsSchema>;
@@ -43,8 +36,7 @@ function normalizeProblemDetailsCandidate(data: unknown): unknown {
   const type = record.type ?? record.Type;
   const errorCode = record.errorCode ?? record.ErrorCode;
   const traceId = record.traceId ?? record.TraceId;
-  const fields =
-    record.fields ?? record.Fields ?? record.errors ?? record.Errors;
+  const fields = record.fields ?? record.Fields;
 
   return {
     ...record,
@@ -76,18 +68,6 @@ export function parseProblemDetails(data: unknown): ProblemDetails | null {
       errorCode: result.data.errorCode,
       traceId: result.data.traceId,
       fields: result.data.fields,
-    };
-  }
-
-  const validationResult = ValidationProblemDetailsSchema.safeParse(data);
-
-  if (validationResult.success) {
-    return {
-      type: "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1",
-      title: "One or more validation errors occurred.",
-      status: validationResult.data.statusCode,
-      detail: validationResult.data.message,
-      fields: validationResult.data.errors,
     };
   }
 

--- a/lib/endatix-api/shared/problem-details.ts
+++ b/lib/endatix-api/shared/problem-details.ts
@@ -13,13 +13,23 @@ export const ProblemDetailsSchema = z.object({
   type: z.string().optional(),
   title: z.string().optional(),
   status: z.number(),
-  detail: z.string(),
+  // RFC7807 makes `detail` optional. Endatix always sends it, but ASP.NET's built-in
+  // writers (401/404 from auth and routing) omit it - accept those instead of failing
+  // the parse and falling back to a generic message.
+  detail: z.string().optional(),
+  instance: z.string().optional(),
   errorCode: z.string().optional(),
   traceId: z.string().optional(),
   fields: z.record(z.string(), z.array(z.string())).optional(),
 });
 
-export type ProblemDetails = z.infer<typeof ProblemDetailsSchema>;
+/**
+ * Parsed problem details. `detail` is normalized to always be present (falling back to
+ * `title`), so callers never have to branch on a missing message.
+ */
+export type ProblemDetails = z.infer<typeof ProblemDetailsSchema> & {
+  detail: string;
+};
 
 /**
  * Normalize common ProblemDetails shapes (camelCase RFC7807 and PascalCase .NET defaults).
@@ -34,6 +44,7 @@ function normalizeProblemDetailsCandidate(data: unknown): unknown {
   const status = record.status ?? record.Status;
   const title = record.title ?? record.Title;
   const type = record.type ?? record.Type;
+  const instance = record.instance ?? record.Instance;
   const errorCode = record.errorCode ?? record.ErrorCode;
   const traceId = record.traceId ?? record.TraceId;
   const fields = record.fields ?? record.Fields;
@@ -44,6 +55,7 @@ function normalizeProblemDetailsCandidate(data: unknown): unknown {
     ...(typeof status === "number" ? { status } : {}),
     ...(typeof title === "string" ? { title } : {}),
     ...(typeof type === "string" ? { type } : {}),
+    ...(typeof instance === "string" ? { instance } : {}),
     ...(typeof errorCode === "string" ? { errorCode } : {}),
     ...(typeof traceId === "string" ? { traceId } : {}),
     ...(fields !== undefined ? { fields } : {}),
@@ -60,11 +72,15 @@ export function parseProblemDetails(data: unknown): ProblemDetails | null {
   const result = ProblemDetailsSchema.safeParse(normalized);
 
   if (result.success) {
+    const title = result.data.title ?? "Error";
     return {
       type: result.data.type ?? "about:blank",
-      title: result.data.title ?? "Error",
+      title,
       status: result.data.status,
-      detail: result.data.detail,
+      // Keep `detail` a guaranteed string for consumers; fall back to the title when the
+      // producer omitted it.
+      detail: result.data.detail ?? title,
+      instance: result.data.instance,
       errorCode: result.data.errorCode,
       traceId: result.data.traceId,
       fields: result.data.fields,


### PR DESCRIPTION
# feat(e168): drop legacy FluentValidation error body from Hub API client.

## Summary
- Closes the Hub side of endatix/endatix#168: parse only RFC7807 ProblemDetails (`status`/`detail`/`fields`/`traceId`).
- Removes `ValidationProblemDetailsSchema` and the `{statusCode, message, errors}` fallback.
- Stacked on `feature/h908-sjs-v3-upgrade` so client tests run on SurveyJS v3 before that lands on `main`.

## Why
API 0.7.5 makes FluentValidation 400s the same problem+json shape as handler `ToProblem`. Keeping the old FE body parser would hide breakages and leave a dead schema.

## Scope
- `lib/endatix-api/shared/problem-details.ts` + tests / auth fixture / `http-error-mapper` tests only.
- Does **not** migrate `services/api.ts` → `EndatixApi`.

## Test plan
- [x] `vitest` auth + problem-details + http-error-mapper
- [ ] Pair against API build that emits FE 400 as problem+json (`fields`, not `errors`)
- [ ] Do not merge to `main` until API ProblemDetails PR is ready (or Hub still needs the old body)

## Links
- closes https://github.com/endatix/endatix/issues/168
- endatix-hub#908 (stack base)
- Depends on API 0.7.5 error contract

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [x] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
With server side validation error
<img width="753" height="606" alt="image" src="https://github.com/user-attachments/assets/594008e7-2cb3-4df9-98fe-5850e325fccc" />
With unexpected error
<img width="687" height="597" alt="image" src="https://github.com/user-attachments/assets/a5b5b496-0d31-496b-8ccd-1a07796f0f34" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of RFC 7807 problem-detail responses, including validation messages, status information, fields, trace IDs, error codes, and instances.
  - Added support for PascalCase and responses that omit `detail` by using the provided title as a fallback.
  - Preserved compatibility with legacy error responses through status-based validation mapping.
  - Simplified conflict-error messages to display the response’s detail or title directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->