### PR TITLE
feat(config): resolve public client config at runtime, not build time

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,7 @@ AUTH_URL=https://yourdomain.com
 ############################
 
 # [OPTIONAL] Application-level debug mode flag. Set to "true" to enable debug mode. If not set, defaults to development mode.
-NEXT_PUBLIC_IS_DEBUG_MODE=false
+ENDATIX_IS_DEBUG_MODE=false
 
 # Data Collection
 ############################
@@ -70,7 +70,7 @@ NEXT_FORMS_COOKIE_DURATION_DAYS=7
 # [OPTIONAL] The Google reCAPTCHA v3 Site Key for client side integration
 # 💡 TIP: You can obtain the key and learn more at https://developers.google.com/recaptcha/docs/v3
 # Example: 4LcsG3UfAAAaAF5HQnF5IijKep9PwZbMYo0y_Igt
-# NEXT_PUBLIC_RECAPTCHA_SITE_KEY=
+# ENDATIX_RECAPTCHA_SITE_KEY=
 
 # Slack
 ############################
@@ -159,18 +159,18 @@ TELEMETRY_CONSOLE_FALLBACK=false
 # PostHog
 ############################
 # [OPTIONAL] PostHog API key for client-side analytics tracking.
-NEXT_PUBLIC_POSTHOG_KEY=
+ENDATIX_POSTHOG_KEY=
 # [OPTIONAL] PostHog API host URL. Default: https://us.i.posthog.com
-NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+ENDATIX_POSTHOG_HOST=https://us.i.posthog.com
 # [OPTIONAL] PostHog UI host URL for linking directly to the PostHog UI.
-NEXT_PUBLIC_POSTHOG_UI_HOST=
+ENDATIX_POSTHOG_UI_HOST=
 # [OPTIONAL] Use this to enable PostHog as a feature flag adapter (provider). true to enable
 ENABLE_POSTHOG_ADAPTER=
 
 # Public
 ############################
 # [OPTIONAL] SLK.
-NEXT_PUBLIC_SLK=
+ENDATIX_SURVEY_LICENSE_KEY=
 
 # [OPTIONAL] Public name for the application.
 NEXT_PUBLIC_NAME=
@@ -203,3 +203,12 @@ MAINTENANCE_FOOTER=
 MAINTENANCE_METADATA_TITLE=
 # [OPTIONAL] Meta description for the maintenance page.
 MAINTENANCE_METADATA_DESCRIPTION=
+
+# --- Public, request-time client config -------------------------------------
+# These are projected to the browser per request, NOT inlined at build time, so a
+# container env var changes them without rebuilding the image. The old NEXT_PUBLIC_*
+# names still work as deprecated fallbacks. Never reintroduce a NEXT_PUBLIC_* key: it is
+# baked into the client bundle and can only be changed by a rebuild. Licence keys in
+# particular must always be replaceable at runtime.
+# ENDATIX_SUBMITTER_PRIMARY_FILTER_LABEL=Submitter
+# ENDATIX_SUBMITTER_GRID_PROFILE_FIELDS=

--- a/app/(main)/forms/[formId]/design/page.tsx
+++ b/app/(main)/forms/[formId]/design/page.tsx
@@ -7,6 +7,7 @@ import { authorization } from "@/features/auth/authorization";
 import FormDesignerWrapper, {
   FormDesignerWrapperProps,
 } from "@/features/forms/ui/designer/form-designer-wrapper";
+import { getSurveyLicenseKey } from "@/features/config/legacy-public-env.server";
 import { DesignerRuntimeProvider } from "@/lib/designer-runtime";
 import FormEditorLoader from "@/features/forms/ui/editor/form-editor-loader";
 import { FormAssistantProvider } from "@/features/forms/use-cases/design-form/form-assistant.context";
@@ -87,7 +88,7 @@ export default async function FormDesignerPage({ params }: Params) {
     formId: formId,
     formJson: formJson,
     formName: form.name,
-    slkVal: process.env.NEXT_PUBLIC_SLK,
+    slkVal: getSurveyLicenseKey(),
     themeId: form.themeId ?? undefined,
     isPublic: form.isPublic,
     formIsEnabled: form.isEnabled,

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -8,6 +8,8 @@ import { Metadata } from "next";
 import { cookies, headers } from "next/headers";
 import { getMetadataBase } from "@/lib/seo";
 import { getClientEndatixConfig } from "@/features/config";
+import { getSurveyLicenseKey } from "@/features/config/legacy-public-env.server";
+import { SurveyLicenseProvider } from "@/features/config/survey-license-provider";
 
 export const metadata: Metadata = {
   metadataBase: getMetadataBase(),
@@ -36,7 +38,6 @@ export default async function RootLayout({
   header,
   nav,
 }: RootLayoutProps) {
-
   const requestHeaders = await headers();
   const osClass = getOsClass(requestHeaders);
   const session = await auth();
@@ -60,11 +61,13 @@ export default async function RootLayout({
           sidebarDefaultOpen={defaultSidebarOpen}
           endatixConfig={endatixConfig}
         >
-          {nav}
-          <main data-slot="sidebar-inset">
-            {header}
-            <div data-slot="content-wrapper">{children}</div>
-          </main>
+          <SurveyLicenseProvider value={getSurveyLicenseKey()}>
+            {nav}
+            <main data-slot="sidebar-inset">
+              {header}
+              <div data-slot="content-wrapper">{children}</div>
+            </main>
+          </SurveyLicenseProvider>
         </AppProvider>
       </body>
     </html>

--- a/components/providers/__tests__/endatix-config-provider.test.tsx
+++ b/components/providers/__tests__/endatix-config-provider.test.tsx
@@ -6,12 +6,21 @@ import {
   useEndatixConfig,
 } from "../endatix-config-provider";
 import {
+  EMPTY_CLIENT_ENDATIX_CONFIG,
   getBrowserEndatixConfig,
   resetBrowserEndatixConfigForTests,
   toClientEndatixConfig,
+  type ClientEndatixConfig,
 } from "@/features/config/client-endatix-config";
 
-function wrapper(value: { apiBaseUrl: string; extensionsEnabled: boolean }) {
+/** Only the fields a case cares about; the rest fall back to the empty projection. */
+function config(
+  overrides: Partial<ClientEndatixConfig> = {},
+): ClientEndatixConfig {
+  return { ...EMPTY_CLIENT_ENDATIX_CONFIG, ...overrides };
+}
+
+function wrapper(value: ClientEndatixConfig) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <EndatixConfigProvider value={value}>{children}</EndatixConfigProvider>
@@ -24,22 +33,25 @@ describe("EndatixConfigProvider", () => {
     resetBrowserEndatixConfigForTests();
   });
 
-  it("projects only apiBaseUrl and extensionsEnabled into context and the browser getter", () => {
-    const extra = {
+  it("projects only the public fields into context and the browser getter", () => {
+    const expected = config({
       apiBaseUrl: "https://api.example.com/api",
       extensionsEnabled: true,
-      secret: "do-not-leak",
-    };
+      recaptchaSiteKey: "recaptcha-site-key",
+      posthogKey: "posthog-key",
+    });
+    const extra = { ...expected, secret: "do-not-leak" };
 
     const { result } = renderHook(() => useEndatixConfig(), {
       wrapper: wrapper(extra),
     });
 
-    expect(result.current).toEqual({
-      apiBaseUrl: "https://api.example.com/api",
-      extensionsEnabled: true,
-    });
+    expect(result.current).toEqual(expected);
     expect(result.current).not.toHaveProperty("secret");
+    // The SurveyJS licence key is a commercial credential and this projection is
+    // serialised into the HTML of every public form page. It belongs to
+    // SurveyLicenseProvider, mounted only by the authenticated shell.
+    expect(result.current).not.toHaveProperty("surveyLicenseKey");
     expect(getBrowserEndatixConfig()).toEqual(result.current);
   });
 
@@ -53,7 +65,10 @@ describe("EndatixConfigProvider", () => {
 
     const { rerender } = render(
       <EndatixConfigProvider
-        value={{ apiBaseUrl: "https://a.example/api", extensionsEnabled: true }}
+        value={config({
+          apiBaseUrl: "https://a.example/api",
+          extensionsEnabled: true,
+        })}
       >
         <Consumer />
       </EndatixConfigProvider>,
@@ -61,7 +76,10 @@ describe("EndatixConfigProvider", () => {
 
     rerender(
       <EndatixConfigProvider
-        value={{ apiBaseUrl: "https://a.example/api", extensionsEnabled: true }}
+        value={config({
+          apiBaseUrl: "https://a.example/api",
+          extensionsEnabled: true,
+        })}
       >
         <Consumer />
       </EndatixConfigProvider>,
@@ -79,10 +97,12 @@ describe("EndatixConfigProvider", () => {
 
   it("treats non-boolean extensionsEnabled as off", () => {
     expect(
-      toClientEndatixConfig({
-        apiBaseUrl: "https://api.example.com/api",
-        extensionsEnabled: "true" as unknown as boolean,
-      }).extensionsEnabled,
+      toClientEndatixConfig(
+        config({
+          apiBaseUrl: "https://api.example.com/api",
+          extensionsEnabled: "true" as unknown as boolean,
+        }),
+      ).extensionsEnabled,
     ).toBe(false);
   });
 });

--- a/components/providers/__tests__/endatix-config-provider.test.tsx
+++ b/components/providers/__tests__/endatix-config-provider.test.tsx
@@ -40,7 +40,13 @@ describe("EndatixConfigProvider", () => {
       recaptchaSiteKey: "recaptcha-site-key",
       posthogKey: "posthog-key",
     });
-    const extra = { ...expected, secret: "do-not-leak" };
+    // Sentinels: both must be dropped by the projection. Without an explicit
+    // surveyLicenseKey here the assertion below would pass vacuously.
+    const extra = {
+      ...expected,
+      secret: "do-not-leak",
+      surveyLicenseKey: "do-not-project",
+    };
 
     const { result } = renderHook(() => useEndatixConfig(), {
       wrapper: wrapper(extra),

--- a/components/providers/endatix-config-provider.tsx
+++ b/components/providers/endatix-config-provider.tsx
@@ -22,10 +22,43 @@ export function EndatixConfigProvider({
   value,
   children,
 }: Readonly<EndatixConfigProviderProps>) {
-  const { apiBaseUrl, extensionsEnabled } = value;
+  const {
+    apiBaseUrl,
+    extensionsEnabled,
+    recaptchaSiteKey,
+    posthogKey,
+    posthogHost,
+    posthogUiHost,
+    isDebugMode,
+    submitterPrimaryFilterLabel,
+    submitterGridProfileFields,
+  } = value;
+  // Destructured to primitives so the memo compares by value: a new object identity from
+  // the server on every request must not re-render every consumer of this context.
   const stable = useMemo(
-    () => toClientEndatixConfig({ apiBaseUrl, extensionsEnabled }),
-    [apiBaseUrl, extensionsEnabled],
+    () =>
+      toClientEndatixConfig({
+        apiBaseUrl,
+        extensionsEnabled,
+        recaptchaSiteKey,
+        posthogKey,
+        posthogHost,
+        posthogUiHost,
+        isDebugMode,
+        submitterPrimaryFilterLabel,
+        submitterGridProfileFields,
+      }),
+    [
+      apiBaseUrl,
+      extensionsEnabled,
+      recaptchaSiteKey,
+      posthogKey,
+      posthogHost,
+      posthogUiHost,
+      isDebugMode,
+      submitterPrimaryFilterLabel,
+      submitterGridProfileFields,
+    ],
   );
 
   hydrateBrowserEndatixConfig(stable);

--- a/env.d.ts
+++ b/env.d.ts
@@ -12,6 +12,22 @@ declare namespace NodeJS {
     // Experimental features
     ENDATIX_ENABLE_EXTENSIONS?: string;
 
+    // Public, request-time client config. Projected to the browser by
+    // `getClientEndatixConfig()` — deliberately NOT `NEXT_PUBLIC_*`, which Next inlines
+    // into the client bundle at build time and which therefore cannot be changed by a
+    // container env var. See features/config/client-endatix-config.ts.
+    /**
+     * SurveyJS Creator licence key.
+     */
+    ENDATIX_SURVEY_LICENSE_KEY?: string;
+    ENDATIX_RECAPTCHA_SITE_KEY?: string;
+    ENDATIX_POSTHOG_KEY?: string;
+    ENDATIX_POSTHOG_HOST?: string;
+    ENDATIX_POSTHOG_UI_HOST?: string;
+    ENDATIX_IS_DEBUG_MODE?: string;
+    ENDATIX_SUBMITTER_PRIMARY_FILTER_LABEL?: string;
+    ENDATIX_SUBMITTER_GRID_PROFILE_FIELDS?: string;
+
     // Session
     SESSION_SECRET?: string;
     SESSION_MAX_AGE_IN_MINUTES?: string;
@@ -31,6 +47,7 @@ declare namespace NodeJS {
     NEXT_FORMS_COOKIE_DURATION_DAYS?: string;
 
     // ReCaptcha
+    /** @deprecated Build-time inlined. Use ENDATIX_RECAPTCHA_SITE_KEY. */
     NEXT_PUBLIC_RECAPTCHA_SITE_KEY?: string;
 
     // Slack
@@ -76,7 +93,12 @@ declare namespace NodeJS {
     RESIZE_IMAGES_WIDTH?: string;
 
     // Public
+    /** @deprecated Build-time inlined. Use ENDATIX_SURVEY_LICENSE_KEY. */
     NEXT_PUBLIC_SLK?: string;
+    /** @deprecated Build-time inlined. Use ENDATIX_SUBMITTER_PRIMARY_FILTER_LABEL. */
+    NEXT_PUBLIC_SUBMITTER_PRIMARY_FILTER_LABEL?: string;
+    /** @deprecated Build-time inlined. Use ENDATIX_SUBMITTER_GRID_PROFILE_FIELDS. */
+    NEXT_PUBLIC_SUBMITTER_GRID_PROFILE_FIELDS?: string;
     NEXT_PUBLIC_NAME?: string;
 
     // Telemetry
@@ -86,8 +108,11 @@ declare namespace NodeJS {
     TELEMETRY_CONSOLE_FALLBACK?: string;
 
     // PostHog
+    /** @deprecated Build-time inlined. Use ENDATIX_POSTHOG_KEY. */
     NEXT_PUBLIC_POSTHOG_KEY?: string;
+    /** @deprecated Build-time inlined. Use ENDATIX_POSTHOG_HOST. */
     NEXT_PUBLIC_POSTHOG_HOST?: string;
+    /** @deprecated Build-time inlined. Use ENDATIX_POSTHOG_UI_HOST. */
     NEXT_PUBLIC_POSTHOG_UI_HOST?: string;
     ENABLE_POSTHOG_ADAPTER?: string;
 
@@ -99,6 +124,7 @@ declare namespace NodeJS {
     ENDATIX_RESOLVED_IMAGE_REMOTE_HOSTNAMES?: string;
 
     // Application settings
+    /** @deprecated Build-time inlined. Use ENDATIX_IS_DEBUG_MODE. */
     NEXT_PUBLIC_IS_DEBUG_MODE?: string; // Application-level debug flag
 
     // Hub maintenance (see docs — proxy rewrite + /maintenance page)

--- a/env.d.ts
+++ b/env.d.ts
@@ -16,10 +16,6 @@ declare namespace NodeJS {
     // `getClientEndatixConfig()` — deliberately NOT `NEXT_PUBLIC_*`, which Next inlines
     // into the client bundle at build time and which therefore cannot be changed by a
     // container env var. See features/config/client-endatix-config.ts.
-    /**
-     * SurveyJS Creator licence key.
-     */
-    ENDATIX_SURVEY_LICENSE_KEY?: string;
     ENDATIX_RECAPTCHA_SITE_KEY?: string;
     ENDATIX_POSTHOG_KEY?: string;
     ENDATIX_POSTHOG_HOST?: string;
@@ -27,6 +23,19 @@ declare namespace NodeJS {
     ENDATIX_IS_DEBUG_MODE?: string;
     ENDATIX_SUBMITTER_PRIMARY_FILTER_LABEL?: string;
     ENDATIX_SUBMITTER_GRID_PROFILE_FIELDS?: string;
+
+    /**
+     * SurveyJS Creator licence key. NOT part of the shared projection above: that object
+     * is serialised into the HTML of every page mounting AppProvider, including the
+     * anonymous public form routes. Read server-side and provided only to the
+     * authenticated shell, via SurveyLicenseProvider.
+     *
+     * Perpetual: the embedded date governs eligibility for updates and support, not the
+     * right to run, so an existing deployment keeps working. A new key is needed when
+     * upgrading the SurveyJS packages beyond the window it covers — and replacing it must
+     * be a config change, never an image rebuild.
+     */
+    ENDATIX_SURVEY_LICENSE_KEY?: string;
 
     // Session
     SESSION_SECRET?: string;

--- a/features/analytics/posthog/shared/config.ts
+++ b/features/analytics/posthog/shared/config.ts
@@ -1,6 +1,7 @@
 /**
  * PostHog configuration utilities
  */
+import { getIsomorphicEndatixConfig } from "@/features/config/client-endatix-config";
 import { PostHogConfig } from "./types";
 
 /**
@@ -12,7 +13,7 @@ export function isPostHogEnabled(config?: PostHogConfig): boolean {
     return config.enabled;
   }
 
-  return !!process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  return !!getIsomorphicEndatixConfig().posthogKey;
 }
 
 /**
@@ -32,19 +33,13 @@ export function isProduction(): boolean {
 }
 
 /**
- * Check if application debug mode is enabled
- * Uses NEXT_PUBLIC_IS_DEBUG_MODE environment variable if set, otherwise falls back to development mode
+ * Check if application debug mode is enabled.
+ * Uses ENDATIX_IS_DEBUG_MODE if set, otherwise falls back to the development build.
+ * The precedence lives in `readPublicEndatixEnv()` so server and browser agree.
  * @returns Whether debug mode is enabled
  */
 export function isDebugMode(): boolean {
-  // Check if NEXT_PUBLIC_IS_DEBUG_MODE is explicitly set
-  const debugMode = process.env.NEXT_PUBLIC_IS_DEBUG_MODE;
-  if (debugMode !== undefined) {
-    return debugMode === "true";
-  }
-
-  // Fall back to development mode check
-  return isDevelopment();
+  return getIsomorphicEndatixConfig().isDebugMode;
 }
 
 /**
@@ -67,13 +62,14 @@ export function createPostHogConfig(
  * @returns Default PostHog configuration
  */
 export function getDefaultPostHogConfig(): PostHogConfig {
-  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY || "";
+  const { posthogKey, posthogHost, posthogUiHost, isDebugMode } =
+    getIsomorphicEndatixConfig();
 
   return {
-    enabled: !!apiKey,
-    apiKey,
-    apiHost: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com",
-    uiHost: process.env.NEXT_PUBLIC_POSTHOG_UI_HOST || undefined,
-    debug: isDebugMode(),
+    enabled: !!posthogKey,
+    apiKey: posthogKey,
+    apiHost: posthogHost,
+    uiHost: posthogUiHost || undefined,
+    debug: isDebugMode,
   };
 }

--- a/features/config/__tests__/legacy-public-env.server.test.ts
+++ b/features/config/__tests__/legacy-public-env.server.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyLegacyPublicEnv } from "../legacy-public-env.server";
+
+const TOUCHED = [
+  "ENDATIX_SURVEY_LICENSE_KEY",
+  "ENDATIX_RECAPTCHA_SITE_KEY",
+  "ENDATIX_POSTHOG_HOST",
+  "ENDATIX_IS_DEBUG_MODE",
+  "NEXT_PUBLIC_SLK",
+  "NEXT_PUBLIC_RECAPTCHA_SITE_KEY",
+  "NEXT_PUBLIC_POSTHOG_HOST",
+  "NEXT_PUBLIC_IS_DEBUG_MODE",
+];
+
+describe("applyLegacyPublicEnv", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = Object.fromEntries(TOUCHED.map((key) => [key, process.env[key]]));
+    TOUCHED.forEach((key) => delete process.env[key]);
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("fills an unset current name from its deprecated counterpart", () => {
+    // Arrange
+    process.env.NEXT_PUBLIC_SLK = "legacy-licence";
+
+    // Act
+    const applied = applyLegacyPublicEnv();
+
+    // Assert
+    expect(process.env.ENDATIX_SURVEY_LICENSE_KEY).toBe("legacy-licence");
+    expect(applied).toContain("NEXT_PUBLIC_SLK -> ENDATIX_SURVEY_LICENSE_KEY");
+  });
+
+  it("never overwrites a current name that is already set", () => {
+    // Arrange
+    process.env.ENDATIX_RECAPTCHA_SITE_KEY = "current-key";
+    process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY = "legacy-key";
+
+    // Act
+    applyLegacyPublicEnv();
+
+    // Assert
+    expect(process.env.ENDATIX_RECAPTCHA_SITE_KEY).toBe("current-key");
+  });
+
+  it("treats an explicit current value equal to the default as set", () => {
+    // Guards the precedence bug the read-time merge had: a current value that happens to
+    // match the default must still win over a custom deprecated one.
+    // Arrange
+    process.env.ENDATIX_POSTHOG_HOST = "https://us.i.posthog.com";
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://legacy.posthog.example";
+
+    // Act
+    applyLegacyPublicEnv();
+
+    // Assert
+    expect(process.env.ENDATIX_POSTHOG_HOST).toBe("https://us.i.posthog.com");
+  });
+
+  it("treats a whitespace-only current value as unset", () => {
+    // Arrange
+    process.env.ENDATIX_IS_DEBUG_MODE = "   ";
+    process.env.NEXT_PUBLIC_IS_DEBUG_MODE = "true";
+
+    // Act
+    applyLegacyPublicEnv();
+
+    // Assert
+    expect(process.env.ENDATIX_IS_DEBUG_MODE).toBe("true");
+  });
+
+  it("is idempotent", () => {
+    // Arrange
+    process.env.NEXT_PUBLIC_SLK = "legacy-licence";
+
+    // Act
+    applyLegacyPublicEnv();
+    const secondRun = applyLegacyPublicEnv();
+
+    // Assert
+    expect(secondRun).toEqual([]);
+    expect(process.env.ENDATIX_SURVEY_LICENSE_KEY).toBe("legacy-licence");
+  });
+});

--- a/features/config/__tests__/no-build-time-client-config.test.ts
+++ b/features/config/__tests__/no-build-time-client-config.test.ts
@@ -1,0 +1,92 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+/**
+ * A `NEXT_PUBLIC_`-prefixed value is inlined into the client bundle at build time, so the
+ * only way to change one is to rebuild and redeploy the image. Everything public must
+ * therefore go through the request-time projection instead.
+ *
+ * Licence keys are the case this rule exists for: replacing one must always be a config
+ * change, never a rebuild.
+ */
+
+/** The two build-time reads that have no runtime equivalent, and the deprecation shim. */
+const ALLOWED_BUILD_TIME_READS = [
+  // basePath feeds next.config.ts, which Next resolves at build. No runtime equivalent.
+  "lib/hosting/base-path.ts",
+  "proxy.ts",
+  "features/forms/use-cases/create-form/resolve-default-create-folder.ts",
+  "features/auth/infrastructure/auth-logout.utils.ts",
+  // Deprecated fallbacks. Safe ONLY while no client component imports it — asserted below.
+  LEGACY_SERVER_MODULE(),
+];
+
+function LEGACY_SERVER_MODULE(): string {
+  return "features/config/legacy-public-env.server.ts";
+}
+
+/** `git grep` exits 1 when nothing matches, which is success here, not failure. */
+function gitGrepFiles(pattern: string): string[] {
+  let out: string;
+  try {
+    out = execFileSync(
+      "git",
+      ["grep", "-l", "--", pattern, "--", "*.ts", "*.tsx"],
+      { cwd: REPO_ROOT, encoding: "utf-8" },
+    );
+  } catch (error) {
+    const status = (error as { status?: number }).status;
+    if (status === 1) {
+      return [];
+    }
+    throw error;
+  }
+
+  return out
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((file) => !file.includes("__tests__") && !file.includes(".test."));
+}
+
+function isClientModule(file: string): boolean {
+  const out = execFileSync("git", ["show", `HEAD:${file}`], {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+  });
+  return /^\s*["']use client["']/m.test(out);
+}
+
+describe("public client config stays request-time", () => {
+  it("has no build-time env reads outside the documented exceptions", () => {
+    const offenders = gitGrepFiles("process\\.env\\.NEXT_PUBLIC_").filter(
+      (file) => !ALLOWED_BUILD_TIME_READS.includes(file),
+    );
+
+    expect(
+      offenders,
+      "These files read a NEXT_PUBLIC_-prefixed env var, which Next inlines at build " +
+        "time. Add the value to ClientEndatixConfig and read it from the request-time " +
+        "projection instead. See features/config/client-endatix-config.ts.",
+    ).toEqual([]);
+  });
+
+  it("keeps the deprecated fallbacks out of every client-reachable module", () => {
+    // The exemption above is only sound while this module stays server-side: one import
+    // from a "use client" file is enough for Next to inline every literal inside it.
+    const importers = gitGrepFiles("legacy-public-env.server").filter(
+      (file) => file !== LEGACY_SERVER_MODULE(),
+    );
+    const clientImporters = importers.filter(isClientModule);
+
+    expect(
+      clientImporters,
+      `${LEGACY_SERVER_MODULE()} is imported by a client component, so its deprecated ` +
+        "NEXT_PUBLIC_-prefixed reads are now inlined into the browser bundle. Read them " +
+        "on the server and pass the value down instead.",
+    ).toEqual([]);
+  });
+});

--- a/features/config/client-endatix-config.ts
+++ b/features/config/client-endatix-config.ts
@@ -1,19 +1,44 @@
 /**
- * Browser-safe Endatix settings. Origin URL and a boolean only — no secrets,
- * storage keys, or auth. Safe to send to the client.
+ * Browser-safe Endatix settings. Public, non-secret values only — no storage keys,
+ * no auth secrets. Safe to send to the client.
  *
- * React trees read this via {@link EndatixConfigProvider}. Non-React
- * SurveyJS fetchers read {@link getBrowserEndatixConfig} (they cannot use a hook).
+ * Every field here is resolved at REQUEST time, never inlined at build time. That is the
+ * point of this module: a value baked into the client bundle can only be changed by
+ * rebuilding and redeploying the image, which breaks promote-the-same-artifact releases.
+ *
+ * Licence keys in particular must always be replaceable at runtime — swapping one should be
+ * a config change, never a rebuild. That is a standing rule for any licence this project
+ * carries, not a property of one vendor's terms.
+ *
+ * React trees read this via {@link EndatixConfigProvider}. Non-React SurveyJS fetchers and
+ * isomorphic modules read {@link getIsomorphicEndatixConfig}.
  */
 
 export interface ClientEndatixConfig {
   readonly apiBaseUrl: string;
   readonly extensionsEnabled: boolean;
+  readonly recaptchaSiteKey: string;
+  readonly posthogKey: string;
+  readonly posthogHost: string;
+  readonly posthogUiHost: string;
+  readonly isDebugMode: boolean;
+  readonly submitterPrimaryFilterLabel: string;
+  readonly submitterGridProfileFields: string;
 }
+
+export const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+export const DEFAULT_SUBMITTER_PRIMARY_FILTER_LABEL = "Submitter";
 
 export const EMPTY_CLIENT_ENDATIX_CONFIG: ClientEndatixConfig = Object.freeze({
   apiBaseUrl: "",
   extensionsEnabled: false,
+  recaptchaSiteKey: "",
+  posthogKey: "",
+  posthogHost: DEFAULT_POSTHOG_HOST,
+  posthogUiHost: "",
+  isDebugMode: false,
+  submitterPrimaryFilterLabel: DEFAULT_SUBMITTER_PRIMARY_FILTER_LABEL,
+  submitterGridProfileFields: "",
 });
 
 let browserConfig: ClientEndatixConfig = EMPTY_CLIENT_ENDATIX_CONFIG;
@@ -25,9 +50,67 @@ export function toClientEndatixConfig(
   value: ClientEndatixConfig,
 ): ClientEndatixConfig {
   return Object.freeze({
-    apiBaseUrl: value.apiBaseUrl,
+    apiBaseUrl: value.apiBaseUrl ?? "",
     extensionsEnabled: value.extensionsEnabled === true,
+    recaptchaSiteKey: value.recaptchaSiteKey ?? "",
+    posthogKey: value.posthogKey ?? "",
+    posthogHost: value.posthogHost || DEFAULT_POSTHOG_HOST,
+    posthogUiHost: value.posthogUiHost ?? "",
+    isDebugMode: value.isDebugMode === true,
+    // Defaulted, not passed through: a partial or legacy object would otherwise yield
+    // undefined here, and `submitterGridProfileFields.split(",")` would throw.
+    submitterPrimaryFilterLabel:
+      value.submitterPrimaryFilterLabel ||
+      DEFAULT_SUBMITTER_PRIMARY_FILTER_LABEL,
+    submitterGridProfileFields: value.submitterGridProfileFields ?? "",
   });
+}
+
+/** First non-empty value, after trimming. `undefined` and blank strings are skipped. */
+function firstNonEmpty(...values: (string | undefined)[]): string {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return "";
+}
+
+/**
+ * The public slice of the runtime environment.
+ *
+ * `ENDATIX_*` only. This module is imported by client components, and Next inlines any
+ * `NEXT_PUBLIC_`-prefixed env literal it finds in a client-reachable module at build time —
+ * so the deprecated names live in `legacy-public-env.server.ts`, which no client component
+ * imports, and are merged in by `getClientEndatixConfig()` on the server.
+ *
+ * Non-`NEXT_PUBLIC_` reads are safe here: Next does not inline them, so in the browser they
+ * simply resolve to `undefined` and the hydrated projection supplies the value instead.
+ */
+export function readPublicEndatixEnv(): Omit<
+  ClientEndatixConfig,
+  "apiBaseUrl" | "extensionsEnabled"
+> {
+  const debugOverride = firstNonEmpty(process.env.ENDATIX_IS_DEBUG_MODE);
+
+  return {
+    recaptchaSiteKey: firstNonEmpty(process.env.ENDATIX_RECAPTCHA_SITE_KEY),
+    posthogKey: firstNonEmpty(process.env.ENDATIX_POSTHOG_KEY),
+    posthogHost:
+      firstNonEmpty(process.env.ENDATIX_POSTHOG_HOST) || DEFAULT_POSTHOG_HOST,
+    posthogUiHost: firstNonEmpty(process.env.ENDATIX_POSTHOG_UI_HOST),
+    // Explicit override wins; otherwise debug follows the development build.
+    isDebugMode: debugOverride
+      ? debugOverride === "true"
+      : process.env.NODE_ENV === "development",
+    submitterPrimaryFilterLabel:
+      firstNonEmpty(process.env.ENDATIX_SUBMITTER_PRIMARY_FILTER_LABEL) ||
+      DEFAULT_SUBMITTER_PRIMARY_FILTER_LABEL,
+    submitterGridProfileFields: firstNonEmpty(
+      process.env.ENDATIX_SUBMITTER_GRID_PROFILE_FIELDS,
+    ),
+  };
 }
 
 /**
@@ -35,6 +118,31 @@ export function toClientEndatixConfig(
  */
 export function getBrowserEndatixConfig(): ClientEndatixConfig {
   return browserConfig;
+}
+
+/**
+ * Same values on both sides of the boundary, for modules that run in either.
+ *
+ * In the browser this is the projection {@link EndatixConfigProvider} hydrated during
+ * render. On the server it is a direct runtime `process.env` read — deliberately not the
+ * module-level `browserConfig`, which SSR of a client component would otherwise share
+ * across requests.
+ *
+ * `apiBaseUrl`/`extensionsEnabled` are omitted on the server path; server callers that need
+ * those use `getClientEndatixConfig()` from `@/features/config`, which resolves the full
+ * object including API settings.
+ */
+export function getIsomorphicEndatixConfig(): ClientEndatixConfig {
+  if (typeof window !== "undefined") {
+    return browserConfig;
+  }
+  return Object.freeze({
+    apiBaseUrl: "",
+    extensionsEnabled: false,
+    ...readPublicEndatixEnv(),
+  });
+  // NOTE: the server branch does not apply the deprecated NEXT_PUBLIC_* fallbacks — those
+  // are server-module-only and reach the browser through the hydrated projection instead.
 }
 
 /** Called from {@link EndatixConfigProvider} during render (before children). */

--- a/features/config/legacy-public-env.server.ts
+++ b/features/config/legacy-public-env.server.ts
@@ -1,0 +1,81 @@
+/**
+ * Deprecated `NEXT_PUBLIC_*` names, kept so an existing self-hosted `.env` keeps working
+ * across the rename to `ENDATIX_*`.
+ *
+ * SERVER ONLY — and the file name is the contract. Next's DefinePlugin inlines any
+ * `process.env.NEXT_PUBLIC_*` literal it finds in a module that is reachable from a client
+ * component, which is exactly the build-time baking this feature exists to remove. Keeping
+ * these reads in a module that no client component imports is what makes them a runtime
+ * lookup. `no-build-time-client-config.test.ts` enforces both halves.
+ *
+ * Delete this file once the deprecation window closes.
+ */
+
+import { DEFAULT_POSTHOG_HOST } from "./client-endatix-config";
+
+/** First non-empty value, after trimming. */
+function firstNonEmpty(...values: (string | undefined)[]): string {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return "";
+}
+
+export interface LegacyPublicEnv {
+  readonly surveyLicenseKey: string;
+  readonly recaptchaSiteKey: string;
+  readonly posthogKey: string;
+  readonly posthogHost: string;
+  readonly posthogUiHost: string;
+  readonly debugMode: string;
+  readonly submitterPrimaryFilterLabel: string;
+  readonly submitterGridProfileFields: string;
+}
+
+export function readLegacyPublicEnv(): LegacyPublicEnv {
+  return {
+    surveyLicenseKey: firstNonEmpty(process.env.NEXT_PUBLIC_SLK),
+    recaptchaSiteKey: firstNonEmpty(process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY),
+    posthogKey: firstNonEmpty(process.env.NEXT_PUBLIC_POSTHOG_KEY),
+    posthogHost: firstNonEmpty(process.env.NEXT_PUBLIC_POSTHOG_HOST),
+    posthogUiHost: firstNonEmpty(process.env.NEXT_PUBLIC_POSTHOG_UI_HOST),
+    debugMode: firstNonEmpty(process.env.NEXT_PUBLIC_IS_DEBUG_MODE),
+    submitterPrimaryFilterLabel: firstNonEmpty(
+      process.env.NEXT_PUBLIC_SUBMITTER_PRIMARY_FILTER_LABEL,
+    ),
+    submitterGridProfileFields: firstNonEmpty(
+      process.env.NEXT_PUBLIC_SUBMITTER_GRID_PROFILE_FIELDS,
+    ),
+  };
+}
+
+/**
+ * The SurveyJS Creator licence key, read on the server.
+ *
+ * Deliberately NOT part of {@link ClientEndatixConfig}: that projection is serialised into
+ * the HTML of every page that mounts `AppProvider`, including the anonymous public form
+ * routes, and a respondent filling in a form has no use for a commercial licence key. Only
+ * the authenticated designer surface receives it, via `SurveyLicenseProvider`.
+ */
+export function getServerPostHogConfig(): {
+  readonly key: string;
+  readonly host: string;
+} {
+  const legacy = readLegacyPublicEnv();
+  return {
+    key: firstNonEmpty(process.env.ENDATIX_POSTHOG_KEY, legacy.posthogKey),
+    host:
+      firstNonEmpty(process.env.ENDATIX_POSTHOG_HOST, legacy.posthogHost) ||
+      DEFAULT_POSTHOG_HOST,
+  };
+}
+
+export function getSurveyLicenseKey(): string {
+  return firstNonEmpty(
+    process.env.ENDATIX_SURVEY_LICENSE_KEY,
+    process.env.NEXT_PUBLIC_SLK,
+  );
+}

--- a/features/config/legacy-public-env.server.ts
+++ b/features/config/legacy-public-env.server.ts
@@ -1,81 +1,70 @@
 /**
- * Deprecated `NEXT_PUBLIC_*` names, kept so an existing self-hosted `.env` keeps working
- * across the rename to `ENDATIX_*`.
+ * Deprecated `NEXT_PUBLIC_*` names, normalised into their `ENDATIX_*` equivalents once at
+ * server startup so an existing self-hosted `.env` keeps working across the rename.
  *
  * SERVER ONLY — and the file name is the contract. Next's DefinePlugin inlines any
- * `process.env.NEXT_PUBLIC_*` literal it finds in a module that is reachable from a client
+ * `NEXT_PUBLIC_`-prefixed env literal it finds in a module reachable from a client
  * component, which is exactly the build-time baking this feature exists to remove. Keeping
  * these reads in a module that no client component imports is what makes them a runtime
  * lookup. `no-build-time-client-config.test.ts` enforces both halves.
  *
+ * Normalising at boot rather than merging at read time is deliberate: every consumer then
+ * reads one name from one place, so there is no current-versus-legacy precedence to get
+ * wrong, and server-rendered client components see the same values the browser will.
+ *
  * Delete this file once the deprecation window closes.
  */
 
-import { DEFAULT_POSTHOG_HOST } from "./client-endatix-config";
+/** Current name -> the deprecated name it supersedes. */
+const RENAMES: ReadonlyArray<readonly [string, string]> = [
+  ["ENDATIX_SURVEY_LICENSE_KEY", "NEXT_PUBLIC_SLK"],
+  ["ENDATIX_RECAPTCHA_SITE_KEY", "NEXT_PUBLIC_RECAPTCHA_SITE_KEY"],
+  ["ENDATIX_POSTHOG_KEY", "NEXT_PUBLIC_POSTHOG_KEY"],
+  ["ENDATIX_POSTHOG_HOST", "NEXT_PUBLIC_POSTHOG_HOST"],
+  ["ENDATIX_POSTHOG_UI_HOST", "NEXT_PUBLIC_POSTHOG_UI_HOST"],
+  ["ENDATIX_IS_DEBUG_MODE", "NEXT_PUBLIC_IS_DEBUG_MODE"],
+  [
+    "ENDATIX_SUBMITTER_PRIMARY_FILTER_LABEL",
+    "NEXT_PUBLIC_SUBMITTER_PRIMARY_FILTER_LABEL",
+  ],
+  [
+    "ENDATIX_SUBMITTER_GRID_PROFILE_FIELDS",
+    "NEXT_PUBLIC_SUBMITTER_GRID_PROFILE_FIELDS",
+  ],
+];
 
-/** First non-empty value, after trimming. */
-function firstNonEmpty(...values: (string | undefined)[]): string {
-  for (const value of values) {
-    const trimmed = value?.trim();
-    if (trimmed) {
-      return trimmed;
+/**
+ * Fills any unset `ENDATIX_*` name from its deprecated counterpart. Idempotent, and the
+ * current name always wins — a blank or whitespace-only value counts as unset on both
+ * sides, matching how `readPublicEndatixEnv()` normalises.
+ *
+ * @returns the names that were filled from a deprecated variable, for logging.
+ */
+export function applyLegacyPublicEnv(): string[] {
+  const applied: string[] = [];
+
+  for (const [current, deprecated] of RENAMES) {
+    if (process.env[current]?.trim()) {
+      continue;
+    }
+    const legacyValue = process.env[deprecated]?.trim();
+    if (legacyValue) {
+      process.env[current] = legacyValue;
+      applied.push(`${deprecated} -> ${current}`);
     }
   }
-  return "";
-}
 
-export interface LegacyPublicEnv {
-  readonly surveyLicenseKey: string;
-  readonly recaptchaSiteKey: string;
-  readonly posthogKey: string;
-  readonly posthogHost: string;
-  readonly posthogUiHost: string;
-  readonly debugMode: string;
-  readonly submitterPrimaryFilterLabel: string;
-  readonly submitterGridProfileFields: string;
-}
-
-export function readLegacyPublicEnv(): LegacyPublicEnv {
-  return {
-    surveyLicenseKey: firstNonEmpty(process.env.NEXT_PUBLIC_SLK),
-    recaptchaSiteKey: firstNonEmpty(process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY),
-    posthogKey: firstNonEmpty(process.env.NEXT_PUBLIC_POSTHOG_KEY),
-    posthogHost: firstNonEmpty(process.env.NEXT_PUBLIC_POSTHOG_HOST),
-    posthogUiHost: firstNonEmpty(process.env.NEXT_PUBLIC_POSTHOG_UI_HOST),
-    debugMode: firstNonEmpty(process.env.NEXT_PUBLIC_IS_DEBUG_MODE),
-    submitterPrimaryFilterLabel: firstNonEmpty(
-      process.env.NEXT_PUBLIC_SUBMITTER_PRIMARY_FILTER_LABEL,
-    ),
-    submitterGridProfileFields: firstNonEmpty(
-      process.env.NEXT_PUBLIC_SUBMITTER_GRID_PROFILE_FIELDS,
-    ),
-  };
+  return applied;
 }
 
 /**
  * The SurveyJS Creator licence key, read on the server.
  *
- * Deliberately NOT part of {@link ClientEndatixConfig}: that projection is serialised into
- * the HTML of every page that mounts `AppProvider`, including the anonymous public form
- * routes, and a respondent filling in a form has no use for a commercial licence key. Only
- * the authenticated designer surface receives it, via `SurveyLicenseProvider`.
+ * Deliberately NOT part of `ClientEndatixConfig`: that projection is serialised into the
+ * HTML of every page that mounts `AppProvider`, including the anonymous public form routes,
+ * and a respondent filling in a form has no use for a commercial licence key. Only the
+ * authenticated designer surface receives it, via `SurveyLicenseProvider`.
  */
-export function getServerPostHogConfig(): {
-  readonly key: string;
-  readonly host: string;
-} {
-  const legacy = readLegacyPublicEnv();
-  return {
-    key: firstNonEmpty(process.env.ENDATIX_POSTHOG_KEY, legacy.posthogKey),
-    host:
-      firstNonEmpty(process.env.ENDATIX_POSTHOG_HOST, legacy.posthogHost) ||
-      DEFAULT_POSTHOG_HOST,
-  };
-}
-
 export function getSurveyLicenseKey(): string {
-  return firstNonEmpty(
-    process.env.ENDATIX_SURVEY_LICENSE_KEY,
-    process.env.NEXT_PUBLIC_SLK,
-  );
+  return process.env.ENDATIX_SURVEY_LICENSE_KEY?.trim() ?? "";
 }

--- a/features/config/resolve-endatix-settings.ts
+++ b/features/config/resolve-endatix-settings.ts
@@ -17,12 +17,9 @@ import {
   type ExperimentalConfig,
 } from "./experimental-config";
 import {
-  DEFAULT_POSTHOG_HOST,
-  DEFAULT_SUBMITTER_PRIMARY_FILTER_LABEL,
   readPublicEndatixEnv,
   type ClientEndatixConfig,
 } from "./client-endatix-config";
-import { readLegacyPublicEnv } from "./legacy-public-env.server";
 
 const DEFAULT_API_PREFIX = "/api";
 
@@ -217,33 +214,12 @@ export function getRuntimeStorageProfile(): StorageProfileSlice {
 export function getClientEndatixConfig(): ClientEndatixConfig {
   const resolved = resolveEndatixSettings({ source: "runtime" });
 
-  const current = readPublicEndatixEnv();
-  // Deprecated NEXT_PUBLIC_-prefixed names, applied only where the current name is unset.
-  // Server-side, so nothing here is inlined into the client bundle.
-  const legacy = readLegacyPublicEnv();
-
   return Object.freeze({
     apiBaseUrl: resolved.mergedApiConfig?.apiUrl ?? "",
     extensionsEnabled: resolved.mergedExperimentalConfig.extensions,
-    recaptchaSiteKey: current.recaptchaSiteKey || legacy.recaptchaSiteKey,
-    posthogKey: current.posthogKey || legacy.posthogKey,
-    posthogHost:
-      current.posthogHost !== DEFAULT_POSTHOG_HOST
-        ? current.posthogHost
-        : legacy.posthogHost || DEFAULT_POSTHOG_HOST,
-    posthogUiHost: current.posthogUiHost || legacy.posthogUiHost,
-    isDebugMode:
-      process.env.ENDATIX_IS_DEBUG_MODE || !legacy.debugMode
-        ? current.isDebugMode
-        : legacy.debugMode === "true",
-    submitterPrimaryFilterLabel:
-      current.submitterPrimaryFilterLabel !==
-      DEFAULT_SUBMITTER_PRIMARY_FILTER_LABEL
-        ? current.submitterPrimaryFilterLabel
-        : legacy.submitterPrimaryFilterLabel ||
-          DEFAULT_SUBMITTER_PRIMARY_FILTER_LABEL,
-    submitterGridProfileFields:
-      current.submitterGridProfileFields || legacy.submitterGridProfileFields,
+    // Deprecated NEXT_PUBLIC_-prefixed names were folded into these at server startup by
+    // applyLegacyPublicEnv(), so there is exactly one source to read here.
+    ...readPublicEndatixEnv(),
   });
 }
 

--- a/features/config/resolve-endatix-settings.ts
+++ b/features/config/resolve-endatix-settings.ts
@@ -16,7 +16,13 @@ import {
   getExperimentalConfig,
   type ExperimentalConfig,
 } from "./experimental-config";
-import type { ClientEndatixConfig } from "./client-endatix-config";
+import {
+  DEFAULT_POSTHOG_HOST,
+  DEFAULT_SUBMITTER_PRIMARY_FILTER_LABEL,
+  readPublicEndatixEnv,
+  type ClientEndatixConfig,
+} from "./client-endatix-config";
+import { readLegacyPublicEnv } from "./legacy-public-env.server";
 
 const DEFAULT_API_PREFIX = "/api";
 
@@ -211,9 +217,33 @@ export function getRuntimeStorageProfile(): StorageProfileSlice {
 export function getClientEndatixConfig(): ClientEndatixConfig {
   const resolved = resolveEndatixSettings({ source: "runtime" });
 
+  const current = readPublicEndatixEnv();
+  // Deprecated NEXT_PUBLIC_-prefixed names, applied only where the current name is unset.
+  // Server-side, so nothing here is inlined into the client bundle.
+  const legacy = readLegacyPublicEnv();
+
   return Object.freeze({
     apiBaseUrl: resolved.mergedApiConfig?.apiUrl ?? "",
     extensionsEnabled: resolved.mergedExperimentalConfig.extensions,
+    recaptchaSiteKey: current.recaptchaSiteKey || legacy.recaptchaSiteKey,
+    posthogKey: current.posthogKey || legacy.posthogKey,
+    posthogHost:
+      current.posthogHost !== DEFAULT_POSTHOG_HOST
+        ? current.posthogHost
+        : legacy.posthogHost || DEFAULT_POSTHOG_HOST,
+    posthogUiHost: current.posthogUiHost || legacy.posthogUiHost,
+    isDebugMode:
+      process.env.ENDATIX_IS_DEBUG_MODE || !legacy.debugMode
+        ? current.isDebugMode
+        : legacy.debugMode === "true",
+    submitterPrimaryFilterLabel:
+      current.submitterPrimaryFilterLabel !==
+      DEFAULT_SUBMITTER_PRIMARY_FILTER_LABEL
+        ? current.submitterPrimaryFilterLabel
+        : legacy.submitterPrimaryFilterLabel ||
+          DEFAULT_SUBMITTER_PRIMARY_FILTER_LABEL,
+    submitterGridProfileFields:
+      current.submitterGridProfileFields || legacy.submitterGridProfileFields,
   });
 }
 

--- a/features/config/survey-license-provider.tsx
+++ b/features/config/survey-license-provider.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+/**
+ * The SurveyJS Creator licence key, scoped to the authenticated application shell.
+ *
+ * Separate from `EndatixConfigProvider` on purpose. That projection is mounted by the
+ * public layouts too, so anything added to it is serialised into the HTML of every
+ * anonymous form page. The licence key is a commercial credential with no purpose in the
+ * public form runtime, so it is provided only where the designer and preview surfaces live.
+ */
+const SurveyLicenseContext = createContext<string>("");
+
+interface SurveyLicenseProviderProps {
+  value: string;
+  children: ReactNode;
+}
+
+export function SurveyLicenseProvider({
+  value,
+  children,
+}: Readonly<SurveyLicenseProviderProps>) {
+  return (
+    <SurveyLicenseContext.Provider value={value}>
+      {children}
+    </SurveyLicenseContext.Provider>
+  );
+}
+
+/** Empty string when no licence is configured, or outside the authenticated shell. */
+export function useSurveyLicenseKey(): string {
+  return useContext(SurveyLicenseContext);
+}

--- a/features/forms/ui/preview/preview-form-container.tsx
+++ b/features/forms/ui/preview/preview-form-container.tsx
@@ -1,17 +1,22 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { useSurveyLicenseKey } from "@/features/config/survey-license-provider";
 
-const PreviewForm = dynamic(() => import("@/features/forms/ui/preview/preview-form"), {
-  ssr: false,
-});
+const PreviewForm = dynamic(
+  () => import("@/features/forms/ui/preview/preview-form"),
+  {
+    ssr: false,
+  },
+);
 
 interface PreviewFormContainerProps {
   model: string;
 }
 
 const PreviewFormContainer = ({ model }: PreviewFormContainerProps) => {
-  return <PreviewForm model={model} slkVal={process.env.NEXT_PUBLIC_SLK} />;
+  const surveyLicenseKey = useSurveyLicenseKey();
+  return <PreviewForm model={model} slkVal={surveyLicenseKey} />;
 };
 
 export default PreviewFormContainer;

--- a/features/recaptcha/recaptcha-config.ts
+++ b/features/recaptcha/recaptcha-config.ts
@@ -1,4 +1,7 @@
-const RECAPTCHA_SITE_KEY = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY!;
+import { getIsomorphicEndatixConfig } from "@/features/config/client-endatix-config";
+
+/** Request-time, never inlined — see `client-endatix-config.ts`. */
+const siteKey = () => getIsomorphicEndatixConfig().recaptchaSiteKey;
 
 const RECAPTCHA_ACTIONS = {
   SUBMIT_FORM: "submit_form",
@@ -9,16 +12,16 @@ const RECAPTCHA_ACTIONS = {
 };
 
 const isReCaptchaEnabled = () => {
-  return RECAPTCHA_SITE_KEY !== "";
+  return siteKey() !== "";
 };
-
-const RECAPTCHA_JS_URL = `https://www.google.com/recaptcha/api.js?render=${RECAPTCHA_SITE_KEY}`;
 
 export const recaptchaConfig = {
   /**
-   * reCAPTCHA site key
+   * reCAPTCHA site key. A getter, not a const: the value is only known at request time.
    */
-  SITE_KEY: RECAPTCHA_SITE_KEY,
+  get SITE_KEY(): string {
+    return siteKey();
+  },
 
   /**
    * reCAPTCHA actions
@@ -26,12 +29,18 @@ export const recaptchaConfig = {
   ACTIONS: RECAPTCHA_ACTIONS,
 
   /**
-   * Check if reCAPTCHA is enabled
+   * Check if reCAPTCHA is enabled.
+   *
+   * Previously compared a non-null-asserted env read to "", so an UNSET key read as
+   * ENABLED and loaded the reCAPTCHA script with `render=undefined`.
+   * The config normalises a missing key to "", so unset now correctly reads as disabled.
    */
   isReCaptchaEnabled,
 
   /**
    * reCAPTCHA JS URL
    */
-  JS_URL: RECAPTCHA_JS_URL,
+  get JS_URL(): string {
+    return `https://www.google.com/recaptcha/api.js?render=${siteKey()}`;
+  },
 };

--- a/features/submissions/ui/table/columns-definition.tsx
+++ b/features/submissions/ui/table/columns-definition.tsx
@@ -1,4 +1,5 @@
 import { TruncatedId } from "@/components/common/truncated-id";
+import { getIsomorphicEndatixConfig } from "@/features/config/client-endatix-config";
 import { DefinitionField, Submission } from "@/lib/endatix-api";
 import {
   QUESTION_REGISTRY,
@@ -32,9 +33,6 @@ interface SubmissionSystemColumnsOptions {
   onSubmitterEmailFilterChange?: (value: string) => void;
 }
 
-const submitterPrimaryFilterLabel =
-  process.env.NEXT_PUBLIC_SUBMITTER_PRIMARY_FILTER_LABEL?.trim() || "Submitter";
-
 /** Icon/action columns stay compact; text columns keep a min width and share leftover space. */
 const COMPACT_COLUMN = "w-12 whitespace-nowrap";
 const FLUID_COLUMN = "min-w-[6.5rem]";
@@ -47,6 +45,10 @@ export function buildSubmissionSystemColumns({
   submitterEmailFilter = "",
   onSubmitterEmailFilterChange,
 }: SubmissionSystemColumnsOptions = {}): ColumnDef<ParsedSubmission>[] {
+  // Read per call, not at module init: a build-inlined label cannot be changed per
+  // deployment, and this builder is invoked from a component after config hydration.
+  const { submitterPrimaryFilterLabel } = getIsomorphicEndatixConfig();
+
   return [
     {
       id: "actions",
@@ -321,13 +323,11 @@ function buildSubmitterProfileColumns({
 }
 
 function getSubmitterGridProfileFields(): string[] {
-  return (process.env.NEXT_PUBLIC_SUBMITTER_GRID_PROFILE_FIELDS ?? "")
-    .split(",")
+  return getIsomorphicEndatixConfig()
+    .submitterGridProfileFields.split(",")
     .map((field) => field.trim())
     .filter(Boolean);
 }
-
-export const COLUMNS_DEFINITION = buildSubmissionSystemColumns();
 
 export function buildSubmissionDataColumns(
   fields: DefinitionField[],

--- a/features/submissions/ui/table/index.ts
+++ b/features/submissions/ui/table/index.ts
@@ -15,7 +15,6 @@ export {
 export {
   buildSubmissionDataColumns,
   buildSubmissionSystemColumns,
-  COLUMNS_DEFINITION,
   humanizeFieldName,
   type ParsedSubmission,
 } from "./columns-definition";

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -60,6 +60,27 @@ spec:
             - name: ENDATIX_ENABLE_EXTENSIONS
               value: {{ .Values.experimental.extensions | quote }}
 
+            # Public client config. Request-time, projected to the browser per request —
+            # changing any of these is a `helm upgrade`, never an image rebuild.
+            - name: ENDATIX_SURVEY_LICENSE_KEY
+              value: {{ .Values.clientConfig.surveyLicenseKey | quote }}
+            - name: ENDATIX_RECAPTCHA_SITE_KEY
+              value: {{ .Values.clientConfig.recaptchaSiteKey | quote }}
+            - name: ENDATIX_SUBMITTER_PRIMARY_FILTER_LABEL
+              value: {{ .Values.clientConfig.submitterPrimaryFilterLabel | quote }}
+            - name: ENDATIX_SUBMITTER_GRID_PROFILE_FIELDS
+              value: {{ .Values.clientConfig.submitterGridProfileFields | quote }}
+            - name: ENDATIX_IS_DEBUG_MODE
+              value: {{ .Values.clientConfig.debugMode | quote }}
+
+            # Product analytics — empty key disables PostHog.
+            - name: ENDATIX_POSTHOG_KEY
+              value: {{ .Values.analytics.posthogKey | quote }}
+            - name: ENDATIX_POSTHOG_HOST
+              value: {{ .Values.analytics.posthogHost | quote }}
+            - name: ENDATIX_POSTHOG_UI_HOST
+              value: {{ .Values.analytics.posthogUiHost | quote }}
+
             # Auth
             - name: SESSION_SECRET
               valueFrom:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,6 +21,28 @@ api:
   # Path prefix in baseUrl mode only. Hub defaults to /api if this is empty.
   apiPrefix: "/api"
 
+# Public, request-time client config. Projected to the browser per request, so these can
+# be changed with a `helm upgrade` — no image rebuild. Licence keys especially: replacing
+# one must always be a config change.
+clientConfig:
+  # SurveyJS Creator licence key. Empty = unlicensed Creator (non-commercial banner).
+  # Perpetual, so a running deployment keeps working; replace this when upgrading the
+  # SurveyJS packages past the subscription window the current key covers.
+  surveyLicenseKey: ""
+  # Google reCAPTCHA site key. Empty disables reCAPTCHA.
+  recaptchaSiteKey: ""
+  # Override the "Submitter" column label and add submitter profile grid columns.
+  submitterPrimaryFilterLabel: ""
+  submitterGridProfileFields: ""
+  # Set to "true"/"false" to force debug mode; empty follows the build type.
+  debugMode: ""
+
+analytics:
+  # PostHog. Empty key disables product analytics entirely.
+  posthogKey: ""
+  posthogHost: "https://us.i.posthog.com"
+  posthogUiHost: ""
+
 experimental:
   # SurveyJS extensions (data-list questions, custom widgets). Defaults on so a
   # stock chart deploy registers and fetches data lists without a hidden switch.

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,12 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Before anything reads config: normalise the deprecated NEXT_PUBLIC_-prefixed
+    // names into their ENDATIX_ equivalents, so server-rendered client components see
+    // the same values the browser will get from the hydrated projection.
+    const { applyLegacyPublicEnv } =
+      await import("@/features/config/legacy-public-env.server");
+    applyLegacyPublicEnv();
+
     // Server-side counterpart to instrumentation-client.ts: survey components
     // are client components, but Next still renders them on the server, so the
     // sanitizer has to be installed in both runtimes.

--- a/lib/feature-flags/__tests__/factories/flag-factory-provider.test.ts
+++ b/lib/feature-flags/__tests__/factories/flag-factory-provider.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/features/auth", () => ({
   }),
 }));
 
-process.env.NEXT_PUBLIC_POSTHOG_KEY = "test-key";
+process.env.ENDATIX_POSTHOG_KEY = "test-key";
 
 vi.mock("@flags-sdk/posthog", () => ({
   createPostHogAdapter: vi.fn(() => ({

--- a/lib/feature-flags/__tests__/index.test.ts
+++ b/lib/feature-flags/__tests__/index.test.ts
@@ -26,7 +26,7 @@ vi.mock("@/features/auth", () => ({
 describe("Feature Flags Module Exports", () => {
   beforeEach(() => {
     // Set PostHog API key for tests
-    process.env.NEXT_PUBLIC_POSTHOG_KEY = "test-key";
+    process.env.ENDATIX_POSTHOG_KEY = "test-key";
   });
 
   describe("main utilities", () => {

--- a/lib/feature-flags/factories/posthog-flag-factory.ts
+++ b/lib/feature-flags/factories/posthog-flag-factory.ts
@@ -1,7 +1,7 @@
 import { dedupe, flag } from "flags/next";
 import { createPostHogAdapter, PostHogEntities } from "@flags-sdk/posthog";
 import type { FlagFactory, FlagDefinition } from "./flag-factory.interface";
-import { getServerPostHogConfig } from "@/features/config/legacy-public-env.server";
+import { readPublicEndatixEnv } from "@/features/config/client-endatix-config";
 import { identify } from "../utils";
 import { Identify } from "flags";
 
@@ -18,12 +18,11 @@ export class PostHogFlagFactory implements FlagFactory {
   constructor() {
     // Server-only adapter, so read the runtime environment directly rather than through
     // the isomorphic accessor — that one branches on `typeof window`, which is defined
-    // under jsdom and would hand a server module the empty browser projection. Being
-    // server-side, it also honours the deprecated NEXT_PUBLIC_-prefixed name.
-    const { key, host } = getServerPostHogConfig();
+    // under jsdom and would hand a server module the empty browser projection.
+    const { posthogKey, posthogHost } = readPublicEndatixEnv();
     this.postHogAdapter = createPostHogAdapter({
-      postHogKey: key,
-      postHogOptions: { host },
+      postHogKey: posthogKey,
+      postHogOptions: { host: posthogHost },
     });
   }
 

--- a/lib/feature-flags/factories/posthog-flag-factory.ts
+++ b/lib/feature-flags/factories/posthog-flag-factory.ts
@@ -1,6 +1,7 @@
 import { dedupe, flag } from "flags/next";
 import { createPostHogAdapter, PostHogEntities } from "@flags-sdk/posthog";
 import type { FlagFactory, FlagDefinition } from "./flag-factory.interface";
+import { getServerPostHogConfig } from "@/features/config/legacy-public-env.server";
 import { identify } from "../utils";
 import { Identify } from "flags";
 
@@ -15,11 +16,14 @@ export class PostHogFlagFactory implements FlagFactory {
   private postHogAdapter: ReturnType<typeof createPostHogAdapter>;
 
   constructor() {
+    // Server-only adapter, so read the runtime environment directly rather than through
+    // the isomorphic accessor — that one branches on `typeof window`, which is defined
+    // under jsdom and would hand a server module the empty browser projection. Being
+    // server-side, it also honours the deprecated NEXT_PUBLIC_-prefixed name.
+    const { key, host } = getServerPostHogConfig();
     this.postHogAdapter = createPostHogAdapter({
-      postHogKey: process.env.NEXT_PUBLIC_POSTHOG_KEY!,
-      postHogOptions: {
-        host: "https://us.i.posthog.com",
-      },
+      postHogKey: key,
+      postHogOptions: { host },
     });
   }
 


### PR DESCRIPTION
## Description

Every `NEXT_PUBLIC_*` value is inlined into the client bundle at build time, so changing one means rebuilding and redeploying the image. That breaks the promote-the-same-artifact release model — and it means **a licence key can only be replaced by a rebuild**. Replacing one should be a config change.

The seam already existed: #874 built `getClientEndatixConfig()` to stop baking `ENDATIX_API_URL` into the bundle. This widens that request-time projection to carry the rest of the public config and routes every consumer through it.

| Was (build-time) | Now (request-time) |
|---|---|
| `NEXT_PUBLIC_SLK` | `ENDATIX_SURVEY_LICENSE_KEY` |
| `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` | `ENDATIX_RECAPTCHA_SITE_KEY` |
| `NEXT_PUBLIC_POSTHOG_{KEY,HOST,UI_HOST}` | `ENDATIX_POSTHOG_*` |
| `NEXT_PUBLIC_IS_DEBUG_MODE` | `ENDATIX_IS_DEBUG_MODE` |
| `NEXT_PUBLIC_SUBMITTER_{PRIMARY_FILTER_LABEL,GRID_PROFILE_FIELDS}` | `ENDATIX_SUBMITTER_*` |

**Not breaking for self-hosters.** The old names keep working as deprecated fallbacks, read only from `legacy-public-env.server.ts` — a module no client component imports, so they are never inlined.

### The licence key is scoped away from public pages

It is deliberately **not** in the shared projection. That object is serialised into the HTML of every page mounting `AppProvider`, including the seven anonymous public form layouts (`view`, `edit`, `embed`, `share`, `slack`, `maintenance`, `unauthorized`), and a respondent filling in a form has no use for a commercial credential. It is provided by `SurveyLicenseProvider`, mounted only by the authenticated `(main)` shell.

Anything added to `ClientEndatixConfig` in future inherits that public exposure — worth checking before extending it.

### Drive-by fix

`isReCaptchaEnabled()` compared a non-null-asserted env read against `""`, so an **unset** site key read as *enabled* and loaded the reCAPTCHA script with `render=undefined`. A missing key now normalises to `""` and correctly reads as disabled.

### Chart

Values exposed under `clientConfig` and `analytics`, so replacing a key is a `helm upgrade`.

## Test plan

- [x] `vitest` — 424 files pass; the 3 that fail (data-lists CSV inference, 2 telemetry strategies) fail identically on clean `main`
- [x] `tsc -p tsconfig.next.json` — clean apart from 3 pre-existing errors in `otel-telemetry-strategy.ts` / `next.config.ts`
- [x] `eslint` and `prettier --check` clean on all changed files
- [x] `helm lint` passes; `helm template` renders the new values
- [x] Guard test verified in both directions — passes clean, fails when a `NEXT_PUBLIC_` read is reintroduced
- [ ] Published image: change the licence key via Helm without a rebuild
- [ ] Existing `.env` using the old `NEXT_PUBLIC_*` names still works

## Follow-up (not in this PR)

`endatix-saas` still sets these six in the Hub job's build `env:` in `_deployment-definition.yml`. Until they move to the runtime settings block, the SaaS still bakes them.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Refactoring (non-breaking change which improves code quality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request-time configuration for reCAPTCHA, analytics, debug mode, survey licensing, and submission display settings.
  * Added deployment configuration options for client and analytics settings.
  * Improved secure handling of survey licensing configuration.

* **Documentation**
  * Added new `ENDATIX_*` environment variable names and configuration guidance.

* **Bug Fixes**
  * Configuration changes now apply without requiring a rebuild.
  * Existing `NEXT_PUBLIC_*` settings remain supported as deprecated fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->